### PR TITLE
feat: PR markdown file counts and open/closed filter

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -233,6 +233,8 @@ export default function Sidebar() {
     createNewFile,
     addFileToPR,
     openLocalFile,
+    prStateFilter,
+    setPRStateFilter,
     setCurrentView,
     selectedFile,
     selectedPR,
@@ -539,6 +541,23 @@ export default function Sidebar() {
           </div>
         ) : (
           <div className="space-y-1">
+            {/* State filter */}
+            <div className="flex items-center gap-1 px-1 mb-2">
+              {(["open", "closed", "all"] as const).map((state) => (
+                <button
+                  key={state}
+                  onClick={() => setPRStateFilter(state)}
+                  className={`flex-1 text-[10px] py-1 rounded transition-colors capitalize ${
+                    prStateFilter === state
+                      ? "bg-[var(--accent-muted)] text-[var(--accent)] font-medium"
+                      : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+                  }`}
+                >
+                  {state}
+                </button>
+              ))}
+            </div>
+
             {/* Create review PR button */}
             <button
               onClick={() => setCurrentView("pr-review")}
@@ -571,12 +590,22 @@ export default function Sidebar() {
                     ) : (
                       <GitPullRequest size={14} className="text-green-500 shrink-0 mt-0.5" />
                     )}
-                    <div className="min-w-0">
+                    <div className="min-w-0 flex-1">
                       <div className="text-sm text-[var(--text-primary)] truncate">
                         {pr.title}
                       </div>
-                      <div className="text-xs text-[var(--text-muted)] mt-0.5">
-                        #{pr.number} by {pr.author}
+                      <div className="flex items-center gap-2 text-xs text-[var(--text-muted)] mt-0.5">
+                        <span>#{pr.number} by {pr.author}</span>
+                        {pr.mdFileCount !== undefined && pr.mdFileCount > 0 && (
+                          <span className="text-[9px] px-1.5 py-0 rounded-full bg-[var(--accent-muted)] text-[var(--accent)] font-medium">
+                            {pr.mdFileCount} md
+                          </span>
+                        )}
+                        {pr.mdFileCount === 0 && (
+                          <span className="text-[9px] px-1.5 py-0 rounded-full bg-[var(--surface-secondary)] text-[var(--text-muted)]">
+                            no md
+                          </span>
+                        )}
                       </div>
                     </div>
                   </div>

--- a/src/lib/app-context.tsx
+++ b/src/lib/app-context.tsx
@@ -2,7 +2,7 @@
 
 import React, { createContext, useContext, useState, useCallback, useEffect, useRef } from "react";
 import { RepoFile, PullRequest, PRFile, PRComment, ViewMode } from "@/types";
-import { initOctokit, fetchRepoTree, fetchPullRequests, fetchFileContent, fetchPRFiles, fetchPRComments, fetchDefaultBranch, fetchBranches } from "./github-api";
+import { initOctokit, fetchRepoTree, fetchPullRequests, fetchFileContent, fetchPRFiles, fetchPRComments, fetchDefaultBranch, fetchBranches, fetchPRMarkdownCounts } from "./github-api";
 import { repoFiles as mockFiles, pullRequests as mockPRs, findFile, flattenFiles } from "./mock-data";
 import { parseHash, buildFileHash, buildPRHash, buildRepoHash } from "./hash-router";
 
@@ -22,6 +22,8 @@ interface AppState {
   setCurrentRepo: (repo: string) => void;
   repoFiles: RepoFile[];
   pullRequests: PullRequest[];
+  prStateFilter: "open" | "closed" | "all";
+  setPRStateFilter: (state: "open" | "closed" | "all") => void;
 
   // Navigation
   currentView: ViewMode;
@@ -75,6 +77,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const [availableBranches, setAvailableBranches] = useState<{ name: string; isDefault: boolean }[]>([]);
   const [repoFilesList, setRepoFiles] = useState<RepoFile[]>(mockFiles);
   const [prList, setPRList] = useState<PullRequest[]>(mockPRs);
+  const [prStateFilter, setPRStateFilterState] = useState<"open" | "closed" | "all">("open");
 
   // Navigation
   const [currentView, setCurrentView] = useState<ViewMode>("editor");
@@ -163,23 +166,50 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       }
 
       // Load PRs and branches in parallel
+      await loadPRs(repo, prStateFilter);
+
       setLoadingPRs(true);
       try {
-        const [prs, branches] = await Promise.all([
-          fetchPullRequests(repo, "all"),
-          fetchBranches(repo).catch(() => [] as { name: string; isDefault: boolean }[]),
-        ]);
-        setPRList(prs);
+        const branches = await fetchBranches(repo).catch(() => [] as { name: string; isDefault: boolean }[]);
         setAvailableBranches(branches);
-      } catch (err: any) {
-        console.error("Failed to load PRs:", err);
-        setPRList([]);
+      } catch {
+        // branches are non-critical
       } finally {
         setLoadingPRs(false);
       }
     },
-    [githubToken]
+    [githubToken, prStateFilter]
   );
+
+  const loadPRs = useCallback(async (repo: string, state: "open" | "closed" | "all") => {
+    if (!githubToken) return;
+    setLoadingPRs(true);
+    try {
+      const prs = await fetchPullRequests(repo, state);
+      setPRList(prs);
+
+      // Enrich with markdown file counts (non-blocking)
+      if (prs.length > 0) {
+        fetchPRMarkdownCounts(repo, prs.map((p) => p.number)).then((counts) => {
+          setPRList((prev) =>
+            prev.map((p) => ({ ...p, mdFileCount: counts.get(p.number) ?? 0 }))
+          );
+        });
+      }
+    } catch (err: any) {
+      console.error("Failed to load PRs:", err);
+      setPRList([]);
+    } finally {
+      setLoadingPRs(false);
+    }
+  }, [githubToken]);
+
+  const setPRStateFilter = useCallback((state: "open" | "closed" | "all") => {
+    setPRStateFilterState(state);
+    if (currentRepo) {
+      loadPRs(currentRepo, state);
+    }
+  }, [currentRepo, loadPRs]);
 
   // Auto-restore: hash route wins over localStorage
   useEffect(() => {
@@ -439,6 +469,8 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         setCurrentRepo,
         repoFiles: repoFilesList,
         pullRequests: prList,
+        prStateFilter,
+        setPRStateFilter,
         currentView,
         setCurrentView,
         selectedFile,

--- a/src/lib/github-api.ts
+++ b/src/lib/github-api.ts
@@ -221,6 +221,51 @@ export async function fetchPullRequests(
   }));
 }
 
+/**
+ * Fetch markdown file counts for a batch of PRs via a single GraphQL query.
+ * Returns a map of PR number → count of .md/.mdx files changed.
+ */
+export async function fetchPRMarkdownCounts(
+  repoFullName: string,
+  prNumbers: number[]
+): Promise<Map<number, number>> {
+  const octokit = getOctokit();
+  if (!octokit || prNumbers.length === 0) return new Map();
+
+  const { owner, repo } = parseOwnerRepo(repoFullName);
+
+  // Build aliased query fragments for each PR
+  const fragments = prNumbers.map(
+    (num, i) => `pr${i}: pullRequest(number: ${num}) { number files(first: 100) { nodes { path } } }`
+  ).join("\n    ");
+
+  const query = `query {
+    repository(owner: "${owner}", name: "${repo}") {
+      ${fragments}
+    }
+  }`;
+
+  try {
+    const result: any = await (octokit as any).graphql(query);
+    const counts = new Map<number, number>();
+
+    for (let i = 0; i < prNumbers.length; i++) {
+      const prData = result.repository[`pr${i}`];
+      if (prData?.files?.nodes) {
+        const mdCount = prData.files.nodes.filter(
+          (f: any) => /\.(md|mdx)$/i.test(f.path)
+        ).length;
+        counts.set(prData.number, mdCount);
+      }
+    }
+
+    return counts;
+  } catch (err) {
+    console.error("Failed to fetch PR markdown counts:", err);
+    return new Map();
+  }
+}
+
 export async function fetchPRFiles(
   repoFullName: string,
   prNumber: number

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,6 +41,7 @@ export interface PullRequest {
   files: PRFile[];
   comments: PRComment[];
   description: string;
+  mdFileCount?: number;
 }
 
 export interface PRFile {


### PR DESCRIPTION
## Summary
- **Md file count badge** on each PR in sidebar — "N md" or "no md" via single GraphQL batch query
- **Open/Closed/All filter** toggle at top of PR list, defaults to open
- Non-blocking enrichment — list loads instantly, counts fill in async

## Test plan
- [ ] Open PR tab — verify open/closed/all filter appears
- [ ] Verify PRs show md file count badges after brief load
- [ ] Switch to "closed" — verify list updates with closed/merged PRs
- [ ] PRs with 0 md files show "no md" badge
- [ ] Verify no performance regression on initial load