### PR TITLE
feat: render images from private repos

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,6 +30,7 @@ export default function Home() {
     error,
     isDemoMode,
     currentRepo,
+    defaultBranch,
     repoFiles,
     pullRequests,
   } = useApp();
@@ -94,6 +95,8 @@ export default function Home() {
               <Editor
                 content={fileContent}
                 filePath={selectedFile.path}
+                repoFullName={currentRepo || undefined}
+                branch={defaultBranch}
                 onContentChange={(html) => {
                   console.log("Content changed");
                 }}

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -15,7 +15,7 @@ import {
   Send,
 } from "lucide-react";
 import ContextMenu from "./ContextMenu";
-import { mapSelectionToLines, rewriteImageUrls } from "@/lib/github-api";
+import { mapSelectionToLines, rewriteImageUrls, loadAuthenticatedImages } from "@/lib/github-api";
 
 interface DiffViewerProps {
   file: PRFile;
@@ -420,6 +420,11 @@ export default function DiffViewer({
 
   const contentRef = useRef<HTMLDivElement>(null);
   const commentInputRef = useRef<HTMLInputElement>(null);
+  // Fetch images with auth for private repos after content renders
+  useEffect(() => {
+    if (!contentRef.current) return;
+    loadAuthenticatedImages(contentRef.current);
+  }, [file, viewMode]);
 
   // Map PR comments into panel format for display
   const allPanelComments: PanelComment[] = useMemo(() => {

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -15,6 +15,7 @@ import { TableRow } from "@tiptap/extension-table-row";
 import { TableCell } from "@tiptap/extension-table-cell";
 import { TableHeader } from "@tiptap/extension-table-header";
 import Showdown from "showdown";
+import { rewriteImageUrls, loadAuthenticatedImages } from "@/lib/github-api";
 import {
   Bold,
   Italic,
@@ -47,6 +48,8 @@ interface EditorProps {
   content: string;
   onContentChange?: (markdown: string) => void;
   filePath: string;
+  repoFullName?: string;
+  branch?: string;
 }
 
 interface EditorComment {
@@ -74,8 +77,12 @@ const showdownConverter = new Showdown.Converter({
   ghCompatibleHeaderId: true,
 });
 
-function markdownToHtml(md: string): string {
-  return showdownConverter.makeHtml(md);
+function markdownToHtml(md: string, repoFullName?: string, branch?: string, filePath?: string): string {
+  const html = showdownConverter.makeHtml(md);
+  if (repoFullName && branch && filePath) {
+    return rewriteImageUrls(html, repoFullName, branch, filePath);
+  }
+  return html;
 }
 
 function ToolbarButton({
@@ -370,13 +377,18 @@ function CommentSidePanel({
 
 // ─── Main Editor Component ──────────────────────────────────────────────
 
-export default function Editor({ content, onContentChange, filePath }: EditorProps) {
+export default function Editor({ content, onContentChange, filePath, repoFullName, branch }: EditorProps) {
   const editorContainerRef = useRef<HTMLDivElement>(null);
   const [comments, setComments] = useState<EditorComment[]>([]);
   const [showComments, setShowComments] = useState(false);
   const [activeCommentId, setActiveCommentId] = useState<string | null>(null);
   const [pendingSelection, setPendingSelection] = useState<string | null>(null);
   const [commentInput, setCommentInput] = useState("");
+  // Fetch images with auth for private repos after content renders
+  useEffect(() => {
+    if (!editorContainerRef.current) return;
+    loadAuthenticatedImages(editorContainerRef.current);
+  }, [filePath]);
 
   const editor = useEditor({
     extensions: [
@@ -403,7 +415,7 @@ export default function Editor({ content, onContentChange, filePath }: EditorPro
       TableCell,
       TableHeader,
     ],
-    content: markdownToHtml(content),
+    content: markdownToHtml(content, repoFullName, branch, filePath),
     onUpdate: ({ editor }) => {
       onContentChange?.(editor.getHTML());
     },
@@ -417,7 +429,7 @@ export default function Editor({ content, onContentChange, filePath }: EditorPro
   // Update content when file changes — also reset comments
   useEffect(() => {
     if (editor && content) {
-      const newHtml = markdownToHtml(content);
+      const newHtml = markdownToHtml(content, repoFullName, branch, filePath);
       editor.commands.setContent(newHtml);
     }
     setComments([]);

--- a/src/lib/app-context.tsx
+++ b/src/lib/app-context.tsx
@@ -2,7 +2,7 @@
 
 import React, { createContext, useContext, useState, useCallback, useEffect } from "react";
 import { RepoFile, PullRequest, PRFile, PRComment, ViewMode } from "@/types";
-import { initOctokit, fetchRepoTree, fetchPullRequests, fetchFileContent, fetchPRFiles, fetchPRComments } from "./github-api";
+import { initOctokit, fetchRepoTree, fetchPullRequests, fetchFileContent, fetchPRFiles, fetchPRComments, fetchDefaultBranch } from "./github-api";
 import { repoFiles as mockFiles, pullRequests as mockPRs, findFile } from "./mock-data";
 
 interface AppState {
@@ -14,6 +14,7 @@ interface AppState {
 
   // Repo
   currentRepo: string | null;
+  defaultBranch: string;
   setCurrentRepo: (repo: string) => void;
   repoFiles: RepoFile[];
   pullRequests: PullRequest[];
@@ -52,18 +53,13 @@ const TOKEN_KEY = "mardoc_github_token";
 const REPO_KEY = "mardoc_current_repo";
 
 export function AppProvider({ children }: { children: React.ReactNode }) {
-  // Auth state — rehydrate from localStorage
-  const [githubToken, setGithubTokenState] = useState<string | null>(() => {
-    if (typeof window === "undefined") return null;
-    return localStorage.getItem(TOKEN_KEY);
-  });
-  const [isDemoMode, setIsDemoMode] = useState(() => {
-    if (typeof window === "undefined") return true;
-    return !localStorage.getItem(TOKEN_KEY);
-  });
+  // Auth state — server-safe defaults, hydrated in useEffect
+  const [githubToken, setGithubTokenState] = useState<string | null>(null);
+  const [isDemoMode, setIsDemoMode] = useState(true);
 
   // Repo state
   const [currentRepo, setCurrentRepoState] = useState<string | null>(null);
+  const [defaultBranch, setDefaultBranch] = useState("main");
   const [repoFilesList, setRepoFiles] = useState<RepoFile[]>(mockFiles);
   const [prList, setPRList] = useState<PullRequest[]>(mockPRs);
 
@@ -103,16 +99,20 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
-  // Restore session on mount: init Octokit and reload last repo
+  // Hydrate auth state from localStorage after mount (avoids SSR mismatch)
   useEffect(() => {
-    if (!githubToken) return;
-    initOctokit(githubToken);
-    const savedRepo = localStorage.getItem(REPO_KEY);
-    if (savedRepo) {
-      setCurrentRepo(savedRepo);
+    const savedToken = localStorage.getItem(TOKEN_KEY);
+    if (savedToken) {
+      setGithubTokenState(savedToken);
+      setIsDemoMode(false);
+      initOctokit(savedToken);
+      const savedRepo = localStorage.getItem(REPO_KEY);
+      if (savedRepo) {
+        setCurrentRepo(savedRepo);
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // intentionally run once on mount
+  }, []);
 
   // Set current repo and load data
   const setCurrentRepo = useCallback(
@@ -123,10 +123,18 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 
       if (!githubToken) return;
 
-      // Load files
+      // Fetch default branch, then load files using it
+      let branch = "main";
+      try {
+        branch = await fetchDefaultBranch(repo);
+        setDefaultBranch(branch);
+      } catch {
+        // Fall back to "main" if we can't determine default branch
+      }
+
       setLoadingFiles(true);
       try {
-        const files = await fetchRepoTree(repo);
+        const files = await fetchRepoTree(repo, branch);
         setRepoFiles(files);
       } catch (err: any) {
         setError(`Failed to load repository: ${err.message}`);
@@ -230,6 +238,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         setGithubToken,
         isDemoMode,
         currentRepo,
+        defaultBranch,
         setCurrentRepo,
         repoFiles: repoFilesList,
         pullRequests: prList,

--- a/src/lib/github-api.ts
+++ b/src/lib/github-api.ts
@@ -24,6 +24,17 @@ function parseOwnerRepo(repo: string): { owner: string; repo: string } {
   return { owner, repo: repoName };
 }
 
+// ─── Repository Metadata ──────────────────────────────────────────────────
+
+export async function fetchDefaultBranch(repoFullName: string): Promise<string> {
+  const octokit = getOctokit();
+  if (!octokit) throw new Error("Not authenticated");
+
+  const { owner, repo } = parseOwnerRepo(repoFullName);
+  const { data } = await octokit.repos.get({ owner, repo });
+  return data.default_branch;
+}
+
 // ─── Repository Files ──────────────────────────────────────────────────────
 
 export async function fetchRepoTree(
@@ -506,22 +517,63 @@ export function rewriteImageUrls(
       if (/^(https?:\/\/|data:|#)/.test(src)) return _match;
 
       let resolvedPath: string;
-      if (src.startsWith("./") || src.startsWith("../")) {
-        // Resolve relative to the markdown file's directory
-        const parts = [...fileDir.split("/"), ...src.split("/")];
+      if (src.startsWith("/")) {
+        // Absolute repo-root path
+        resolvedPath = src.slice(1);
+      } else {
+        // All other paths (./foo, ../foo, foo) resolve relative to the file's directory
+        const parts = [...fileDir.split("/").filter(Boolean), ...src.split("/")];
         const resolved: string[] = [];
         for (const p of parts) {
           if (p === ".." && resolved.length) resolved.pop();
           else if (p !== "." && p !== "") resolved.push(p);
         }
         resolvedPath = resolved.join("/");
-      } else {
-        // Treat as repo-root-relative
-        resolvedPath = src;
       }
 
-      return `${before}https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${resolvedPath}${after}`;
+      return `${before}https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${resolvedPath}" data-gh-owner="${owner}" data-gh-repo="${repo}" data-gh-ref="${ref}" data-gh-path="${resolvedPath}${after}`;
     }
+  );
+}
+
+/**
+ * Fetch all repo images in a container via Octokit (works for private repos).
+ * Reads data-gh-* attributes set by rewriteImageUrls, fetches base64 content,
+ * and replaces src with data URIs.
+ */
+export async function loadAuthenticatedImages(
+  container: HTMLElement
+): Promise<void> {
+  const octokit = getOctokit();
+  if (!octokit) return;
+
+  const imgs = container.querySelectorAll<HTMLImageElement>("img[data-gh-path]");
+  if (imgs.length === 0) return;
+
+  const mimeTypes: Record<string, string> = {
+    png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg",
+    gif: "image/gif", svg: "image/svg+xml", webp: "image/webp",
+    ico: "image/x-icon", bmp: "image/bmp",
+  };
+
+  await Promise.allSettled(
+    Array.from(imgs).map(async (img) => {
+      const owner = img.dataset.ghOwner;
+      const repo = img.dataset.ghRepo;
+      const ref = img.dataset.ghRef;
+      const path = img.dataset.ghPath;
+      if (!owner || !repo || !ref || !path) return;
+
+      const { data } = await octokit.repos.getContent({
+        owner, repo, path, ref,
+      });
+
+      if ("content" in data && data.encoding === "base64") {
+        const ext = path.split(".").pop()?.toLowerCase() || "png";
+        const mime = mimeTypes[ext] || "application/octet-stream";
+        img.src = `data:${mime};base64,${data.content.replace(/\n/g, "")}`;
+      }
+    })
   );
 }
 


### PR DESCRIPTION
## Summary
- Fetches repo default branch dynamically via `repos.get()` instead of hardcoding `main`
- Adds image URL rewriting to the Editor component (previously only in DiffViewer)
- Fixes relative path resolution — bare paths like `docs/images/foo.png` now resolve relative to the markdown file's directory, not repo root
- Fetches private repo images via authenticated Octokit `repos.getContent()` and injects as base64 data URIs
- Fixes SSR hydration mismatch by deferring localStorage reads to `useEffect`

## Test plan
- [ ] Open a PR from a private repo containing markdown with relative image paths
- [ ] Verify images render in both Rendered Diff and Side by Side views
- [ ] Open a markdown file with images via the file tree and verify images render in the Editor
- [ ] Verify repos using non-`main` default branches load correctly
- [ ] Confirm no hydration errors in browser console