### PR TITLE
feat: comment reply threading with polling

### DIFF
--- a/docs/features/011-sync-comment-resolution-status.md
+++ b/docs/features/011-sync-comment-resolution-status.md
@@ -1,0 +1,17 @@
+# 011: Sync Comment Resolution Status from GitHub
+
+## Value
+When a reviewer resolves or unresolves a conversation on GitHub, that status is reflected in mardoc.app. Currently resolution only works locally — the poll picks up new comments and replies but not resolve/unresolve actions.
+
+## Acceptance Criteria
+- Resolved threads on GitHub appear as resolved in mardoc.app
+- Unresolving a thread on GitHub re-opens it in mardoc.app
+- Resolving in mardoc.app resolves the thread on GitHub (bi-directional)
+- Status syncs within the polling interval (30s)
+
+## Implementation Notes
+- GitHub REST API (`pulls.listReviewComments`) does not expose thread resolution status
+- Need to use GitHub GraphQL API: `pullRequest { reviewThreads { isResolved, comments { nodes { databaseId } } } }`
+- Match threads to existing comments via `databaseId` ↔ `githubId`
+- Could add a lightweight GraphQL query alongside the existing REST poll, or replace the REST fetch entirely
+- Resolving from mardoc.app → GitHub requires `resolveReviewThread` GraphQL mutation (takes `threadId`)

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -35,6 +35,7 @@ interface DiffViewerProps {
     endLine?: number
   ) => void;
   onResolveComment: (commentId: string) => void;
+  onReplyComment?: (commentId: string, body: string) => void;
 }
 
 interface DiffBlock {
@@ -413,6 +414,7 @@ export default function DiffViewer({
   comments,
   onAddComment,
   onResolveComment,
+  onReplyComment,
 }: DiffViewerProps) {
   const [viewMode, setViewMode] = useState<"rendered" | "split" | "preview">("rendered");
   const [showPanel, setShowPanel] = useState(true);
@@ -443,7 +445,12 @@ export default function DiffViewer({
       createdAt: c.createdAt,
       blockIndex: c.blockIndex || 0,
       resolved: c.resolved,
-      replies: [],
+      replies: (c.replies || []).map((r) => ({
+        author: r.author,
+        avatarColor: r.avatarColor,
+        body: r.body,
+        createdAt: r.createdAt,
+      })),
       source: "github" as const,
     }));
   }, [comments]);
@@ -546,10 +553,10 @@ export default function DiffViewer({
   }, [pendingSelection, pendingCommentInput, file.headContent, onAddComment]);
 
   const handleReply = useCallback((commentId: string, body: string) => {
-    // For now, replies are handled locally in the panel
-    // TODO: wire to GitHub API for reply threading
-    console.log("Reply to", commentId, body);
-  }, []);
+    if (onReplyComment) {
+      onReplyComment(commentId, body);
+    }
+  }, [onReplyComment]);
 
   const handleResolve = useCallback((commentId: string) => {
     onResolveComment(commentId);

--- a/src/components/PRDetail.tsx
+++ b/src/components/PRDetail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect, useRef } from "react";
 import {
   GitPullRequest,
   GitMerge,
@@ -12,7 +12,7 @@ import {
 } from "lucide-react";
 import { PullRequest, PRComment } from "@/types";
 import { useApp } from "@/lib/app-context";
-import { createPRComment, createInlineComment } from "@/lib/github-api";
+import { createPRComment, createInlineComment, replyToReviewComment, fetchPRComments } from "@/lib/github-api";
 import DiffViewer from "./DiffViewer";
 import Showdown from "showdown";
 
@@ -52,6 +52,22 @@ export default function PRDetail({ pr, onBack }: PRDetailProps) {
     }
   }, [prComments, comments.length]);
 
+  // Poll for new comments every 30s when authenticated
+  useEffect(() => {
+    if (isDemoMode || !currentRepo || !pr.number) return;
+
+    const poll = setInterval(async () => {
+      try {
+        const fresh = await fetchPRComments(currentRepo, pr.number);
+        setComments(fresh);
+      } catch {
+        // Silently skip — next poll will retry
+      }
+    }, 30_000);
+
+    return () => clearInterval(poll);
+  }, [isDemoMode, currentRepo, pr.number]);
+
   const selectedFile = prFiles[selectedPRFileIdx];
 
   const handleAddComment = useCallback(async (
@@ -72,6 +88,7 @@ export default function PRDetail({ pr, onBack }: PRDetailProps) {
       blockIndex,
       selectedText,
       resolved: false,
+      replies: [],
     };
     setComments((prev) => [...prev, newComment]);
 
@@ -125,6 +142,44 @@ export default function PRDetail({ pr, onBack }: PRDetailProps) {
       prev.map((c) => (c.id === commentId ? { ...c, resolved: true } : c))
     );
   };
+
+  const handleReplyComment = useCallback(async (commentId: string, body: string) => {
+    const comment = comments.find((c) => c.id === commentId);
+
+    // Optimistic local update
+    const localReply = {
+      id: `r-${Date.now()}`,
+      author: "you",
+      avatarColor: "#2a9d8f",
+      body,
+      createdAt: new Date().toISOString(),
+    };
+    setComments((prev) =>
+      prev.map((c) =>
+        c.id === commentId
+          ? { ...c, replies: [...c.replies, localReply] }
+          : c
+      )
+    );
+
+    // Post to GitHub if authenticated and comment has a GitHub ID
+    if (!isDemoMode && currentRepo && pr.number && comment?.githubId) {
+      try {
+        await replyToReviewComment(currentRepo, pr.number, comment.githubId, body);
+      } catch (err) {
+        console.error("Failed to post reply to GitHub:", err);
+        // Fall back to a general PR comment with context
+        try {
+          const fallbackBody = comment.selectedText
+            ? `> _Re: "${comment.selectedText}"_\n\n${body}`
+            : body;
+          await createPRComment(currentRepo, pr.number, fallbackBody);
+        } catch (fallbackErr) {
+          console.error("Fallback reply also failed:", fallbackErr);
+        }
+      }
+    }
+  }, [comments, isDemoMode, currentRepo, pr.number]);
 
   return (
     <div className="h-full flex flex-col">
@@ -251,6 +306,7 @@ export default function PRDetail({ pr, onBack }: PRDetailProps) {
             comments={comments}
             onAddComment={handleAddComment}
             onResolveComment={handleResolveComment}
+            onReplyComment={handleReplyComment}
           />
         ) : null}
       </div>

--- a/src/lib/github-api.ts
+++ b/src/lib/github-api.ts
@@ -315,23 +315,56 @@ export async function fetchPRComments(
 
   const colors = ["#e76f51", "#2a9d8f", "#264653", "#e9c46a", "#f4a261"];
 
+  // Build a color map per author for consistency
+  const authorColors = new Map<string, string>();
+  const getColor = (author: string) => {
+    if (!authorColors.has(author)) {
+      authorColors.set(author, colors[authorColors.size % colors.length]);
+    }
+    return authorColors.get(author)!;
+  };
+
+  // Separate top-level review comments from replies using in_reply_to_id
+  const topLevel: typeof reviewComments.data = [];
+  const replyMap = new Map<number, typeof reviewComments.data>();
+
+  for (const c of reviewComments.data) {
+    const parentId = (c as any).in_reply_to_id;
+    if (parentId) {
+      if (!replyMap.has(parentId)) replyMap.set(parentId, []);
+      replyMap.get(parentId)!.push(c);
+    } else {
+      topLevel.push(c);
+    }
+  }
+
   const allComments: PRComment[] = [
-    ...reviewComments.data.map((c, i) => ({
+    ...topLevel.map((c) => ({
       id: `rc-${c.id}`,
+      githubId: c.id,
       author: c.user?.login || "unknown",
-      avatarColor: colors[i % colors.length],
+      avatarColor: getColor(c.user?.login || "unknown"),
       body: c.body,
       createdAt: c.created_at,
       blockIndex: c.line || c.original_line || 0,
       resolved: false,
+      replies: (replyMap.get(c.id) || []).map((r) => ({
+        id: `rc-${r.id}`,
+        author: r.user?.login || "unknown",
+        avatarColor: getColor(r.user?.login || "unknown"),
+        body: r.body,
+        createdAt: r.created_at,
+      })),
     })),
-    ...issueComments.data.map((c, i) => ({
+    ...issueComments.data.map((c) => ({
       id: `ic-${c.id}`,
+      githubId: c.id,
       author: c.user?.login || "unknown",
-      avatarColor: colors[(i + 2) % colors.length],
+      avatarColor: getColor(c.user?.login || "unknown"),
       body: c.body || "",
       createdAt: c.created_at,
       resolved: false,
+      replies: [],
     })),
   ];
 
@@ -401,6 +434,36 @@ export async function createInlineComment(
   }
 
   await octokit.pulls.createReviewComment(params as any);
+}
+
+/**
+ * Reply to an existing review comment on a PR.
+ * Uses the pull request review comment reply endpoint.
+ */
+export async function replyToReviewComment(
+  repoFullName: string,
+  prNumber: number,
+  commentId: number,
+  body: string
+): Promise<{ id: number; author: string; createdAt: string }> {
+  const octokit = getOctokit();
+  if (!octokit) throw new Error("Not authenticated");
+
+  const { owner, repo } = parseOwnerRepo(repoFullName);
+
+  const { data } = await octokit.pulls.createReplyForReviewComment({
+    owner,
+    repo,
+    pull_number: prNumber,
+    comment_id: commentId,
+    body,
+  });
+
+  return {
+    id: data.id,
+    author: data.user?.login || "unknown",
+    createdAt: data.created_at,
+  };
 }
 
 /**

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -503,6 +503,15 @@ The application uses a modern React stack with Next.js for server-side rendering
         createdAt: "2026-03-30T15:00:00Z",
         blockIndex: 1,
         resolved: false,
+        replies: [
+          {
+            id: "c1-r1",
+            author: "joe.barnett",
+            avatarColor: "#264653",
+            body: "Thanks! I wanted to make sure the onboarding experience is smooth.",
+            createdAt: "2026-03-30T15:30:00Z",
+          },
+        ],
       },
       {
         id: "c2",
@@ -512,6 +521,7 @@ The application uses a modern React stack with Next.js for server-side rendering
         createdAt: "2026-03-30T16:30:00Z",
         blockIndex: 3,
         resolved: false,
+        replies: [],
       },
     ],
   },
@@ -654,6 +664,7 @@ The editor supports GitHub webhooks for real-time synchronization. Configure you
         createdAt: "2026-03-29T10:15:00Z",
         blockIndex: 5,
         resolved: false,
+        replies: [],
       },
     ],
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,8 +7,17 @@ export interface RepoFile {
   content?: string;
 }
 
+export interface PRCommentReply {
+  id: string;
+  author: string;
+  avatarColor: string;
+  body: string;
+  createdAt: string;
+}
+
 export interface PRComment {
   id: string;
+  githubId?: number; // numeric GitHub comment ID for API calls (replies, resolve)
   author: string;
   avatarColor: string;
   body: string;
@@ -16,6 +25,7 @@ export interface PRComment {
   blockIndex?: number; // which rendered block this comment is on
   selectedText?: string; // the text that was selected when the comment was created
   resolved: boolean;
+  replies: PRCommentReply[];
 }
 
 export interface PullRequest {


### PR DESCRIPTION
## Summary
- Wire reply input in DiffViewer to post threaded replies via GitHub API
- Fetch and display threaded replies from GitHub (grouped by `in_reply_to_id`)
- Poll for new comments/replies every 30s when viewing a PR
- Optimistic local updates with fallback to general PR comment
- Add `PRComment.replies` and `githubId` to type system
- Add demo reply data to showcase threading in demo mode

## Known gaps
- **Resolve sync** does not work yet — GitHub REST API doesn't expose thread resolution status. Resolving locally doesn't push to GitHub, and resolving on GitHub doesn't reflect here. Story 011 filed to address via GraphQL API.

## Test plan
- [ ] Open a PR, reply to a comment — reply appears immediately and posts to GitHub
- [ ] Open the same PR on GitHub — reply is visible as a threaded reply
- [ ] Have someone reply on GitHub — reply appears in mardoc within 30s
- [ ] Demo mode shows threaded reply on PR #42