### PR TITLE
docs: add feature stories 001-009

### DIFF
--- a/docs/features/001-render-final-markdown.md
+++ b/docs/features/001-render-final-markdown.md
@@ -1,0 +1,15 @@
+# 001: Render Final Markdown View with Comments
+
+## Value
+Users can view the final rendered markdown (head version only, no diff) for PR files, with full commenting ability. Currently the PR view only offers "Rendered Diff" and "Side by Side" — there's no clean read-through of the final document.
+
+## Acceptance Criteria
+- New view mode alongside "Rendered Diff" and "Side by Side" (e.g. "Final" or "Rendered")
+- Shows only the head content rendered as markdown — no diff highlighting, no base content
+- Full commenting support: select text, add comments, view in side panel
+- Comments map to line numbers in the head content for GitHub API integration
+
+## Implementation Notes
+- Add a third `viewMode` option in DiffViewer
+- Reuse existing `headBlockToHtml` rendering and comment infrastructure
+- Simpler than diff view — just render `file.headContent` as a single document

--- a/docs/features/002-branch-selector.md
+++ b/docs/features/002-branch-selector.md
@@ -1,0 +1,21 @@
+# 002: Branch Selector for File View
+
+## Value
+Users can browse markdown files on any branch, not just the default branch. Useful for reviewing work-in-progress content without a PR.
+
+## Acceptance Criteria
+- Branch selector UI in the header or sidebar when viewing the file tree
+- Fetches and displays available branches from the repo
+- Switching branches reloads the file tree and file content for the selected branch
+- Current branch is visually indicated
+- Default branch is pre-selected on repo load
+
+## Dependencies
+- Relies on existing `fetchRepoTree(repo, branch)` which already accepts a branch parameter
+- Relies on `fetchFileContent(repo, path, ref)` which already accepts a ref
+
+## Implementation Notes
+- Add `fetchBranches()` API call using `octokit.repos.listBranches()`
+- Store `selectedBranch` in app context (distinct from `defaultBranch`)
+- Pass `selectedBranch` to `fetchRepoTree` and `fetchFileContent`
+- Image URL rewriting already uses the branch ref, so images will resolve correctly

--- a/docs/features/003-comment-to-pr.md
+++ b/docs/features/003-comment-to-pr.md
@@ -1,0 +1,20 @@
+# 003: Open PR from Comments on Any Branch
+
+## Value
+Users can comment on markdown files in any branch (non-PR context) and submit those comments as a new PR. Enables a review workflow without requiring a PR to exist first — the act of commenting creates one.
+
+## Acceptance Criteria
+- When viewing a file on a non-default branch, comments can be added (same UX as PR commenting)
+- A "Submit as PR" action collects all comments and creates a PR from the current branch to the default branch
+- Comments are posted as PR review comments with line mappings
+- If a PR already exists for the branch, comments are added to the existing PR instead
+- User is shown the PR link after creation
+
+## Dependencies
+- 002 (Branch Selector) — need to be on a non-default branch to comment
+
+## Implementation Notes
+- Existing `createReviewPR()` in github-api.ts handles PR creation
+- Existing `createInlineComment()` handles posting review comments with line ranges
+- Need to check for existing PRs from the current branch before creating a new one
+- Editor component already has comment infrastructure — wire it to GitHub API when in authenticated mode

--- a/docs/features/004-edit-to-pr.md
+++ b/docs/features/004-edit-to-pr.md
@@ -1,0 +1,19 @@
+# 004: Edit File and Submit as PR
+
+## Value
+Users can edit markdown files directly in the Editor and submit changes as a PR. Turns mardoc into a full propose-changes workflow — edit content, preview it rendered, submit for review.
+
+## Acceptance Criteria
+- Editor changes are tracked as a dirty state (modified vs original content)
+- "Submit as PR" action creates a new branch, commits the edited file, and opens a PR
+- User can provide a PR title/description before submitting
+- Works from any branch (edits on default branch create a new feature branch)
+- After PR creation, user is shown the PR link
+
+## Dependencies
+- 002 (Branch Selector) — useful but not strictly required; edits on default branch can auto-create a feature branch
+
+## Implementation Notes
+- Editor already has `onContentChange` wired up — need to convert HTML back to markdown (or store the raw markdown and track edits)
+- GitHub API: create branch via `git.createRef()`, update file via `repos.createOrUpdateFileContents()`, then `pulls.create()`
+- Consider markdown round-trip fidelity — editing in TipTap and exporting back to markdown may lose formatting. May want a raw markdown editing mode as an alternative.

--- a/docs/features/005-restore-last-repo-on-return.md
+++ b/docs/features/005-restore-last-repo-on-return.md
@@ -1,0 +1,16 @@
+# 005: Restore Last Repo on Return
+
+## Value
+Returning users land back where they left off — the app automatically reloads their last-selected repo instead of dropping them on a blank screen and forcing them through Settings → wait for enumeration → find repo → click.
+
+## Acceptance Criteria
+- On startup, if a valid token and saved repo exist in localStorage, the app calls `setCurrentRepo()` to load the repo automatically
+- The user sees a loading state while the repo tree and PRs are fetched (not a blank "no repo selected" screen)
+- If the saved repo fails to load (deleted, token revoked, permissions changed), fall back gracefully — clear the saved repo and show the normal unauthenticated/no-repo state
+- No extra clicks required for the returning user path
+
+## Implementation Notes
+- The fix is in `src/lib/app-context.tsx`, in the initialization `useEffect` (~line 103–115)
+- The saved repo is already read from localStorage (`REPO_KEY`) — it just needs to be passed to `setCurrentRepo()` after Octokit is initialized
+- `setCurrentRepo()` already handles fetching the tree, PRs, and setting loading states — no new loading logic needed
+- Error handling: wrap the auto-restore in a try/catch; on failure, `localStorage.removeItem(REPO_KEY)` and let the user re-select manually

--- a/docs/features/006-code-block-syntax-highlighting.md
+++ b/docs/features/006-code-block-syntax-highlighting.md
@@ -1,0 +1,19 @@
+# 006: Code Block Syntax Highlighting
+
+## Value
+Code blocks in markdown files render with syntax colorization instead of plain monospace text. Makes technical documentation with code samples significantly more readable.
+
+## Acceptance Criteria
+- Code blocks with language hints (` ```python `, ` ```go `, etc.) render with syntax highlighting
+- Minimum languages: Python, Go, Bash/Shell, JSON, YAML, JavaScript, TypeScript
+- Auto-detection works for unlabeled code blocks (best-effort)
+- Highlighting works in all views: Editor, Rendered Diff, Side by Side, Final view
+- A highlight.js theme is applied that respects light/dark mode
+
+## Implementation Notes
+- All dependencies already installed: `lowlight@3.3.0`, `@tiptap/extension-code-block-lowlight@2.11.5`, `highlight.js@11.11.1`
+- The `common` grammar set from lowlight includes all 7 requested languages plus ~28 more — no individual language imports needed
+- In `src/components/Editor.tsx`: replace StarterKit's basic `CodeBlock` with `CodeBlockLowlight.configure({ lowlight })` where lowlight is created via `createLowlight(common)`
+- Need to disable StarterKit's built-in `codeBlock` when adding `CodeBlockLowlight` (they conflict)
+- Add a highlight.js CSS theme — pick one that works with both light and dark modes, or swap themes based on `useTheme()`
+- Non-TipTap views (DiffViewer, etc.) that render HTML directly may need separate lowlight processing if they don't go through TipTap

--- a/docs/features/007-url-routing-and-deep-links.md
+++ b/docs/features/007-url-routing-and-deep-links.md
@@ -1,0 +1,55 @@
+# 007: URL Routing and Deep Links
+
+## Value
+Every navigation state produces a shareable URL. Users can bookmark, share, and link directly to a file, PR, or PR file view. Browser back/forward buttons work. Page refresh preserves navigation state instead of dumping the user on the welcome screen.
+
+## Acceptance Criteria
+- Hash-based routing reflects navigation state bidirectionally (URL ↔ app state)
+- URL updates as the user navigates (address bar is always a shareable link)
+- Inbound links restore full navigation state: repo, view, file/PR selection
+- Browser back/forward buttons navigate through view history
+- Page refresh preserves current view
+- Graceful fallback: if a linked file/PR doesn't exist or the user lacks access, show an error rather than a blank screen
+
+## URL Scheme
+```
+/#/{owner}/{repo}/blob/{branch}/{path}       → file view
+/#/{owner}/{repo}/pull/{number}               → PR diff view
+/#/{owner}/{repo}/pull/{number}/files/{idx}   → specific file in PR
+/#/{owner}/{repo}                             → repo root (file tree)
+```
+
+Mirrors GitHub's URL structure so it feels familiar.
+
+## Suggested Breakdown
+
+### 007a: Hash router infrastructure
+- Add a lightweight hash router (no library needed — `hashchange` event + parser)
+- Define route patterns and a parser that extracts owner, repo, branch, path, PR number, file index
+- Wire `parseHash()` on mount and `hashchange` events to dispatch navigation actions in AppContext
+- Wire navigation actions (`openFile`, `openPR`, `setCurrentRepo`) to update `window.location.hash`
+- No UI changes — just the plumbing
+
+### 007b: File deep links
+- Navigating to a file updates the hash to `/#/{owner}/{repo}/blob/{branch}/{path}`
+- Inbound file links trigger repo load (if needed) → file tree load → file selection
+- Handles missing files gracefully
+
+### 007c: PR deep links
+- Navigating to a PR updates the hash to `/#/{owner}/{repo}/pull/{number}`
+- Selecting a file within a PR appends `/files/{idx}`
+- Inbound PR links trigger repo load → PR fetch → PR selection
+- Handles missing/closed PRs gracefully
+
+### 007d: Browser history integration
+- Back/forward buttons navigate between views
+- `pushState`-style behavior via hash changes (each navigation pushes a new hash, not replaces)
+
+## Dependencies
+- 005 (Restore Last Repo) — the auto-restore logic should defer to URL state if a hash route is present (URL wins over localStorage)
+
+## Implementation Notes
+- Static export on GitHub Pages rules out path-based routing — hash routing is the right fit
+- Keep the router minimal: a `parseHash()` function, a `useHashRoute()` hook, and hash updates in existing navigation functions
+- No external routing library needed — the route space is small and well-defined
+- The init flow in `app-context.tsx` needs to check for a hash route before falling back to localStorage repo restore (from 005)

--- a/docs/features/008-wide-format-toggle.md
+++ b/docs/features/008-wide-format-toggle.md
@@ -1,0 +1,18 @@
+# 008: Wide Format Toggle
+
+## Value
+Users working with wide content (tables, diagrams, code blocks) can expand the document view to use more of the screen, while keeping a ~50px side margin for a clean reading experience. Currently the content area is constrained to a narrower column.
+
+## Acceptance Criteria
+- Toggle button in the toolbar or header to switch between normal and wide format
+- Wide format expands the content area to near-full viewport width with ~50px padding on each side
+- Normal format retains current narrower content width
+- Preference persists across sessions (localStorage)
+- Works in all views: Editor, Rendered Diff, Side by Side, Final view
+- Side-by-side view benefits most — more room for both panes
+
+## Implementation Notes
+- Likely a `max-width` toggle on the main content container — from the current constrained width to `calc(100vw - 100px)` or similar
+- Store preference in localStorage (e.g. `mardoc_wide_format`)
+- Could live in the existing theme/settings context or as a simple standalone toggle
+- Button placement: near the view mode switcher makes sense — it's a display preference, not a setting

--- a/docs/features/009-document-link-navigation.md
+++ b/docs/features/009-document-link-navigation.md
@@ -1,0 +1,36 @@
+# 009: Document Link Navigation
+
+## Value
+Clicking links in rendered markdown does something useful instead of breaking or going nowhere. Relative links navigate within MarDoc, anchor links jump to headings, and external links open in a new tab. Makes the rendered view behave like a real document reader.
+
+## Suggested Breakdown
+
+### 009a: Anchor links (same-document)
+- Clicking `[section](#heading-name)` scrolls to that heading within the current file
+- Headings need `id` attributes generated from their text (standard slug rules: lowercase, hyphens, strip special chars)
+- Works in all rendered views (Editor, Diff, Side by Side, Final)
+
+### 009b: Relative links (cross-document)
+- Clicking `[design doc](../design/architecture.md)` navigates to that file within MarDoc
+- Resolve relative paths against the current file's location in the repo tree
+- Triggers file load via existing `openFile()` flow
+- If the target file doesn't exist in the tree, show an error toast rather than failing silently
+- Works with 007 (URL routing) if implemented — navigation updates the hash
+
+### 009c: External links
+- Clicking `https://...` links opens in a new browser tab (`target="_blank"`, `rel="noopener"`)
+- Should already mostly work but needs explicit handling to prevent MarDoc from trying to intercept them
+
+## Acceptance Criteria
+- All three link types work in all rendered views
+- No link click causes a full page navigation away from MarDoc
+- Relative links that point to non-markdown files (images, PDFs) fall back to opening on GitHub
+
+## Dependencies
+- 007 (URL Routing) — not required, but if present, cross-document navigation should update the hash
+
+## Implementation Notes
+- TipTap's Link extension likely handles click events — need to intercept and route based on link type
+- Non-TipTap rendered views (DiffViewer HTML) need a click handler on `<a>` tags that classifies and routes
+- Relative path resolution: given current file path and link href, compute the target path in the repo tree
+- Anchor slug generation should match GitHub's algorithm for compatibility (GFM heading IDs)


### PR DESCRIPTION
## Summary
- Commits the full feature backlog (001–009) covering all planned MarDoc enhancements
- Includes 4 previously untracked stories (001–004) and 5 new stories from today's Q&A session
- New stories: auto-restore last repo (005), code syntax highlighting (006), URL routing & deep links (007), wide format toggle (008), document link navigation (009)

## Stories
| # | Story | Size |
|---|-------|------|
| 001 | Render Final Markdown View | S |
| 002 | Branch Selector | M |
| 003 | Comment on Branch → Create PR | M |
| 004 | Edit File → Submit as PR | M |
| 005 | Restore Last Repo on Return | S |
| 006 | Code Block Syntax Highlighting | S |
| 007 | URL Routing & Deep Links (4 sub-stories) | L |
| 008 | Wide Format Toggle | S |
| 009 | Document Link Navigation (3 sub-stories) | M |