### PR TITLE
fix: mermaid source preserved through HTML round-trip

### DIFF
--- a/src/__tests__/mermaid-roundtrip.test.ts
+++ b/src/__tests__/mermaid-roundtrip.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Mermaid round-trip tests.
+ *
+ * Verifies that mermaid diagram source is preserved through the
+ * HTML → Turndown pipeline via the data-mermaid-source attribute.
+ */
+import { describe, it, expect } from "vitest";
+import { createTurndownService } from "@/lib/turndown";
+
+describe("mermaid round-trip via Turndown", () => {
+  it("restores fenced mermaid block from img with data-mermaid-source", () => {
+    const turndown = createTurndownService();
+    const html = '<img src="blob:https://mardoc.app/abc123" alt="Mermaid diagram" data-mermaid-source="graph TD\nA --> B\nB --> C">';
+    const md = turndown.turndown(html);
+    expect(md).toContain("```mermaid");
+    expect(md).toContain("graph TD");
+    expect(md).toContain("A --> B");
+    expect(md).toContain("B --> C");
+    expect(md).toContain("```");
+  });
+
+  it("does not affect regular images without data-mermaid-source", () => {
+    const turndown = createTurndownService();
+    const html = '<img src="https://example.com/image.png" alt="photo">';
+    const md = turndown.turndown(html);
+    expect(md).toContain("![photo]");
+    expect(md).toContain("https://example.com/image.png");
+    expect(md).not.toContain("```mermaid");
+  });
+
+  it("preserves complex mermaid syntax (sequenceDiagram)", () => {
+    const source = "sequenceDiagram\n    Alice->>Bob: Hello\n    Bob-->>Alice: Hi back";
+    const turndown = createTurndownService();
+    const html = `<img src="blob:x" alt="Mermaid diagram" data-mermaid-source="${source.replace(/"/g, "&quot;")}">`;
+    const md = turndown.turndown(html);
+    expect(md).toContain("```mermaid");
+    expect(md).toContain("sequenceDiagram");
+    expect(md).toContain("Alice->>Bob: Hello");
+    expect(md).toContain("```");
+  });
+
+  it("preserves mermaid source with special characters", () => {
+    const source = "graph TD\n    A[\"Start\"] --> B{Decision}\n    B -->|Yes| C[End]";
+    const turndown = createTurndownService();
+    const html = `<img src="blob:x" alt="Mermaid diagram" data-mermaid-source="${source.replace(/"/g, "&quot;")}">`;
+    const md = turndown.turndown(html);
+    expect(md).toContain("```mermaid");
+    expect(md).toContain("graph TD");
+    expect(md).toContain("Decision");
+  });
+
+  it("handles multiple mermaid diagrams in one document", () => {
+    const turndown = createTurndownService();
+    const html = `
+      <p>First diagram:</p>
+      <img src="blob:a" alt="Mermaid diagram" data-mermaid-source="graph LR\nA --> B">
+      <p>Second diagram:</p>
+      <img src="blob:b" alt="Mermaid diagram" data-mermaid-source="pie\n&quot;A&quot; : 40\n&quot;B&quot; : 60">
+    `;
+    const md = turndown.turndown(html);
+    const fences = md.match(/```mermaid/g);
+    expect(fences).toHaveLength(2);
+    expect(md).toContain("graph LR");
+    expect(md).toContain("pie");
+  });
+});

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -724,7 +724,7 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filePath, editor]);
 
-  const toggleCodeView = useCallback(() => {
+  const toggleCodeView = useCallback(async () => {
     if (!editor) return;
     if (!codeView) {
       const turndown = createTurndownService();
@@ -734,7 +734,8 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
       setCodeView(true);
       editor.setEditable(false);
     } else {
-      const html = showdownConverter.makeHtml(codeContent);
+      const rawHtml = showdownConverter.makeHtml(codeContent);
+      const html = await preRenderMermaid(rawHtml);
       editor.commands.setContent(html);
       setCodeView(false);
       editor.setEditable(true);

--- a/src/lib/mermaid.ts
+++ b/src/lib/mermaid.ts
@@ -55,6 +55,7 @@ export async function preRenderMermaid(html: string): Promise<string> {
       const img = document.createElement("img");
       img.src = blobUrl;
       img.alt = "Mermaid diagram";
+      img.setAttribute("data-mermaid-source", source);
       pre.replaceWith(img);
     } catch (err) {
       console.warn("Mermaid render failed:", err);

--- a/src/lib/turndown.ts
+++ b/src/lib/turndown.ts
@@ -35,6 +35,17 @@ export function createTurndownService(): TurndownService {
     "dd",
   ]);
 
+  // Mermaid diagrams — restore fenced code blocks from rendered <img> tags
+  turndown.addRule("mermaidDiagram", {
+    filter: (node) => {
+      return node.nodeName === "IMG" && node.hasAttribute("data-mermaid-source");
+    },
+    replacement: (_content, node) => {
+      const source = (node as HTMLElement).getAttribute("data-mermaid-source") || "";
+      return `\n\n\`\`\`mermaid\n${source}\n\`\`\`\n\n`;
+    },
+  });
+
   // Preserve div and span with attributes (class, style, id)
   turndown.addRule("divWithAttributes", {
     filter: (node) => {


### PR DESCRIPTION
## Summary

- Store original mermaid source in `data-mermaid-source` attribute on rendered `<img>` tags
- Turndown rule restores fenced ` ```mermaid ` code blocks from that attribute
- Code view now shows actual mermaid source instead of `![Mermaid diagram](blob:...)`
- `toggleCodeView` runs `preRenderMermaid()` when switching back to rich view so edited diagrams render

## Test plan

5 new automated tests:
- [x] Restores fenced block from img with data-mermaid-source
- [x] Regular images unaffected
- [x] Complex syntax (sequenceDiagram) preserved
- [x] Special characters in source preserved
- [x] Multiple diagrams in one document

Manual:
- [ ] Open file with mermaid block → toggle code view → see fenced source, not blob URL
- [ ] Edit mermaid in code view → toggle back → diagram re-renders
- [ ] Commit a file with mermaid blocks → verify clean markdown output