### PR TITLE
feat: PR changed files sidebar tree

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,6 +26,7 @@ export default function Home() {
     setSelectedPR,
     fileContent,
     loadingContent,
+    loadingPRFiles,
     error,
     isDemoMode,
     currentRepo,
@@ -99,13 +100,22 @@ export default function Home() {
               />
             )
           ) : currentView === "pr-diff" && selectedPR ? (
-            <PRDetail
-              pr={selectedPR}
-              onBack={() => {
-                setSelectedPR(null);
-                setCurrentView("editor");
-              }}
-            />
+            loadingPRFiles ? (
+              <div className="h-full flex items-center justify-center">
+                <div className="flex items-center gap-2 text-[var(--text-muted)]">
+                  <Loader2 size={18} className="animate-spin" />
+                  <span className="text-sm">Loading PR files...</span>
+                </div>
+              </div>
+            ) : (
+              <PRDetail
+                pr={selectedPR}
+                onBack={() => {
+                  setSelectedPR(null);
+                  setCurrentView("editor");
+                }}
+              />
+            )
           ) : currentView === "pr-review" ? (
             <PRReview
               onCreatePR={(title, description, filePath) => {

--- a/src/components/PRDetail.tsx
+++ b/src/components/PRDetail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useCallback, useEffect } from "react";
+import React, { useState, useCallback } from "react";
 import {
   GitPullRequest,
   GitMerge,
@@ -10,9 +10,9 @@ import {
   FileText,
   Loader2,
 } from "lucide-react";
-import { PullRequest, PRFile, PRComment } from "@/types";
+import { PullRequest, PRComment } from "@/types";
 import { useApp } from "@/lib/app-context";
-import { createPRComment, createInlineComment, fetchPRFiles, fetchPRComments } from "@/lib/github-api";
+import { createPRComment, createInlineComment } from "@/lib/github-api";
 import DiffViewer from "./DiffViewer";
 import Showdown from "showdown";
 
@@ -31,34 +31,28 @@ interface PRDetailProps {
 }
 
 export default function PRDetail({ pr, onBack }: PRDetailProps) {
-  const { currentRepo, isDemoMode } = useApp();
-  const [selectedFileIdx, setSelectedFileIdx] = useState(0);
-  const [files, setFiles] = useState<PRFile[]>(pr.files);
-  const [comments, setComments] = useState<PRComment[]>(pr.comments);
-  const [loadingFiles, setLoadingFiles] = useState(false);
+  const {
+    currentRepo,
+    isDemoMode,
+    prFiles,
+    prComments,
+    selectedPRFileIdx,
+  } = useApp();
+
+  const [comments, setComments] = useState<PRComment[]>(prComments);
   const [reviewStatus, setReviewStatus] = useState<
     "pending" | "approved" | "changes-requested" | null
   >(null);
   const [postingComment, setPostingComment] = useState(false);
 
-  // Fetch PR files and comments for real repos (they come back empty from the list endpoint)
-  useEffect(() => {
-    if (isDemoMode || !currentRepo || files.length > 0) return;
+  // Sync comments from context when they load
+  React.useEffect(() => {
+    if (prComments.length > 0 && comments.length === 0) {
+      setComments(prComments);
+    }
+  }, [prComments, comments.length]);
 
-    setLoadingFiles(true);
-    Promise.all([
-      fetchPRFiles(currentRepo, pr.number),
-      fetchPRComments(currentRepo, pr.number),
-    ])
-      .then(([fetchedFiles, fetchedComments]) => {
-        setFiles(fetchedFiles);
-        setComments(fetchedComments);
-      })
-      .catch((err) => {
-        console.error("Failed to load PR details:", err);
-      })
-      .finally(() => setLoadingFiles(false));
-  }, [isDemoMode, currentRepo, pr.number, files.length]);
+  const selectedFile = prFiles[selectedPRFileIdx];
 
   const handleAddComment = useCallback(async (
     blockIndex: number,
@@ -67,9 +61,8 @@ export default function PRDetail({ pr, onBack }: PRDetailProps) {
     startLine?: number,
     endLine?: number
   ) => {
-    const file = files[selectedFileIdx];
+    const file = prFiles[selectedPRFileIdx];
 
-    // Optimistically add locally first
     const newComment: PRComment = {
       id: `c-${Date.now()}`,
       author: "you",
@@ -82,13 +75,10 @@ export default function PRDetail({ pr, onBack }: PRDetailProps) {
     };
     setComments((prev) => [...prev, newComment]);
 
-    // Post to GitHub if connected
     if (!isDemoMode && currentRepo && pr.number && file) {
       setPostingComment(true);
       try {
         if (selectedText && endLine) {
-          // Use inline review comment API (tied to file + line range)
-          // Build body with quoted context
           let commentBody = body;
           if (selectedText) {
             commentBody = `> _"${selectedText}"_\n\n${body}`;
@@ -104,7 +94,6 @@ export default function PRDetail({ pr, onBack }: PRDetailProps) {
             "RIGHT"
           );
         } else {
-          // Fall back to general PR comment for non-selection comments
           let fullBody = body;
           if (file) {
             fullBody = `**${file.path}**\n\n${fullBody}`;
@@ -113,7 +102,6 @@ export default function PRDetail({ pr, onBack }: PRDetailProps) {
         }
       } catch (err) {
         console.error("Failed to post comment to GitHub:", err);
-        // If inline comment fails (e.g., line out of range), fall back to general comment
         try {
           let fallbackBody = body;
           if (selectedText) {
@@ -130,7 +118,7 @@ export default function PRDetail({ pr, onBack }: PRDetailProps) {
         setPostingComment(false);
       }
     }
-  }, [currentRepo, isDemoMode, pr.number, files, selectedFileIdx]);
+  }, [currentRepo, isDemoMode, pr.number, prFiles, selectedPRFileIdx]);
 
   const handleResolveComment = (commentId: string) => {
     setComments((prev) =>
@@ -142,80 +130,58 @@ export default function PRDetail({ pr, onBack }: PRDetailProps) {
     <div className="h-full flex flex-col">
       {/* PR Header */}
       <div className="border-b border-[var(--border)] bg-[var(--surface)]">
-        <div className="max-w-6xl mx-auto px-6 py-4">
-          <button
-            onClick={onBack}
-            className="flex items-center gap-1 text-xs text-[var(--text-muted)] hover:text-[var(--accent)] mb-3 transition-colors"
-          >
-            <ArrowLeft size={12} />
-            Back to PR list
-          </button>
+        <div className="px-6 py-3">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3 min-w-0">
+              <button
+                onClick={onBack}
+                className="flex items-center gap-1 text-xs text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors shrink-0"
+              >
+                <ArrowLeft size={12} />
+                Back
+              </button>
 
-          <div className="flex items-start gap-3">
-            {pr.status === "merged" ? (
-              <GitMerge size={20} className="text-purple-500 shrink-0 mt-0.5" />
-            ) : (
-              <GitPullRequest size={20} className="text-green-500 shrink-0 mt-0.5" />
-            )}
-            <div className="flex-1 min-w-0">
-              <h1 className="text-lg font-semibold text-[var(--text-primary)]">
-                {pr.title}{" "}
-                <span className="text-[var(--text-muted)] font-normal">
-                  #{pr.number}
-                </span>
-              </h1>
-              <div className="flex items-center gap-3 mt-1 text-xs text-[var(--text-secondary)]">
-                <span>
-                  <strong>{pr.author}</strong> wants to merge{" "}
-                  <span className="font-mono bg-[var(--surface-secondary)] px-1.5 py-0.5 rounded">
-                    {pr.headBranch}
-                  </span>{" "}
-                  into{" "}
-                  <span className="font-mono bg-[var(--surface-secondary)] px-1.5 py-0.5 rounded">
-                    {pr.baseBranch}
-                  </span>
-                </span>
-                <span className="text-[var(--text-muted)]">
-                  {new Date(pr.createdAt).toLocaleDateString()}
-                </span>
-              </div>
-              {pr.description && (
-                <details className="mt-2">
-                  <summary className="text-xs text-[var(--text-muted)] cursor-pointer hover:text-[var(--text-secondary)] transition-colors">
-                    Description
-                  </summary>
-                  <div
-                    className="text-sm text-[var(--text-secondary)] mt-1 prose prose-sm dark:prose-invert max-w-none max-h-48 overflow-y-auto pr-description"
-                    dangerouslySetInnerHTML={{
-                      __html: descriptionConverter.makeHtml(pr.description),
-                    }}
-                  />
-                </details>
+              {pr.status === "merged" ? (
+                <GitMerge size={16} className="text-purple-500 shrink-0" />
+              ) : (
+                <GitPullRequest size={16} className="text-green-500 shrink-0" />
               )}
-            </div>
-          </div>
 
-          {/* File tabs and review actions */}
-          <div className="flex items-center justify-between mt-4">
-            <div className="flex items-center gap-1">
-              {files.map((file, idx) => (
-                <button
-                  key={file.path}
-                  onClick={() => setSelectedFileIdx(idx)}
-                  className={`flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md transition-colors ${
-                    selectedFileIdx === idx
-                      ? "bg-[var(--accent-muted)] text-[var(--accent)] font-medium"
-                      : "text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--surface-hover)]"
-                  }`}
-                >
-                  <FileText size={12} />
-                  {file.path.split("/").pop()}
-                </button>
-              ))}
+              <div className="min-w-0">
+                <h1 className="text-sm font-semibold text-[var(--text-primary)] truncate">
+                  {pr.title}{" "}
+                  <span className="text-[var(--text-muted)] font-normal">#{pr.number}</span>
+                </h1>
+                <div className="flex items-center gap-2 text-xs text-[var(--text-secondary)]">
+                  <span>
+                    <strong>{pr.author}</strong>{" "}
+                    <span className="font-mono text-[10px] bg-[var(--surface-secondary)] px-1 py-0.5 rounded">
+                      {pr.headBranch}
+                    </span>
+                    {" → "}
+                    <span className="font-mono text-[10px] bg-[var(--surface-secondary)] px-1 py-0.5 rounded">
+                      {pr.baseBranch}
+                    </span>
+                  </span>
+                  {pr.description && (
+                    <details className="inline">
+                      <summary className="text-[var(--text-muted)] cursor-pointer hover:text-[var(--text-secondary)] transition-colors">
+                        Description
+                      </summary>
+                    </details>
+                  )}
+                </div>
+              </div>
             </div>
 
             {/* Review actions */}
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 shrink-0">
+              {selectedFile && (
+                <span className="text-xs text-[var(--text-muted)] font-mono hidden sm:block">
+                  {selectedFile.path}
+                </span>
+              )}
+
               <div className="flex items-center gap-1 text-xs text-[var(--text-muted)]">
                 {postingComment ? (
                   <>
@@ -225,7 +191,7 @@ export default function PRDetail({ pr, onBack }: PRDetailProps) {
                 ) : (
                   <>
                     <MessageSquare size={12} />
-                    {comments.filter((c) => !c.resolved).length} active
+                    {comments.filter((c) => !c.resolved).length}
                   </>
                 )}
               </div>
@@ -239,9 +205,7 @@ export default function PRDetail({ pr, onBack }: PRDetailProps) {
                   }`}
                 >
                   <Check size={12} />
-                  {reviewStatus === "approved"
-                    ? "Approved"
-                    : "Changes Requested"}
+                  {reviewStatus === "approved" ? "Approved" : "Changes Requested"}
                 </span>
               ) : (
                 <div className="flex items-center gap-1">
@@ -261,37 +225,34 @@ export default function PRDetail({ pr, onBack }: PRDetailProps) {
               )}
             </div>
           </div>
+
+          {/* Expanded description */}
+          {pr.description && (
+            <div className="mt-2 text-sm text-[var(--text-secondary)] prose prose-sm dark:prose-invert max-w-none max-h-32 overflow-y-auto hidden [details[open]~&]:block">
+            </div>
+          )}
         </div>
       </div>
 
       {/* Diff viewer */}
       <div className="flex-1 overflow-hidden">
-        {loadingFiles ? (
-          <div className="h-full flex items-center justify-center">
-            <div className="flex items-center gap-2 text-[var(--text-muted)]">
-              <Loader2 size={18} className="animate-spin" />
-              <span className="text-sm">Loading PR files...</span>
-            </div>
-          </div>
-        ) : files.length === 0 ? (
+        {prFiles.length === 0 ? (
           <div className="h-full flex items-center justify-center">
             <p className="text-sm text-[var(--text-muted)]">
               No markdown files changed in this PR.
             </p>
           </div>
-        ) : (
+        ) : selectedFile ? (
           <DiffViewer
-            file={files[selectedFileIdx]}
+            file={selectedFile}
             repoFullName={currentRepo || ""}
             baseBranch={pr.baseBranch}
             headBranch={pr.headBranch}
-            comments={comments.filter(
-              (c) => true /* In a real app, filter by file */
-            )}
+            comments={comments}
             onAddComment={handleAddComment}
             onResolveComment={handleResolveComment}
           />
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useMemo } from "react";
 import {
   FileText,
   Folder,
@@ -11,9 +11,18 @@ import {
   ChevronDown,
   Plus,
   Loader2,
+  FilePlus,
+  FileMinus,
+  FileEdit,
+  Search,
+  X,
+  PanelLeftClose,
+  PanelLeftOpen,
 } from "lucide-react";
-import { RepoFile } from "@/types";
+import { RepoFile, PRFile } from "@/types";
 import { useApp } from "@/lib/app-context";
+
+// ─── Repo file tree item ──────────────────────────────────────────────────
 
 function FileTreeItem({
   file,
@@ -82,6 +91,132 @@ function FileTreeItem({
   );
 }
 
+// ─── PR changed files tree ────────────────────────────────────────────────
+
+interface PRFileTreeNode {
+  name: string;
+  path: string;
+  type: "folder" | "file";
+  children: PRFileTreeNode[];
+  fileIdx?: number;
+  status?: PRFile["status"];
+}
+
+function buildPRFileTree(files: PRFile[]): PRFileTreeNode[] {
+  const root: PRFileTreeNode[] = [];
+  const dirMap = new Map<string, PRFileTreeNode>();
+
+  for (let i = 0; i < files.length; i++) {
+    const parts = files[i].path.split("/");
+    let currentLevel = root;
+
+    // Create directory nodes
+    for (let j = 0; j < parts.length - 1; j++) {
+      const dirPath = parts.slice(0, j + 1).join("/");
+      let dirNode = dirMap.get(dirPath);
+      if (!dirNode) {
+        dirNode = { name: parts[j], path: dirPath, type: "folder", children: [] };
+        dirMap.set(dirPath, dirNode);
+        currentLevel.push(dirNode);
+      }
+      currentLevel = dirNode.children;
+    }
+
+    // Add file node
+    currentLevel.push({
+      name: parts[parts.length - 1],
+      path: files[i].path,
+      type: "file",
+      children: [],
+      fileIdx: i,
+      status: files[i].status,
+    });
+  }
+
+  return root;
+}
+
+const statusIcon = (status: PRFile["status"]) => {
+  switch (status) {
+    case "added":
+      return <FilePlus size={14} className="text-green-500 shrink-0" />;
+    case "deleted":
+      return <FileMinus size={14} className="text-red-500 shrink-0" />;
+    default:
+      return <FileEdit size={14} className="text-yellow-500 shrink-0" />;
+  }
+};
+
+function PRFileTreeItem({
+  node,
+  depth,
+  selectedIdx,
+  onSelect,
+}: {
+  node: PRFileTreeNode;
+  depth: number;
+  selectedIdx: number;
+  onSelect: (idx: number) => void;
+}) {
+  const [expanded, setExpanded] = useState(true);
+
+  if (node.type === "folder") {
+    return (
+      <div>
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="w-full flex items-center gap-1.5 px-2 py-1 text-sm rounded-md hover:bg-[var(--surface-hover)] transition-colors"
+          style={{ paddingLeft: `${depth * 14 + 8}px` }}
+        >
+          {expanded ? (
+            <ChevronDown size={12} className="text-[var(--text-muted)] shrink-0" />
+          ) : (
+            <ChevronRight size={12} className="text-[var(--text-muted)] shrink-0" />
+          )}
+          {expanded ? (
+            <FolderOpen size={14} className="text-[var(--accent)] shrink-0" />
+          ) : (
+            <Folder size={14} className="text-[var(--accent)] shrink-0" />
+          )}
+          <span className="text-[var(--text-primary)] truncate text-xs">{node.name}</span>
+        </button>
+        {expanded && (
+          <div>
+            {node.children.map((child) => (
+              <PRFileTreeItem
+                key={child.path}
+                node={child}
+                depth={depth + 1}
+                selectedIdx={selectedIdx}
+                onSelect={onSelect}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  const isSelected = node.fileIdx === selectedIdx;
+
+  return (
+    <button
+      onClick={() => node.fileIdx !== undefined && onSelect(node.fileIdx)}
+      className={`w-full flex items-center gap-1.5 px-2 py-1 text-xs rounded-md transition-colors ${
+        isSelected
+          ? "bg-[var(--accent-muted)] text-[var(--accent)]"
+          : "hover:bg-[var(--surface-hover)] text-[var(--text-secondary)]"
+      }`}
+      style={{ paddingLeft: `${depth * 14 + 8 + 16}px` }}
+    >
+      {statusIcon(node.status!)}
+      <span className="truncate">{node.name}</span>
+    </button>
+  );
+}
+
+// ─── Main Sidebar ─────────────────────────────────────────────────────────
+
 export default function Sidebar() {
   const {
     repoFiles,
@@ -91,13 +226,53 @@ export default function Sidebar() {
     loadingFiles,
     loadingPRs,
     openFile,
-    setSelectedPR,
+    openPR,
     setCurrentView,
     selectedFile,
     selectedPR,
+    currentView,
+    prFiles,
+    selectedPRFileIdx,
+    setSelectedPRFileIdx,
+    loadingPRFiles,
   } = useApp();
 
   const [activeTab, setActiveTab] = useState<"files" | "prs">("files");
+  const [prFileFilter, setPRFileFilter] = useState("");
+  const [collapsed, setCollapsed] = useState(false);
+
+  const isViewingPR = currentView === "pr-diff" && selectedPR;
+
+  // Auto-switch to Files tab when a PR is opened (to show changed files)
+  React.useEffect(() => {
+    if (isViewingPR) {
+      setActiveTab("files");
+      setPRFileFilter("");
+    }
+  }, [isViewingPR]);
+
+  // Build PR file tree, filtered
+  const prFileTree = useMemo(() => {
+    if (!isViewingPR) return [];
+    const filtered = prFileFilter.trim()
+      ? prFiles.filter((f) => f.path.toLowerCase().includes(prFileFilter.toLowerCase()))
+      : prFiles;
+    return buildPRFileTree(filtered);
+  }, [isViewingPR, prFiles, prFileFilter]);
+
+  if (collapsed) {
+    return (
+      <aside className="w-10 shrink-0 h-full border-r border-[var(--border)] bg-[var(--surface-secondary)] flex flex-col items-center pt-2">
+        <button
+          onClick={() => setCollapsed(false)}
+          className="toolbar-btn"
+          title="Expand sidebar"
+        >
+          <PanelLeftOpen size={16} />
+        </button>
+      </aside>
+    );
+  }
 
   return (
     <aside className="w-64 shrink-0 h-full border-r border-[var(--border)] bg-[var(--surface-secondary)] flex flex-col">
@@ -129,12 +304,77 @@ export default function Sidebar() {
             PRs
           </span>
         </button>
+        <button
+          onClick={() => setCollapsed(true)}
+          className="px-2 py-2.5 text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors"
+          title="Collapse sidebar"
+        >
+          <PanelLeftClose size={14} />
+        </button>
       </div>
 
       {/* Content */}
       <div className="flex-1 overflow-y-auto p-2">
         {activeTab === "files" ? (
-          loadingFiles ? (
+          // When viewing a PR, show changed files; otherwise show repo tree
+          isViewingPR ? (
+            <div>
+              <div className="flex items-center justify-between mb-2 px-1">
+                <span className="text-xs font-medium text-[var(--text-primary)]">
+                  Changed files
+                  {prFiles.length > 0 && (
+                    <span className="text-[var(--text-muted)] font-normal ml-1">
+                      ({prFiles.length})
+                    </span>
+                  )}
+                </span>
+              </div>
+
+              {/* Filter */}
+              {prFiles.length > 3 && (
+                <div className="relative mb-2">
+                  <Search size={12} className="absolute left-2 top-1/2 -translate-y-1/2 text-[var(--text-muted)]" />
+                  <input
+                    type="text"
+                    value={prFileFilter}
+                    onChange={(e) => setPRFileFilter(e.target.value)}
+                    placeholder="Filter files..."
+                    className="w-full pl-7 pr-7 py-1 text-xs rounded-md border border-[var(--border)] bg-[var(--surface)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)]"
+                  />
+                  {prFileFilter && (
+                    <button
+                      onClick={() => setPRFileFilter("")}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+                    >
+                      <X size={10} />
+                    </button>
+                  )}
+                </div>
+              )}
+
+              {loadingPRFiles ? (
+                <div className="flex items-center justify-center py-8">
+                  <Loader2 size={18} className="animate-spin text-[var(--text-muted)]" />
+                </div>
+              ) : prFileTree.length === 0 ? (
+                <p className="text-xs text-[var(--text-muted)] text-center py-4">
+                  {prFileFilter ? "No files matching filter." : "No markdown files changed."}
+                </p>
+              ) : (
+                <div className="space-y-0.5">
+                  {prFileTree.map((node) => (
+                    <PRFileTreeItem
+                      key={node.path}
+                      node={node}
+                      depth={0}
+                      selectedIdx={selectedPRFileIdx}
+                      onSelect={setSelectedPRFileIdx}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          ) : loadingFiles ? (
             <div className="flex items-center justify-center py-8">
               <Loader2 size={18} className="animate-spin text-[var(--text-muted)]" />
             </div>
@@ -182,10 +422,7 @@ export default function Sidebar() {
               pullRequests.map((pr) => (
                 <button
                   key={pr.id}
-                  onClick={() => {
-                    setSelectedPR(pr);
-                    setCurrentView("pr-diff");
-                  }}
+                  onClick={() => openPR(pr)}
                   className={`w-full text-left px-3 py-2.5 rounded-md transition-colors ${
                     selectedPR?.id === pr.id
                       ? "bg-[var(--accent-muted)]"

--- a/src/lib/app-context.tsx
+++ b/src/lib/app-context.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import React, { createContext, useContext, useState, useCallback, useEffect } from "react";
-import { RepoFile, PullRequest, ViewMode } from "@/types";
-import { initOctokit, fetchRepoTree, fetchPullRequests, fetchFileContent } from "./github-api";
+import { RepoFile, PullRequest, PRFile, PRComment, ViewMode } from "@/types";
+import { initOctokit, fetchRepoTree, fetchPullRequests, fetchFileContent, fetchPRFiles, fetchPRComments } from "./github-api";
 import { repoFiles as mockFiles, pullRequests as mockPRs, findFile } from "./mock-data";
 
 interface AppState {
@@ -27,6 +27,13 @@ interface AppState {
   setSelectedPR: (pr: PullRequest | null) => void;
   fileContent: string;
 
+  // PR detail state (shared between sidebar and PRDetail)
+  prFiles: PRFile[];
+  prComments: PRComment[];
+  selectedPRFileIdx: number;
+  setSelectedPRFileIdx: (idx: number) => void;
+  loadingPRFiles: boolean;
+
   // Loading states
   loadingFiles: boolean;
   loadingPRs: boolean;
@@ -36,6 +43,7 @@ interface AppState {
   // Actions
   refreshRepo: () => Promise<void>;
   openFile: (file: RepoFile) => Promise<void>;
+  openPR: (pr: PullRequest) => void;
 }
 
 const AppContext = createContext<AppState | null>(null);
@@ -64,6 +72,12 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const [selectedFile, setSelectedFile] = useState<RepoFile | null>(null);
   const [selectedPR, setSelectedPR] = useState<PullRequest | null>(null);
   const [fileContent, setFileContent] = useState("");
+
+  // PR detail state
+  const [prFiles, setPRFiles] = useState<PRFile[]>([]);
+  const [prComments, setPRComments] = useState<PRComment[]>([]);
+  const [selectedPRFileIdx, setSelectedPRFileIdx] = useState(0);
+  const [loadingPRFiles, setLoadingPRFiles] = useState(false);
 
   // Loading
   const [loadingFiles, setLoadingFiles] = useState(false);
@@ -168,6 +182,39 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     [isDemoMode, currentRepo, githubToken]
   );
 
+  // Open a PR and fetch its files + comments
+  const openPR = useCallback(
+    (pr: PullRequest) => {
+      setSelectedPR(pr);
+      setSelectedFile(null);
+      setCurrentView("pr-diff");
+      setSelectedPRFileIdx(0);
+
+      // Use demo data if available
+      if (pr.files.length > 0) {
+        setPRFiles(pr.files);
+        setPRComments(pr.comments);
+        return;
+      }
+
+      // Fetch from GitHub
+      if (!currentRepo || isDemoMode) return;
+
+      setLoadingPRFiles(true);
+      Promise.all([
+        fetchPRFiles(currentRepo, pr.number),
+        fetchPRComments(currentRepo, pr.number),
+      ])
+        .then(([files, comments]) => {
+          setPRFiles(files);
+          setPRComments(comments);
+        })
+        .catch((err) => console.error("Failed to load PR details:", err))
+        .finally(() => setLoadingPRFiles(false));
+    },
+    [currentRepo, isDemoMode]
+  );
+
   // Refresh the current repo
   const refreshRepo = useCallback(async () => {
     if (currentRepo && githubToken) {
@@ -193,12 +240,18 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         selectedPR,
         setSelectedPR,
         fileContent,
+        prFiles,
+        prComments,
+        selectedPRFileIdx,
+        setSelectedPRFileIdx,
+        loadingPRFiles,
         loadingFiles,
         loadingPRs,
         loadingContent,
         error,
         refreshRepo,
         openFile,
+        openPR,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- Moves PR changed files from overflowing header tabs to a collapsible directory tree in the sidebar
- Sidebar auto-switches to show changed files when viewing a PR, with filter input and add/modify/delete status icons
- PR header condensed to single compact bar with review actions
- Sidebar itself is collapsible via toggle button

## Test plan
- [x] Tested locally with real PAT against Cloudzero/feature-ai-collector-macos PR #23 (56 files)
- [x] Demo mode still works with mock data
- [x] File selection in sidebar updates diff viewer
- [x] Filter input narrows file list
- [x] Sidebar collapse/expand works