### PR TITLE
fix: images and mermaid in Editor file view

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -16,7 +16,7 @@ import { TableCell } from "@tiptap/extension-table-cell";
 import { TableHeader } from "@tiptap/extension-table-header";
 import Showdown from "showdown";
 import { rewriteImageUrls, loadAuthenticatedImages } from "@/lib/github-api";
-import { renderMermaidBlocks } from "@/lib/mermaid";
+import { preRenderMermaid } from "@/lib/mermaid";
 import {
   Bold,
   Italic,
@@ -385,14 +385,8 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
   const [activeCommentId, setActiveCommentId] = useState<string | null>(null);
   const [pendingSelection, setPendingSelection] = useState<string | null>(null);
   const [commentInput, setCommentInput] = useState("");
-  // Post-render: fetch private repo images and render mermaid diagrams
-  useEffect(() => {
-    if (!editorContainerRef.current) return;
-    loadAuthenticatedImages(editorContainerRef.current);
-    renderMermaidBlocks(editorContainerRef.current);
-  }, [filePath]);
-
   const editor = useEditor({
+    immediatelyRender: false,
     extensions: [
       StarterKit.configure({
         heading: { levels: [1, 2, 3] },
@@ -428,17 +422,30 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
     },
   });
 
-  // Update content when file changes — also reset comments
+  // Update content when file changes: pre-render mermaid, set content, then fetch images
   useEffect(() => {
+    let cancelled = false;
+
     if (editor && content) {
-      const newHtml = markdownToHtml(content, repoFullName, branch, filePath);
-      editor.commands.setContent(newHtml);
+      const rawHtml = markdownToHtml(content, repoFullName, branch, filePath);
+      preRenderMermaid(rawHtml).then((html) => {
+        if (cancelled) return;
+        editor.commands.setContent(html);
+        // Fetch private repo images after TipTap renders
+        setTimeout(() => {
+          if (!cancelled && editorContainerRef.current) {
+            loadAuthenticatedImages(editorContainerRef.current);
+          }
+        }, 50);
+      });
     }
+
     setComments([]);
     setShowComments(false);
     setActiveCommentId(null);
+    return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filePath]);
+  }, [filePath, editor]);
 
   const addLink = useCallback(() => {
     if (!editor) return;

--- a/src/lib/github-api.ts
+++ b/src/lib/github-api.ts
@@ -502,6 +502,9 @@ export async function createReviewPR(
  * Rewrite relative image `src` attributes in rendered HTML to point at
  * raw.githubusercontent.com so images from the repo render correctly.
  */
+// Lookup map for image metadata — survives TipTap stripping data attributes
+const imageMetaMap = new Map<string, { owner: string; repo: string; ref: string; path: string }>();
+
 export function rewriteImageUrls(
   html: string,
   repoFullName: string,
@@ -531,15 +534,17 @@ export function rewriteImageUrls(
         resolvedPath = resolved.join("/");
       }
 
-      return `${before}https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${resolvedPath}" data-gh-owner="${owner}" data-gh-repo="${repo}" data-gh-ref="${ref}" data-gh-path="${resolvedPath}${after}`;
+      const rawUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${resolvedPath}`;
+      imageMetaMap.set(rawUrl, { owner, repo, ref, path: resolvedPath });
+      return `${before}${rawUrl}" data-gh-owner="${owner}" data-gh-repo="${repo}" data-gh-ref="${ref}" data-gh-path="${resolvedPath}${after}`;
     }
   );
 }
 
 /**
  * Fetch all repo images in a container via Octokit (works for private repos).
- * Reads data-gh-* attributes set by rewriteImageUrls, fetches base64 content,
- * and replaces src with data URIs.
+ * Uses data-gh-* attributes when available (DiffViewer), falls back to
+ * imageMetaMap lookup by src URL (Editor/TipTap which strips data attributes).
  */
 export async function loadAuthenticatedImages(
   container: HTMLElement
@@ -547,7 +552,10 @@ export async function loadAuthenticatedImages(
   const octokit = getOctokit();
   if (!octokit) return;
 
-  const imgs = container.querySelectorAll<HTMLImageElement>("img[data-gh-path]");
+  // Match images with data attributes OR raw.githubusercontent.com URLs
+  const imgs = container.querySelectorAll<HTMLImageElement>(
+    'img[data-gh-path], img[src*="raw.githubusercontent.com"]'
+  );
   if (imgs.length === 0) return;
 
   const mimeTypes: Record<string, string> = {
@@ -558,10 +566,19 @@ export async function loadAuthenticatedImages(
 
   await Promise.allSettled(
     Array.from(imgs).map(async (img) => {
-      const owner = img.dataset.ghOwner;
-      const repo = img.dataset.ghRepo;
-      const ref = img.dataset.ghRef;
-      const path = img.dataset.ghPath;
+      // Try data attributes first (preserved in dangerouslySetInnerHTML)
+      let owner = img.dataset.ghOwner;
+      let repo = img.dataset.ghRepo;
+      let ref = img.dataset.ghRef;
+      let path = img.dataset.ghPath;
+
+      // Fall back to metadata map (for TipTap which strips data attributes)
+      if (!path) {
+        const meta = imageMetaMap.get(img.src);
+        if (!meta) return;
+        ({ owner, repo, ref, path } = meta);
+      }
+
       if (!owner || !repo || !ref || !path) return;
 
       const { data } = await octokit.repos.getContent({

--- a/src/lib/mermaid.ts
+++ b/src/lib/mermaid.ts
@@ -16,14 +16,68 @@ function getMermaid() {
   return mermaidReady;
 }
 
+const MERMAID_KEYWORDS = /^(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|gantt|pie|gitgraph|journey|mindmap|timeline|quadrantChart|sankey|block|xychart|C4Context)\b/;
+
 /**
- * Find all mermaid code blocks in a container and render them as SVG diagrams.
- * Showdown outputs: <pre><code class="mermaid language-mermaid">...</code></pre>
+ * Pre-render mermaid code blocks in an HTML string, replacing them with
+ * <img> tags containing SVG data URIs. Use this before passing HTML to
+ * TipTap, which manages its own DOM and can't have elements replaced post-render.
  */
-export async function renderMermaidBlocks(container: HTMLElement): Promise<void> {
-  const codeBlocks = container.querySelectorAll<HTMLElement>(
+export async function preRenderMermaid(html: string): Promise<string> {
+  // Quick check — skip the mermaid import if no mermaid blocks
+  if (!html.includes("language-mermaid") && !html.includes("class=\"mermaid")) return html;
+
+  const temp = document.createElement("div");
+  temp.innerHTML = html;
+
+  const codeBlocks = temp.querySelectorAll<HTMLElement>(
     'code.mermaid, code[class*="language-mermaid"]'
   );
+  if (codeBlocks.length === 0) return html;
+
+  const mermaid = await getMermaid();
+
+  for (let i = 0; i < codeBlocks.length; i++) {
+    const codeEl = codeBlocks[i];
+    const pre = codeEl.parentElement;
+    if (!pre || pre.tagName !== "PRE") continue;
+
+    const rawHtml = codeEl.innerHTML.replace(/<br\s*\/?>/gi, "\n");
+    const textarea = document.createElement("textarea");
+    textarea.innerHTML = rawHtml;
+    const source = textarea.value.trim();
+
+    try {
+      const id = `mermaid-pre-${Date.now()}-${i}`;
+      const { svg } = await mermaid.render(id, source);
+      const blob = new Blob([svg], { type: "image/svg+xml" });
+      const blobUrl = URL.createObjectURL(blob);
+      const img = document.createElement("img");
+      img.src = blobUrl;
+      img.alt = "Mermaid diagram";
+      pre.replaceWith(img);
+    } catch (err) {
+      console.warn("Mermaid render failed:", err);
+    }
+  }
+
+  return temp.innerHTML;
+}
+
+/**
+ * Find all mermaid code blocks in a container and render them as SVG diagrams.
+ * Detects mermaid blocks by CSS class (dangerouslySetInnerHTML) or by content
+ * keywords (TipTap which strips language classes).
+ */
+export async function renderMermaidBlocks(container: HTMLElement): Promise<void> {
+  const allCodeBlocks = container.querySelectorAll<HTMLElement>("pre > code");
+  const codeBlocks = Array.from(allCodeBlocks).filter((el) => {
+    // Match by class (DiffViewer / dangerouslySetInnerHTML)
+    if (el.classList.contains("mermaid") || el.className.includes("language-mermaid")) return true;
+    // Match by content keywords (TipTap strips classes)
+    const text = el.textContent?.trim() || "";
+    return MERMAID_KEYWORDS.test(text);
+  });
   if (codeBlocks.length === 0) return;
 
   const mermaid = await getMermaid();
@@ -33,9 +87,10 @@ export async function renderMermaidBlocks(container: HTMLElement): Promise<void>
     const pre = codeEl.parentElement;
     if (!pre || pre.tagName !== "PRE" || pre.dataset.mermaidRendered) continue;
 
-    // Decode HTML entities that Showdown escapes (e.g. &gt; -> >)
+    // Decode HTML entities and normalize line breaks (TipTap may use <br>)
+    const rawHtml = codeEl.innerHTML.replace(/<br\s*\/?>/gi, "\n");
     const textarea = document.createElement("textarea");
-    textarea.innerHTML = codeEl.innerHTML;
+    textarea.innerHTML = rawHtml;
     const source = textarea.value.trim();
 
     try {


### PR DESCRIPTION
## Summary
- Images in private repos now render in the Editor (TipTap strips data attributes, so a metadata map provides fallback)
- Mermaid diagrams pre-render to SVG blob URL images before TipTap processes HTML
- Fixes effect ordering so content is set before post-processing runs
- Fixes TipTap SSR hydration warning

## Test plan
- [x] Images render in Editor file view for private repos
- [x] Mermaid sequence diagrams render in Editor file view
- [x] PR diff view continues to work for both