### PR TITLE
fix: critical — URL decoding, VS Code compat, localStorage safety

### DIFF
--- a/src/__tests__/hash-router.test.ts
+++ b/src/__tests__/hash-router.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { parseHash, buildFileHash, buildPRHash, buildRepoHash } from "@/lib/hash-router";
+
+describe("parseHash", () => {
+  // ─── Basic routes ───────────────────────────────────────────────────
+
+  it("returns none for empty hash", () => {
+    expect(parseHash("")).toEqual({ type: "none" });
+    expect(parseHash("#")).toEqual({ type: "none" });
+    expect(parseHash("#/")).toEqual({ type: "none" });
+  });
+
+  it("returns none for single segment", () => {
+    expect(parseHash("#/owner")).toEqual({ type: "none" });
+  });
+
+  it("parses repo route", () => {
+    expect(parseHash("#/acme/widgets")).toEqual({
+      type: "repo",
+      owner: "acme",
+      repo: "widgets",
+      repoFullName: "acme/widgets",
+    });
+  });
+
+  it("parses file route", () => {
+    expect(parseHash("#/acme/widgets/blob/main/docs/readme.md")).toEqual({
+      type: "file",
+      owner: "acme",
+      repo: "widgets",
+      repoFullName: "acme/widgets",
+      branch: "main",
+      filePath: "docs/readme.md",
+    });
+  });
+
+  it("parses PR route", () => {
+    expect(parseHash("#/acme/widgets/pull/42")).toEqual({
+      type: "pr",
+      owner: "acme",
+      repo: "widgets",
+      repoFullName: "acme/widgets",
+      prNumber: 42,
+    });
+  });
+
+  it("parses PR file route", () => {
+    expect(parseHash("#/acme/widgets/pull/42/files/3")).toEqual({
+      type: "pr",
+      owner: "acme",
+      repo: "widgets",
+      repoFullName: "acme/widgets",
+      prNumber: 42,
+      prFileIdx: 3,
+    });
+  });
+
+  // ─── URL decoding ──────────────────────────────────────────────────
+
+  it("decodes URL-encoded file paths", () => {
+    const route = parseHash("#/acme/widgets/blob/main/docs/my%20file.md");
+    expect(route.filePath).toBe("docs/my file.md");
+  });
+
+  it("decodes URL-encoded branch names", () => {
+    const route = parseHash("#/acme/widgets/blob/feature%2Fnew-thing/readme.md");
+    expect(route.branch).toBe("feature/new-thing");
+  });
+
+  it("decodes unicode in file paths", () => {
+    const route = parseHash("#/acme/widgets/blob/main/docs/%E4%B8%AD%E6%96%87.md");
+    expect(route.filePath).toBe("docs/中文.md");
+  });
+
+  it("handles already-decoded paths (no double decoding)", () => {
+    const route = parseHash("#/acme/widgets/blob/main/docs/normal-file.md");
+    expect(route.filePath).toBe("docs/normal-file.md");
+  });
+
+  // ─── Malformed routes ──────────────────────────────────────────────
+
+  it("falls back to repo for non-numeric PR number", () => {
+    const route = parseHash("#/acme/widgets/pull/abc");
+    expect(route.type).toBe("repo");
+  });
+
+  it("falls back to repo for non-numeric file index", () => {
+    const route = parseHash("#/acme/widgets/pull/42/files/abc");
+    // Non-numeric fileIdx fails the isNaN check, falls through to PR route
+    expect(route.type).toBe("pr");
+    expect(route.prNumber).toBe(42);
+    expect(route.prFileIdx).toBeUndefined();
+  });
+});
+
+describe("buildFileHash", () => {
+  it("builds a file hash", () => {
+    expect(buildFileHash("acme/widgets", "main", "docs/readme.md"))
+      .toBe("#/acme/widgets/blob/main/docs/readme.md");
+  });
+});
+
+describe("buildPRHash", () => {
+  it("builds a PR hash without file index", () => {
+    expect(buildPRHash("acme/widgets", 42)).toBe("#/acme/widgets/pull/42");
+  });
+
+  it("builds a PR hash with file index", () => {
+    expect(buildPRHash("acme/widgets", 42, 3)).toBe("#/acme/widgets/pull/42/files/3");
+  });
+
+  it("omits file index when 0", () => {
+    expect(buildPRHash("acme/widgets", 42, 0)).toBe("#/acme/widgets/pull/42");
+  });
+});
+
+describe("buildRepoHash", () => {
+  it("builds a repo hash", () => {
+    expect(buildRepoHash("acme/widgets")).toBe("#/acme/widgets");
+  });
+});

--- a/src/__tests__/open-external.test.ts
+++ b/src/__tests__/open-external.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { openExternal } from "@/lib/open-external";
+
+describe("openExternal", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses window.open in browser mode", () => {
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    openExternal("https://example.com", false);
+    expect(openSpy).toHaveBeenCalledWith("https://example.com", "_blank", "noopener,noreferrer");
+  });
+
+  it("posts message to parent in embed mode", () => {
+    const postSpy = vi.spyOn(window.parent, "postMessage").mockImplementation(() => {});
+    openExternal("https://example.com", true);
+    expect(postSpy).toHaveBeenCalledWith(
+      { type: "open-external", url: "https://example.com" },
+      "*"
+    );
+  });
+
+  it("does not use window.open in embed mode", () => {
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    vi.spyOn(window.parent, "postMessage").mockImplementation(() => {});
+    openExternal("https://example.com", true);
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/safe-storage.test.ts
+++ b/src/__tests__/safe-storage.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getItem, setItem, removeItem } from "@/lib/safe-storage";
+
+describe("safe-storage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ─── Normal operation ──────────────────────────────────────────────
+
+  it("getItem returns stored value", () => {
+    localStorage.setItem("key", "value");
+    expect(getItem("key")).toBe("value");
+  });
+
+  it("getItem returns null for missing key", () => {
+    expect(getItem("missing")).toBeNull();
+  });
+
+  it("setItem stores a value", () => {
+    setItem("key", "value");
+    expect(localStorage.getItem("key")).toBe("value");
+  });
+
+  it("removeItem removes a value", () => {
+    localStorage.setItem("key", "value");
+    removeItem("key");
+    expect(localStorage.getItem("key")).toBeNull();
+  });
+
+  // ─── Error handling (private browsing / restricted contexts) ───────
+
+  it("getItem returns null when localStorage throws", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new DOMException("access denied", "SecurityError");
+    });
+    expect(getItem("key")).toBeNull();
+  });
+
+  it("setItem is a no-op when localStorage throws", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("quota exceeded", "QuotaExceededError");
+    });
+    // Should not throw
+    expect(() => setItem("key", "value")).not.toThrow();
+  });
+
+  it("removeItem is a no-op when localStorage throws", () => {
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new DOMException("access denied", "SecurityError");
+    });
+    expect(() => removeItem("key")).not.toThrow();
+  });
+});

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -36,6 +36,8 @@ import {
 import ContextMenu from "./ContextMenu";
 import { mapSelectionToLines, rewriteImageUrls, loadAuthenticatedImages } from "@/lib/github-api";
 import { classifyLink } from "@/lib/link-handler";
+import { useApp } from "@/lib/app-context";
+import { openExternal } from "@/lib/open-external";
 import { renderMermaidBlocks } from "@/lib/mermaid";
 import { highlightCodeBlocks } from "@/lib/highlight";
 import { useWideFormat } from "@/lib/use-wide-format";
@@ -720,6 +722,7 @@ export default function DiffViewer({
   const [viewMode, setViewMode] = useState<"rendered" | "split" | "suggest" | "preview">("rendered");
   const [showPanel, setShowPanel] = useState(true);
   const { wide, toggle: toggleWide } = useWideFormat();
+  const { isEmbedded } = useApp();
 
   // Single source of truth: comments prop from PRDetail (no local duplicate)
   const [activeCommentId, setActiveCommentId] = useState<string | null>(null);
@@ -1056,7 +1059,7 @@ export default function DiffViewer({
             el.scrollIntoView({ behavior: "smooth", block: "start" });
           }
         } else if (type === "external") {
-          window.open(href, "_blank", "noopener,noreferrer");
+          openExternal(href, isEmbedded);
         }
         // Relative links don't apply in diff view — ignore
         return;

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -23,6 +23,7 @@ const lowlight = createLowlight(common);
 import { rewriteImageUrls, loadAuthenticatedImages, createReviewPR, createInlineComment, mapSelectionToLines, fetchFileContent, createFileAsPR, commitFileToPRBranch } from "@/lib/github-api";
 import { classifyLink, resolvePath, findFileByPath } from "@/lib/link-handler";
 import { useApp } from "@/lib/app-context";
+import { openExternal } from "@/lib/open-external";
 import { preRenderMermaid } from "@/lib/mermaid";
 import { useWideFormat } from "@/lib/use-wide-format";
 import {
@@ -600,7 +601,7 @@ function CommentSidePanel({
 
 export default function Editor({ content, onContentChange, filePath, repoFullName, branch }: EditorProps) {
   const editorContainerRef = useRef<HTMLDivElement>(null);
-  const { isDemoMode, refreshRepo, prBranchForNewFile, prNumberForNewFile, openPR, pullRequests, repoFiles, openFile } = useApp();
+  const { isDemoMode, isEmbedded, refreshRepo, prBranchForNewFile, prNumberForNewFile, openPR, pullRequests, repoFiles, openFile } = useApp();
   const { wide, toggle: toggleWide, contentClass } = useWideFormat();
   const [comments, setComments] = useState<EditorComment[]>([]);
   const [showComments, setShowComments] = useState(false);
@@ -1076,9 +1077,9 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
         }
       }
     } else {
-      window.open(href, "_blank", "noopener,noreferrer");
+      openExternal(href, isEmbedded);
     }
-  }, [filePath, repoFiles, openFile]);
+  }, [filePath, repoFiles, openFile, isEmbedded]);
 
   if (!editor) return null;
 

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useMemo } from "react";
 import { Settings, X, Github, LogIn, LogOut, RefreshCw, Lock, Globe, Search } from "lucide-react";
 import { useApp } from "@/lib/app-context";
 import { fetchUserRepos } from "@/lib/github-api";
+import * as safeStorage from "@/lib/safe-storage";
 
 interface SettingsPanelProps {
   isOpen: boolean;
@@ -46,7 +47,7 @@ export default function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
   useEffect(() => {
     if (isAuthenticated && isOpen) {
       // Show cached repos instantly
-      const cached = localStorage.getItem("mardoc_user_repos");
+      const cached = safeStorage.getItem("mardoc_user_repos");
       if (cached) {
         try {
           setUserRepos(JSON.parse(cached));
@@ -58,7 +59,7 @@ export default function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
       fetchUserRepos()
         .then((repos) => {
           setUserRepos(repos);
-          localStorage.setItem("mardoc_user_repos", JSON.stringify(repos));
+          safeStorage.setItem("mardoc_user_repos", JSON.stringify(repos));
         })
         .catch(console.error)
         .finally(() => setLoadingRepos(false));
@@ -76,7 +77,7 @@ export default function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
     setGithubToken(null);
     setTokenInput("");
     setUserRepos([]);
-    localStorage.removeItem("mardoc_user_repos");
+    safeStorage.removeItem("mardoc_user_repos");
     setActiveTab("connect");
   };
 
@@ -258,7 +259,7 @@ export default function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
                         fetchUserRepos()
                           .then((repos) => {
                             setUserRepos(repos);
-                            localStorage.setItem("mardoc_user_repos", JSON.stringify(repos));
+                            safeStorage.setItem("mardoc_user_repos", JSON.stringify(repos));
                           })
                           .catch(console.error)
                           .finally(() => setLoadingRepos(false));

--- a/src/lib/app-context.tsx
+++ b/src/lib/app-context.tsx
@@ -5,6 +5,7 @@ import { RepoFile, PullRequest, PRFile, PRComment, ViewMode } from "@/types";
 import { initOctokit, fetchRepoTree, fetchPullRequests, fetchFileContent, fetchPRFiles, fetchPRComments, fetchDefaultBranch, fetchBranches, fetchPRMarkdownCounts } from "./github-api";
 import { repoFiles as mockFiles, pullRequests as mockPRs, findFile, flattenFiles } from "./mock-data";
 import { parseHash, buildFileHash, buildPRHash, buildRepoHash } from "./hash-router";
+import * as safeStorage from "./safe-storage";
 
 interface AppState {
   // Auth
@@ -124,12 +125,12 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const setGithubToken = useCallback((token: string | null) => {
     setGithubTokenState(token);
     if (token) {
-      localStorage.setItem(TOKEN_KEY, token);
+      safeStorage.setItem(TOKEN_KEY, token);
       initOctokit(token);
       setIsDemoMode(false);
     } else {
-      localStorage.removeItem(TOKEN_KEY);
-      localStorage.removeItem(REPO_KEY);
+      safeStorage.removeItem(TOKEN_KEY);
+      safeStorage.removeItem(REPO_KEY);
       setIsDemoMode(true);
       setRepoFiles(mockFiles);
       setPRList(mockPRs);
@@ -138,7 +139,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 
   // Hydrate auth state from localStorage after mount (avoids SSR mismatch)
   useEffect(() => {
-    const savedToken = localStorage.getItem(TOKEN_KEY);
+    const savedToken = safeStorage.getItem(TOKEN_KEY);
     if (savedToken) {
       setGithubTokenState(savedToken);
       setIsDemoMode(false);
@@ -207,7 +208,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const setCurrentRepo = useCallback(
     async (repo: string) => {
       setCurrentRepoState(repo);
-      localStorage.setItem(REPO_KEY, repo);
+      safeStorage.setItem(REPO_KEY, repo);
       setError(null);
       setHash(buildRepoHash(repo));
 
@@ -298,7 +299,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       return;
     }
 
-    const savedRepo = localStorage.getItem(REPO_KEY);
+    const savedRepo = safeStorage.getItem(REPO_KEY);
     if (savedRepo) {
       setCurrentRepo(savedRepo);
     }

--- a/src/lib/hash-router.ts
+++ b/src/lib/hash-router.ts
@@ -33,8 +33,8 @@ export function parseHash(hash: string): HashRoute {
 
   // /{owner}/{repo}/blob/{branch}/{path...}
   if (parts[2] === "blob" && parts.length >= 5) {
-    const branch = parts[3];
-    const filePath = parts.slice(4).join("/");
+    const branch = decodeURIComponent(parts[3]);
+    const filePath = parts.slice(4).map(decodeURIComponent).join("/");
     return { type: "file", owner, repo, repoFullName, branch, filePath };
   }
 

--- a/src/lib/open-external.ts
+++ b/src/lib/open-external.ts
@@ -1,0 +1,12 @@
+/**
+ * Open an external URL. In VS Code WebView, posts a message to the
+ * extension host. In a normal browser, uses window.open.
+ */
+export function openExternal(href: string, isEmbedded: boolean): void {
+  if (isEmbedded) {
+    // VS Code WebView blocks window.open — ask the extension to open it
+    window.parent.postMessage({ type: "open-external", url: href }, "*");
+  } else {
+    window.open(href, "_blank", "noopener,noreferrer");
+  }
+}

--- a/src/lib/safe-storage.ts
+++ b/src/lib/safe-storage.ts
@@ -1,0 +1,28 @@
+/**
+ * Safe localStorage wrapper. Returns null / no-ops when localStorage
+ * is unavailable (private browsing, restricted contexts, quota exceeded).
+ */
+
+export function getItem(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function setItem(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // Quota exceeded or access denied — silently ignore
+  }
+}
+
+export function removeItem(key: string): void {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    // Access denied — silently ignore
+  }
+}

--- a/src/lib/theme-context.tsx
+++ b/src/lib/theme-context.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { createContext, useContext, useEffect, useState, useCallback } from "react";
+import * as safeStorage from "./safe-storage";
 
 type Theme = "light" | "dark";
 
@@ -20,7 +21,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     setMounted(true);
-    const stored = localStorage.getItem("theme") as Theme | null;
+    const stored = safeStorage.getItem("theme") as Theme | null;
     if (stored) {
       setTheme(stored);
     } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
@@ -31,7 +32,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (mounted) {
       document.documentElement.classList.toggle("dark", theme === "dark");
-      localStorage.setItem("theme", theme);
+      safeStorage.setItem("theme", theme);
     }
   }, [theme, mounted]);
 

--- a/src/lib/use-wide-format.ts
+++ b/src/lib/use-wide-format.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import * as safeStorage from "./safe-storage";
 
 const STORAGE_KEY = "mardoc_wide_format";
 
@@ -9,12 +10,12 @@ export function useWideFormat() {
 
   // Hydrate from localStorage after mount
   useEffect(() => {
-    setWideState(localStorage.getItem(STORAGE_KEY) === "true");
+    setWideState(safeStorage.getItem(STORAGE_KEY) === "true");
   }, []);
 
   const setWide = useCallback((value: boolean) => {
     setWideState(value);
-    localStorage.setItem(STORAGE_KEY, String(value));
+    safeStorage.setItem(STORAGE_KEY, String(value));
   }, []);
 
   const toggle = useCallback(() => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
     },
   },
   test: {
-    environment: "node",
+    environment: "jsdom",
   },
 });


### PR DESCRIPTION
## Summary

- **021 — Hash router URL decoding**: `decodeURIComponent` on file paths and branch names so files with spaces, unicode, or encoded slashes resolve correctly via deep links
- **020 — VS Code WebView compat**: Replace `window.open` (silently fails in WebView) with `openExternal` helper that posts a message to the extension host in embed mode. Covers Editor.tsx and DiffViewer.tsx
- **023 — localStorage safety**: Extract `safe-storage` module wrapping all `localStorage` calls in try-catch. App no longer crashes in private browsing or restricted contexts. Replaced 14 raw calls across 4 files

## Test plan

27 new automated tests:
- [x] 17 hash router tests (URL decoding, basic routes, malformed routes, build helpers)
- [x] 3 openExternal tests (browser mode, embed mode, no window.open in embed)
- [x] 7 safe-storage tests (normal CRUD, SecurityError, QuotaExceededError)

Manual:
- [ ] Deep link to a file with spaces in the path
- [ ] Open external link from editor in VS Code embed mode
- [ ] Open app in private/incognito — no crashes, demo mode works