### PR TITLE
feat: code view toggle for raw markdown editing

### DIFF
--- a/docs/features/019-code-view-toggle.md
+++ b/docs/features/019-code-view-toggle.md
@@ -1,0 +1,28 @@
+# 019: Code View Toggle
+
+## Value
+
+Users can switch between the WYSIWYG editor and a raw markdown/HTML source view. This is the escape hatch for anything the rich editor doesn't handle perfectly — HTML comments, complex table attributes, raw HTML blocks, or just verifying exactly what will be committed.
+
+## Acceptance Criteria
+
+- Toggle button in the editor toolbar switches between "Rich" and "Code" views
+- Code view shows the raw markdown source in a monospace textarea with syntax highlighting
+- Edits in code view are reflected when switching back to rich view (re-parsed through Showdown → TipTap)
+- Edits in rich view are reflected when switching to code view (converted via Turndown)
+- Save/commit uses whichever view is active — no conversion surprise
+- Toggle state is per-file, not global (switching files resets to rich view)
+- Code view textarea auto-sizes to content height
+
+## Dependencies
+
+None — TipTap already supports `getHTML()` / `setContent()`, and the Showdown/Turndown pipeline is in place.
+
+## Implementation Notes
+
+- Add a `codeView` boolean state to the Editor component
+- When toggling to code view: convert TipTap content via Turndown → show in a `<textarea>` or a simple code editor
+- When toggling back to rich view: parse the textarea content via Showdown → set TipTap content
+- The toggle button can use the existing toolbar pattern with a `Code` or `FileCode` icon from lucide-react
+- For save/commit in code view: use the textarea content directly as markdown (skip Turndown since it's already markdown)
+- Consider using the existing `CodeBlockLowlight` styling for the textarea to keep the look consistent

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -415,6 +415,11 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
   const [editFilePath, setEditFilePath] = useState("");
   const [newFileTitle, setNewFileTitle] = useState("");
 
+  // Code view toggle
+  const [codeView, setCodeView] = useState(false);
+  const [codeContent, setCodeContent] = useState("");
+  const codeTextareaRef = useRef<HTMLTextAreaElement>(null);
+
   // Dirty tracking for existing files
   const [isDirty, setIsDirty] = useState(false);
   const [showEditPRModal, setShowEditPRModal] = useState(false);
@@ -489,11 +494,28 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
     setSubmittedPR(null);
     setSubmitError(null);
     setIsDirty(false);
+    setCodeView(false);
+    setCodeContent("");
     setShowEditPRModal(false);
     setEditPRTitle("");
     return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filePath, editor]);
+
+  const toggleCodeView = useCallback(() => {
+    if (!editor) return;
+    if (!codeView) {
+      const turndown = createTurndownService();
+      const html = editor.getHTML();
+      const md = turndown.turndown(html);
+      setCodeContent(md);
+      setCodeView(true);
+    } else {
+      const html = showdownConverter.makeHtml(codeContent);
+      editor.commands.setContent(html);
+      setCodeView(false);
+    }
+  }, [editor, codeView, codeContent]);
 
   const addLink = useCallback(() => {
     if (!editor) return;
@@ -626,10 +648,15 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
     setSubmitError(null);
 
     try {
-      // Convert TipTap HTML to markdown
-      const turndown = createTurndownService();
-      const html = editor.getHTML();
-      const markdown = turndown.turndown(html);
+      // Use code view content directly, or convert TipTap HTML to markdown
+      let markdown: string;
+      if (codeView) {
+        markdown = codeContent;
+      } else {
+        const turndown = createTurndownService();
+        const html = editor.getHTML();
+        markdown = turndown.turndown(html);
+      }
 
       const path = newFilePath.endsWith(".md") ? newFilePath : `${newFilePath}.md`;
 
@@ -672,7 +699,7 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
     } finally {
       setSavingNewFile(false);
     }
-  }, [repoFullName, isDemoMode, editor, newFilePath, newFileTitle, prBranchForNewFile, prNumberForNewFile, pullRequests, openPR, refreshRepo]);
+  }, [repoFullName, isDemoMode, editor, newFilePath, newFileTitle, prBranchForNewFile, prNumberForNewFile, pullRequests, openPR, codeView, codeContent, refreshRepo]);
 
   const handleSubmitEditsAsPR = useCallback(async () => {
     if (!repoFullName || isDemoMode || !editor || !editPRTitle.trim()) return;
@@ -684,9 +711,14 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
     setSubmitError(null);
 
     try {
-      const turndown = createTurndownService();
-      const html = editor.getHTML();
-      const markdown = turndown.turndown(html);
+      let markdown: string;
+      if (codeView) {
+        markdown = codeContent;
+      } else {
+        const turndown = createTurndownService();
+        const html = editor.getHTML();
+        markdown = turndown.turndown(html);
+      }
 
       const path = commitPath.endsWith(".md") ? commitPath : `${commitPath}.md`;
       const pr = await createFileAsPR(
@@ -705,7 +737,7 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
     } finally {
       setSubmittingPR(false);
     }
-  }, [repoFullName, isDemoMode, editor, filePath, isLocalFile, editFilePath, editPRTitle, refreshRepo]);
+  }, [repoFullName, isDemoMode, editor, filePath, isLocalFile, editFilePath, editPRTitle, codeView, codeContent, refreshRepo]);
 
   // Link click handler — intercept clicks on <a> tags in the editor
   const handleLinkClick = useCallback((e: React.MouseEvent) => {
@@ -758,6 +790,7 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
       <div className="flex-1 flex flex-col min-w-0">
         {/* Toolbar */}
         <div className="sticky top-0 z-10 bg-[var(--surface)] border-b border-[var(--border)] px-3 py-1.5 flex items-center gap-0.5 flex-wrap">
+          {!codeView && (<>
           <ToolbarButton
             onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
             isActive={editor.isActive("heading", { level: 1 })}
@@ -869,6 +902,7 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
             title="Redo (⌘⇧Z)"
           />
 
+          </>)}
           {/* Wide format + comment toggle + submit PR — right side */}
           <div className="ml-auto flex items-center gap-1">
             {/* Save new file as PR */}
@@ -923,6 +957,13 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
             {submitError && (
               <span className="text-xs text-red-500 px-2">{submitError}</span>
             )}
+            <button
+              onClick={toggleCodeView}
+              className={`toolbar-btn ${codeView ? "active" : ""}`}
+              title={codeView ? "Rich view" : "Code view"}
+            >
+              <FileCode size={15} />
+            </button>
             <button
               onClick={toggleWide}
               className={`toolbar-btn ${wide ? "active" : ""}`}
@@ -992,7 +1033,17 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
               onComment={handleStartComment}
             />
 
-            <EditorContent editor={editor} />
+            {codeView ? (
+              <textarea
+                ref={codeTextareaRef}
+                value={codeContent}
+                onChange={(e) => { setCodeContent(e.target.value); setIsDirty(true); }}
+                className="w-full min-h-[60vh] p-4 font-mono text-sm leading-relaxed bg-[var(--surface-secondary)] text-[var(--text-primary)] border border-[var(--border)] rounded-lg resize-y focus:outline-none focus:border-[var(--accent)]"
+                spellCheck={false}
+              />
+            ) : (
+              <EditorContent editor={editor} />
+            )}
 
             {/* Pending comment input — inline below selection */}
             {pendingSelection && (


### PR DESCRIPTION
## Summary
- Toggle button (FileCode icon) in toolbar switches between WYSIWYG and raw markdown views
- Code view shows a monospace textarea with the markdown source
- Formatting toolbar hides in code view — only toggle, save, wide format, and comments remain
- Save/commit uses the raw textarea content directly when in code view
- Resets to rich view on file switch
- Feature doc: `docs/features/019-code-view-toggle.md`

## Test plan
- [ ] Toggle to code view — verify markdown source appears
- [ ] Edit in code view, toggle back — verify changes reflected in rich view
- [ ] Edit in code view, submit as PR — verify committed content matches textarea
- [ ] Switch files — verify code view resets to rich view
- [ ] Verify formatting toolbar hidden in code view, visible in rich view