### PR TITLE
feat: embed mode for VS Code extension

### DIFF
--- a/docs/features/017-vscode-extension.md
+++ b/docs/features/017-vscode-extension.md
@@ -1,0 +1,40 @@
+# 017: VS Code Extension
+
+## Value
+
+MarDoc as a rich markdown editor and PR reviewer inside VS Code. The extension loads mardoc.app in a WebView, passes workspace context, and provides an "Edit with MarDoc" right-click action on markdown files. Git operations (commit, branch, push) stay in VS Code where they belong — MarDoc handles rendering, editing, and PR review.
+
+## Acceptance Criteria
+
+### Extension
+- "MarDoc: Open" command launches mardoc.app in a WebView panel
+- "Edit with MarDoc" in the explorer context menu for `.md` / `.mdx` files — opens the file in MarDoc beside the editor
+- Extension detects workspace GitHub remote and branch from git
+- Extension gets a GitHub token via `vscode.authentication.getSession('github')`
+- On load, passes repo, branch, token, and theme to the app via `postMessage`
+- Dark/light theme follows VS Code's active color theme
+- Save in MarDoc writes back to disk via postMessage → extension → `vscode.workspace.fs`
+
+### Embed mode (`?embed=true`) in the MarDoc app
+- No file tree tab — VS Code drives file navigation
+- PR tab stays — browse, review, diff, comment on PRs
+- Save writes to disk (via postMessage to extension), not to GitHub API
+- Auth section hidden when token is provided externally
+
+## Dependencies
+
+- VS Code Extension API (`@types/vscode`)
+- `?embed=true` query param support in the MarDoc app (`src/lib/vscode-bridge.ts`)
+
+## Implementation Notes
+
+- Extension is a separate package (`mardoc-vscode/`), ~3 files
+- WebView loads `https://mardoc.app/?embed=true` with a hash route to the target file
+- Message types: `ready` (app → extension), `init` (extension → app), `file:save` (app → extension)
+- Bridge module in the app detects embed mode, hides file tree, routes save to postMessage instead of GitHub API
+- Bridge is a no-op when not embedded — zero impact on the web app
+
+## Future Stories (not this one)
+
+- Configurable URL setting for self-hosted or localhost dev
+- Multi-file editing session (track edits across files, bulk save)

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,6 +15,7 @@
   --accent: #2383e2;
   --accent-hover: #1b6ec2;
   --accent-muted: #e8f0fe;
+  --inline-code: #d63384;
   --diff-add: #dafbe1;
   --diff-add-text: #1a7f37;
   --diff-remove: #ffebe9;
@@ -32,6 +33,7 @@
   --accent: #bd93f9;
   --accent-hover: #caa5fb;
   --accent-muted: #363949;
+  --inline-code: #ffb86c;
   --diff-add: #1e3a2a;
   --diff-add-text: #50fa7b;
   --diff-remove: #3d1a1e;
@@ -127,11 +129,19 @@ body {
   padding: 0.15em 0.3em;
   font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, monospace;
   font-size: 0.9em;
+  color: var(--inline-code);
+}
+
+/* Remove Tailwind prose backtick pseudo-elements */
+.ProseMirror code::before,
+.ProseMirror code::after {
+  content: none !important;
 }
 
 .ProseMirror pre code {
   background: none;
   padding: 0;
+  color: inherit;
 }
 
 .ProseMirror img {
@@ -220,10 +230,16 @@ body {
   padding: 0.15em 0.3em;
   font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, monospace;
   font-size: 0.9em;
+  color: var(--inline-code);
+}
+.diff-content code::before,
+.diff-content code::after {
+  content: none !important;
 }
 .diff-content pre code {
   background: none;
   padding: 0;
+  color: inherit;
 }
 
 /* Mermaid diagrams */

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,6 +33,7 @@ export default function Home() {
     selectedBranch,
     repoFiles,
     pullRequests,
+    isEmbedded,
   } = useApp();
 
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -55,7 +56,7 @@ export default function Home() {
             </span>
           ) : (
             <span className="text-xs text-[var(--text-muted)]">
-              {isDemoMode ? "Demo Mode" : "No repo selected"}
+              {isEmbedded ? "" : isDemoMode ? "Demo Mode" : "No repo selected"}
             </span>
           )}
         </div>
@@ -67,13 +68,15 @@ export default function Home() {
               <span className="max-w-48 truncate">{error}</span>
             </div>
           )}
-          <button
-            onClick={() => setSettingsOpen(true)}
-            className="toolbar-btn"
-            title="Settings"
-          >
-            <Settings size={16} />
-          </button>
+          {!isEmbedded && (
+            <button
+              onClick={() => setSettingsOpen(true)}
+              className="toolbar-btn"
+              title="Settings"
+            >
+              <Settings size={16} />
+            </button>
+          )}
           <ThemeToggle />
         </div>
       </header>
@@ -136,7 +139,9 @@ export default function Home() {
                   Welcome to mardoc.app
                 </h2>
                 <p className="text-sm text-[var(--text-secondary)] leading-relaxed mb-6">
-                  {isDemoMode
+                  {isEmbedded
+                    ? "Select a pull request from the sidebar to start reviewing, or right-click a markdown file to edit with MarDoc."
+                    : isDemoMode
                     ? "You're in demo mode with sample data. Open Settings to connect a GitHub repository."
                     : "Select a file from the sidebar to start editing, or open a pull request to review rendered markdown diffs."}
                 </p>
@@ -150,7 +155,7 @@ export default function Home() {
                     <span>{pullRequests.length} pull requests</span>
                   </div>
                 </div>
-                {isDemoMode && (
+                {isDemoMode && !isEmbedded && (
                   <button
                     onClick={() => setSettingsOpen(true)}
                     className="mt-5 inline-flex items-center gap-2 px-4 py-2 bg-[var(--accent)] text-white text-sm rounded-lg hover:bg-[var(--accent-hover)] transition-colors"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -246,11 +246,17 @@ export default function Sidebar() {
     selectedBranch,
     availableBranches,
     setSelectedBranch,
+    isEmbedded,
   } = useApp();
 
   const [activeTab, setActiveTab] = useState<"files" | "prs">("files");
   const [prFileFilter, setPRFileFilter] = useState("");
   const [collapsed, setCollapsed] = useState(false);
+
+  // Switch to PRs tab once embed mode is detected (deferred via useEffect)
+  useEffect(() => {
+    if (isEmbedded) setActiveTab("prs");
+  }, [isEmbedded]);
   const [branchDropdownOpen, setBranchDropdownOpen] = useState(false);
   const [branchFilter, setBranchFilter] = useState("");
   const branchDropdownRef = useRef<HTMLDivElement>(null);
@@ -319,19 +325,21 @@ export default function Sidebar() {
     <aside className="w-64 shrink-0 h-full border-r border-[var(--border)] bg-[var(--surface-secondary)] flex flex-col">
       {/* Tabs */}
       <div className="flex border-b border-[var(--border)]">
-        <button
-          onClick={() => setActiveTab("files")}
-          className={`flex-1 px-3 py-2.5 text-sm font-medium transition-colors ${
-            activeTab === "files"
-              ? "text-[var(--text-primary)] border-b-2 border-[var(--accent)]"
-              : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
-          }`}
-        >
-          <span className="flex items-center justify-center gap-1.5">
-            <FileText size={14} />
-            Files
-          </span>
-        </button>
+        {(!isEmbedded || isViewingPR) && (
+          <button
+            onClick={() => setActiveTab("files")}
+            className={`flex-1 px-3 py-2.5 text-sm font-medium transition-colors ${
+              activeTab === "files"
+                ? "text-[var(--text-primary)] border-b-2 border-[var(--accent)]"
+                : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+            }`}
+          >
+            <span className="flex items-center justify-center gap-1.5">
+              <FileText size={14} />
+              {isEmbedded ? "Changed Files" : "Files"}
+            </span>
+          </button>
+        )}
         <button
           onClick={() => setActiveTab("prs")}
           className={`flex-1 px-3 py-2.5 text-sm font-medium transition-colors ${
@@ -501,29 +509,31 @@ export default function Sidebar() {
             </div>
           ) : (
             <div className="space-y-0.5">
-              <div className="flex items-center gap-1 mb-1">
-                <button
-                  onClick={createNewFile}
-                  className="flex-1 flex items-center gap-2 px-3 py-1.5 text-xs rounded-md text-[var(--accent)] hover:bg-[var(--surface-hover)] transition-colors"
-                >
-                  <FilePlus size={14} />
-                  New File
-                </button>
-                <button
-                  onClick={() => fileInputRef.current?.click()}
-                  className="flex items-center gap-1.5 px-2 py-1.5 text-xs rounded-md text-[var(--text-muted)] hover:text-[var(--accent)] hover:bg-[var(--surface-hover)] transition-colors"
-                  title="Open a local .md file"
-                >
-                  <FolderInput size={14} />
-                </button>
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept=".md,.mdx,.markdown"
-                  onChange={handleLocalFileSelect}
-                  className="hidden"
-                />
-              </div>
+              {!isEmbedded && (
+                <div className="flex items-center gap-1 mb-1">
+                  <button
+                    onClick={createNewFile}
+                    className="flex-1 flex items-center gap-2 px-3 py-1.5 text-xs rounded-md text-[var(--accent)] hover:bg-[var(--surface-hover)] transition-colors"
+                  >
+                    <FilePlus size={14} />
+                    New File
+                  </button>
+                  <button
+                    onClick={() => fileInputRef.current?.click()}
+                    className="flex items-center gap-1.5 px-2 py-1.5 text-xs rounded-md text-[var(--text-muted)] hover:text-[var(--accent)] hover:bg-[var(--surface-hover)] transition-colors"
+                    title="Open a local .md file"
+                  >
+                    <FolderInput size={14} />
+                  </button>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept=".md,.mdx,.markdown"
+                    onChange={handleLocalFileSelect}
+                    className="hidden"
+                  />
+                </div>
+              )}
               {repoFiles.map((file) => (
                 <FileTreeItem
                   key={file.id}

--- a/src/lib/app-context.tsx
+++ b/src/lib/app-context.tsx
@@ -58,6 +58,7 @@ interface AppState {
   createNewFile: () => void;
   addFileToPR: (pr: PullRequest) => void;
   openLocalFile: (name: string, content: string) => void;
+  isEmbedded: boolean;
 }
 
 const AppContext = createContext<AppState | null>(null);
@@ -65,7 +66,18 @@ const AppContext = createContext<AppState | null>(null);
 const TOKEN_KEY = "mardoc_github_token";
 const REPO_KEY = "mardoc_current_repo";
 
+// Module-level cache for VS Code init data — survives React Strict Mode remount
+let vsCodeInitData: Record<string, any> | null = null;
+
 export function AppProvider({ children }: { children: React.ReactNode }) {
+  // Embed mode — detected from URL query param, deferred to avoid hydration mismatch
+  const [isEmbedded, setIsEmbedded] = useState(false);
+  useEffect(() => {
+    if (new URLSearchParams(window.location.search).get("embed") === "true") {
+      setIsEmbedded(true);
+    }
+  }, []);
+
   // Auth state — server-safe defaults, hydrated in useEffect
   const [githubToken, setGithubTokenState] = useState<string | null>(null);
   const [isDemoMode, setIsDemoMode] = useState(true);
@@ -133,6 +145,62 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       initOctokit(savedToken);
     }
   }, []);
+
+  // Embed mode: listen for postMessage from VS Code extension
+  const pendingInitRef = useRef<{ owner: string; repo: string; branch: string; token: string } | null>(null);
+
+  const applyInitData = useCallback((data: Record<string, any>) => {
+    setIsEmbedded(true);
+
+    if (data.token) {
+      setGithubTokenState(data.token);
+      setIsDemoMode(false);
+      initOctokit(data.token);
+    }
+    if (data.owner && data.repo) {
+      pendingInitRef.current = data as any;
+    }
+
+    if (data.fileName && data.fileContent) {
+      const localFile: RepoFile = {
+        id: `local-${Date.now()}`,
+        name: data.fileName,
+        path: `__local__/${data.fileName}`,
+        type: "file" as const,
+      };
+      setSelectedFile(localFile);
+      setSelectedPR(null);
+      setCurrentView("editor");
+      setFileContent(data.fileContent);
+    }
+  }, []);
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      const data = event.data;
+      if (!data || data.type !== "init") return;
+
+      // Cache at module level so Strict Mode remount can replay
+      vsCodeInitData = data;
+      applyInitData(data);
+    };
+
+    window.addEventListener("message", handleMessage);
+
+    // On mount (or Strict Mode remount), replay cached init data if available
+    if (vsCodeInitData) {
+      applyInitData(vsCodeInitData);
+    }
+
+    // Signal to parent that we're ready to receive init
+    if (window.parent !== window) {
+      window.parent.postMessage({ type: "ready" }, "*");
+    }
+
+    return () => window.removeEventListener("message", handleMessage);
+  }, [isEmbedded]);
+
+
 
   // Set current repo and load data
   const setCurrentRepo = useCallback(
@@ -210,6 +278,14 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       loadPRs(currentRepo, state);
     }
   }, [currentRepo, loadPRs]);
+
+  // Embed mode: process pending init repo after token and setCurrentRepo are ready
+  useEffect(() => {
+    if (!pendingInitRef.current || !githubToken) return;
+    const { owner, repo } = pendingInitRef.current;
+    pendingInitRef.current = null;
+    setCurrentRepo(`${owner}/${repo}`);
+  }, [githubToken, setCurrentRepo]);
 
   // Auto-restore: hash route wins over localStorage
   useEffect(() => {
@@ -337,6 +413,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     setCurrentView("editor");
     setFileContent(content);
   }, []);
+
 
   // Open a PR and fetch its files + comments
   const openPR = useCallback(
@@ -495,6 +572,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         createNewFile,
         addFileToPR,
         openLocalFile,
+        isEmbedded,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- Adds `?embed=true` query param support for embedding MarDoc in VS Code WebView
- Hides file tree tab, settings button, and connect screen in embed mode
- Adds postMessage bridge to receive workspace context (repo, branch, token, file content) from the VS Code extension
- Feature doc: `docs/features/017-vscode-extension.md`

## Test plan
- [ ] Verify `http://localhost:3000/?embed=true` shows PRs tab, no file tree, no settings gear
- [ ] Verify `http://localhost:3000` (no param) works unchanged — full app with all tabs
- [ ] Test in VS Code extension: right-click .md → "Edit with MarDoc" renders the file
- [ ] Verify dark mode works in both embedded and standalone