### PR TITLE
fix: code view keyboard shortcuts captured by TipTap

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -701,6 +701,7 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
     setIsDirty(false);
     setCodeView(false);
     setCodeContent("");
+    if (editor) editor.setEditable(true);
     setShowEditPRModal(false);
     setEditPRTitle("");
     setBubbleTarget(null);
@@ -716,10 +717,12 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
       const md = turndown.turndown(html);
       setCodeContent(md);
       setCodeView(true);
+      editor.setEditable(false);
     } else {
       const html = showdownConverter.makeHtml(codeContent);
       editor.commands.setContent(html);
       setCodeView(false);
+      editor.setEditable(true);
     }
   }, [editor, codeView, codeContent]);
 


### PR DESCRIPTION
## Summary

- Disable TipTap's editability when switching to code view so Cmd+B/I/E/K reach the textarea's `onKeyDown` handler
- Re-enable editability when switching back to rich view or changing files

## Test plan

- [ ] Switch to code view, select text, press Cmd+B — wraps with `**`
- [ ] Cmd+I, Cmd+E, Cmd+K all work in code view
- [ ] Switch back to rich view — Cmd+B toggles bold as before
- [ ] Change files while in code view — editor returns to rich view, shortcuts work