### PR TITLE
fix: dirty tracking compares to original content

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -624,8 +624,10 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
   const [codeContent, setCodeContent] = useState("");
   const codeTextareaRef = useRef<HTMLTextAreaElement>(null);
 
-  // Dirty tracking for existing files
+  // Dirty tracking for existing files — compare current markdown to original
   const [isDirty, setIsDirty] = useState(false);
+  const originalMarkdownRef = useRef<string | null>(null);
+  const dirtyCheckTimer = useRef<ReturnType<typeof setTimeout>>();
   const [showEditPRModal, setShowEditPRModal] = useState(false);
   const [editPRTitle, setEditPRTitle] = useState("");
   const [showNewFileModal, setShowNewFileModal] = useState(false);
@@ -662,7 +664,15 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
     content: markdownToHtml(content, repoFullName, branch, filePath),
     onUpdate: ({ editor }) => {
       onContentChange?.(editor.getHTML());
-      if (!isNewFile) setIsDirty(true);
+      if (!isNewFile && originalMarkdownRef.current !== null) {
+        // Debounce the Turndown comparison to avoid running on every keystroke
+        if (dirtyCheckTimer.current) clearTimeout(dirtyCheckTimer.current);
+        dirtyCheckTimer.current = setTimeout(() => {
+          const turndown = createTurndownService();
+          const currentMd = turndown.turndown(editor.getHTML());
+          setIsDirty(currentMd !== originalMarkdownRef.current);
+        }, 300);
+      }
     },
     editorProps: {
       attributes: {
@@ -681,6 +691,9 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
         preRenderMermaid(rawHtml).then((html) => {
           if (cancelled) return;
           editor.commands.setContent(html);
+          // Capture baseline markdown for dirty comparison
+          const turndown = createTurndownService();
+          originalMarkdownRef.current = turndown.turndown(editor.getHTML());
           // Fetch private repo images after TipTap renders
           setTimeout(() => {
             if (!cancelled && editorContainerRef.current) {
@@ -753,7 +766,7 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
     const replacement = `${prefix}${selected}${s}`;
     const newContent = codeContent.slice(0, start) + replacement + codeContent.slice(end);
     setCodeContent(newContent);
-    setIsDirty(true);
+    setIsDirty(newContent !== originalMarkdownRef.current);
     // Restore cursor position after React re-renders
     requestAnimationFrame(() => {
       textarea.focus();
@@ -1336,7 +1349,7 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
               <textarea
                 ref={codeTextareaRef}
                 value={codeContent}
-                onChange={(e) => { setCodeContent(e.target.value); setIsDirty(true); }}
+                onChange={(e) => { setCodeContent(e.target.value); setIsDirty(e.target.value !== originalMarkdownRef.current); }}
                 onKeyDown={handleCodeViewKeyDown}
                 className="w-full min-h-[60vh] p-4 font-mono text-sm leading-relaxed bg-[var(--surface-secondary)] text-[var(--text-primary)] border border-[var(--border)] rounded-lg resize-y focus:outline-none focus:border-[var(--accent)]"
                 spellCheck={false}

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -701,6 +701,7 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
     setIsDirty(false);
     setCodeView(false);
     setCodeContent("");
+    if (editor) editor.setEditable(true);
     setShowEditPRModal(false);
     setEditPRTitle("");
     setBubbleTarget(null);
@@ -716,10 +717,12 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
       const md = turndown.turndown(html);
       setCodeContent(md);
       setCodeView(true);
+      editor.setEditable(false);
     } else {
       const html = showdownConverter.makeHtml(codeContent);
       editor.commands.setContent(html);
       setCodeView(false);
+      editor.setEditable(true);
     }
   }, [editor, codeView, codeContent]);
 


### PR DESCRIPTION
## Summary

- `isDirty` now compares current markdown against the baseline captured after initial render, instead of setting `true` on any change
- Reverting edits clears the flag and hides "Submit Edits as PR"
- Rich view comparison debounced at 300ms to avoid Turndown on every keystroke
- Code view textarea and `wrapSelection` also compare against original

## Test plan

- [ ] Open a file — "Submit Edits as PR" does not appear
- [ ] Make an edit — button appears
- [ ] Undo the edit (Cmd+Z) — button disappears
- [ ] In code view: type something, delete it back — button disappears
- [ ] Formatting shortcuts in code view update dirty state correctly