### PR TITLE
feat: wide format toggle

### DIFF
--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -13,10 +13,13 @@ import {
   Check,
   X,
   Send,
+  Maximize2,
+  Minimize2,
 } from "lucide-react";
 import ContextMenu from "./ContextMenu";
 import { mapSelectionToLines, rewriteImageUrls, loadAuthenticatedImages } from "@/lib/github-api";
 import { renderMermaidBlocks } from "@/lib/mermaid";
+import { useWideFormat } from "@/lib/use-wide-format";
 
 interface DiffViewerProps {
   file: PRFile;
@@ -413,6 +416,7 @@ export default function DiffViewer({
 }: DiffViewerProps) {
   const [viewMode, setViewMode] = useState<"rendered" | "split">("rendered");
   const [showPanel, setShowPanel] = useState(true);
+  const { wide, toggle: toggleWide } = useWideFormat();
 
   // Single source of truth: comments prop from PRDetail (no local duplicate)
   const [activeCommentId, setActiveCommentId] = useState<string | null>(null);
@@ -647,6 +651,14 @@ export default function DiffViewer({
               : "Comments"}
           </button>
 
+          <button
+            onClick={toggleWide}
+            className={`toolbar-btn ${wide ? "active" : ""}`}
+            title={wide ? "Normal width" : "Wide format"}
+          >
+            {wide ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
+          </button>
+
           <div className="flex items-center gap-1 bg-[var(--surface-secondary)] rounded-md p-0.5">
             <button
               onClick={() => setViewMode("rendered")}
@@ -738,7 +750,7 @@ export default function DiffViewer({
                 onComment={handleSelectionComment}
               />
 
-              <div className="max-w-5xl mx-auto px-8 py-6">
+              <div className={wide ? "mx-auto px-12 py-6" : "max-w-5xl mx-auto px-8 py-6"}>
                 {/* Hint */}
                 <div className="text-[10px] text-[var(--text-muted)] mb-4 flex items-center gap-1.5">
                   <MessageSquarePlus size={10} />

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -17,6 +17,7 @@ import { TableHeader } from "@tiptap/extension-table-header";
 import Showdown from "showdown";
 import { rewriteImageUrls, loadAuthenticatedImages } from "@/lib/github-api";
 import { preRenderMermaid } from "@/lib/mermaid";
+import { useWideFormat } from "@/lib/use-wide-format";
 import {
   Bold,
   Italic,
@@ -43,6 +44,8 @@ import {
   Check as CheckIcon,
   ChevronDown,
   ChevronRight,
+  Maximize2,
+  Minimize2,
 } from "lucide-react";
 
 interface EditorProps {
@@ -380,6 +383,7 @@ function CommentSidePanel({
 
 export default function Editor({ content, onContentChange, filePath, repoFullName, branch }: EditorProps) {
   const editorContainerRef = useRef<HTMLDivElement>(null);
+  const { wide, toggle: toggleWide, contentClass } = useWideFormat();
   const [comments, setComments] = useState<EditorComment[]>([]);
   const [showComments, setShowComments] = useState(false);
   const [activeCommentId, setActiveCommentId] = useState<string | null>(null);
@@ -636,8 +640,15 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
             title="Redo (⌘⇧Z)"
           />
 
-          {/* Comment toggle — right side */}
+          {/* Wide format + comment toggle — right side */}
           <div className="ml-auto flex items-center gap-1">
+            <button
+              onClick={toggleWide}
+              className={`toolbar-btn ${wide ? "active" : ""}`}
+              title={wide ? "Normal width" : "Wide format"}
+            >
+              {wide ? <Minimize2 size={15} /> : <Maximize2 size={15} />}
+            </button>
             <button
               onClick={() => setShowComments(!showComments)}
               className={`flex items-center gap-1.5 px-2.5 py-1.5 text-xs rounded-md transition-colors ${
@@ -659,7 +670,7 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
 
         {/* Editor area */}
         <div className="flex-1 overflow-y-auto" ref={editorContainerRef as React.RefObject<HTMLDivElement>}>
-          <div className="max-w-5xl mx-auto px-8 py-8 relative">
+          <div className={contentClass}>
             {/* File path breadcrumb */}
             <div className="text-xs text-[var(--text-muted)] mb-4 font-mono flex items-center gap-2">
               {filePath}

--- a/src/lib/use-wide-format.ts
+++ b/src/lib/use-wide-format.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+const STORAGE_KEY = "mardoc_wide_format";
+
+export function useWideFormat() {
+  const [wide, setWideState] = useState(false);
+
+  // Hydrate from localStorage after mount
+  useEffect(() => {
+    setWideState(localStorage.getItem(STORAGE_KEY) === "true");
+  }, []);
+
+  const setWide = useCallback((value: boolean) => {
+    setWideState(value);
+    localStorage.setItem(STORAGE_KEY, String(value));
+  }, []);
+
+  const toggle = useCallback(() => {
+    setWide(!wide);
+  }, [wide, setWide]);
+
+  const contentClass = wide
+    ? "mx-auto px-12 py-8 relative"
+    : "max-w-5xl mx-auto px-8 py-8 relative";
+
+  return { wide, setWide, toggle, contentClass };
+}


### PR DESCRIPTION
## Summary
- Adds a wide format toggle (Maximize2/Minimize2 icon) to the Editor and DiffViewer toolbars
- Wide mode expands content area to near-full viewport width with comfortable side padding
- Preference persists across sessions via localStorage (`mardoc_wide_format`)
- Implemented as a reusable `useWideFormat` hook in `src/lib/use-wide-format.ts`

## Test plan
- [ ] Toggle wide format in Editor view — content area expands
- [ ] Toggle wide format in Rendered Diff view — content area expands
- [ ] Refresh page — preference persists
- [ ] Toggle back to normal — content returns to constrained width