### PR TITLE
fix: image round-trip, PR description display, bubble robustness

### DIFF
--- a/src/__tests__/image-roundtrip.test.ts
+++ b/src/__tests__/image-roundtrip.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Image round-trip tests.
+ *
+ * Verifies that images with data-original-src preserve their
+ * original URL through the Turndown pipeline instead of outputting
+ * data: or blob: URIs.
+ */
+import { describe, it, expect } from "vitest";
+import { createTurndownService } from "@/lib/turndown";
+
+describe("image round-trip via Turndown", () => {
+  it("restores original src from data-original-src attribute", () => {
+    const turndown = createTurndownService();
+    const html = '<img src="data:image/png;base64,abc123" alt="diagram" data-original-src="https://raw.githubusercontent.com/acme/repo/main/docs/diagram.png">';
+    const md = turndown.turndown(html);
+    expect(md).toBe("![diagram](https://raw.githubusercontent.com/acme/repo/main/docs/diagram.png)");
+  });
+
+  it("does not affect images without data-original-src", () => {
+    const turndown = createTurndownService();
+    const html = '<img src="https://example.com/photo.jpg" alt="photo">';
+    const md = turndown.turndown(html);
+    expect(md).toContain("![photo]");
+    expect(md).toContain("https://example.com/photo.jpg");
+  });
+
+  it("preserves alt text", () => {
+    const turndown = createTurndownService();
+    const html = '<img src="data:image/png;base64,x" alt="Architecture overview" data-original-src="./images/arch.png">';
+    const md = turndown.turndown(html);
+    expect(md).toBe("![Architecture overview](./images/arch.png)");
+  });
+
+  it("handles empty alt text", () => {
+    const turndown = createTurndownService();
+    const html = '<img src="data:image/png;base64,x" alt="" data-original-src="image.png">';
+    const md = turndown.turndown(html);
+    expect(md).toBe("![](image.png)");
+  });
+
+  it("prefers data-original-src over data: URI", () => {
+    const turndown = createTurndownService();
+    // Even with a very long base64 src, the original URL is used
+    const longBase64 = "data:image/png;base64," + "A".repeat(1000);
+    const html = `<img src="${longBase64}" alt="img" data-original-src="docs/small.png">`;
+    const md = turndown.turndown(html);
+    expect(md).toBe("![img](docs/small.png)");
+    expect(md).not.toContain("base64");
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -100,9 +100,7 @@ export default function Home() {
                 filePath={selectedFile.path}
                 repoFullName={currentRepo || undefined}
                 branch={selectedBranch}
-                onContentChange={(html) => {
-                  console.log("Content changed");
-                }}
+                onContentChange={() => {}}
               />
             )
           ) : currentView === "pr-diff" && selectedPR ? (
@@ -124,9 +122,7 @@ export default function Home() {
             )
           ) : currentView === "pr-review" ? (
             <PRReview
-              onCreatePR={(title, description, filePath) => {
-                console.log("Creating review PR:", { title, description, filePath });
-              }}
+              onCreatePR={() => {}}
             />
           ) : (
             /* Welcome screen */

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -275,10 +275,19 @@ function LinkImageBubble({
   const container = containerRef.current;
   if (!container) return null;
 
+  // Dismiss if the target element was removed from the DOM (stale ref)
+  if (!document.contains(target.element)) {
+    // Can't call onDismiss during render — schedule it
+    requestAnimationFrame(onDismiss);
+    return null;
+  }
+
   const rect = target.element.getBoundingClientRect();
   const containerRect = container.getBoundingClientRect();
+  const bubbleWidth = 280;
   const top = rect.bottom - containerRect.top + 6;
-  const left = Math.max(0, rect.left - containerRect.left + rect.width / 2 - 140);
+  const rawLeft = rect.left - containerRect.left + rect.width / 2 - bubbleWidth / 2;
+  const left = Math.max(0, Math.min(rawLeft, containerRect.width - bubbleWidth));
 
   const startEdit = () => {
     setEditUrl(target.href);
@@ -734,13 +743,22 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
       setCodeView(true);
       editor.setEditable(false);
     } else {
-      const rawHtml = showdownConverter.makeHtml(codeContent);
+      let rawHtml = showdownConverter.makeHtml(codeContent);
+      if (repoFullName && branch && filePath) {
+        rawHtml = rewriteImageUrls(rawHtml, repoFullName, branch, filePath);
+      }
       const html = await preRenderMermaid(rawHtml);
       editor.commands.setContent(html);
       setCodeView(false);
       editor.setEditable(true);
+      // Reload authenticated images after TipTap renders
+      setTimeout(() => {
+        if (editorContainerRef.current) {
+          loadAuthenticatedImages(editorContainerRef.current);
+        }
+      }, 50);
     }
-  }, [editor, codeView, codeContent]);
+  }, [editor, codeView, codeContent, repoFullName, branch, filePath]);
 
   // Inline add link/image popover (replaces window.prompt for VS Code compat)
   const [addPopover, setAddPopover] = useState<{ type: "link" | "image"; url: string; alt: string } | null>(null);

--- a/src/components/PRDetail.tsx
+++ b/src/components/PRDetail.tsx
@@ -389,8 +389,10 @@ export default function PRDetail({ pr, onBack }: PRDetailProps) {
 
           {/* Expanded description */}
           {pr.description && (
-            <div className="mt-2 text-sm text-[var(--text-secondary)] prose prose-sm dark:prose-invert max-w-none max-h-32 overflow-y-auto hidden [details[open]~&]:block">
-            </div>
+            <div
+              className="mt-2 text-sm text-[var(--text-secondary)] prose prose-sm dark:prose-invert max-w-none max-h-40 overflow-y-auto border-t border-[var(--border)] pt-2"
+              dangerouslySetInnerHTML={{ __html: descriptionConverter.makeHtml(pr.description) }}
+            />
           )}
         </div>
       </div>

--- a/src/lib/github-api.ts
+++ b/src/lib/github-api.ts
@@ -965,6 +965,10 @@ export async function loadAuthenticatedImages(
       if ("content" in data && data.encoding === "base64") {
         const ext = path.split(".").pop()?.toLowerCase() || "png";
         const mime = mimeTypes[ext] || "application/octet-stream";
+        // Preserve original src for round-trip back to markdown
+        if (!img.getAttribute("data-original-src")) {
+          img.setAttribute("data-original-src", img.src);
+        }
         img.src = `data:${mime};base64,${data.content.replace(/\n/g, "")}`;
       }
     })

--- a/src/lib/turndown.ts
+++ b/src/lib/turndown.ts
@@ -35,6 +35,19 @@ export function createTurndownService(): TurndownService {
     "dd",
   ]);
 
+  // Images with original src — restore the original URL instead of data: or blob: URIs
+  turndown.addRule("imageWithOriginalSrc", {
+    filter: (node) => {
+      return node.nodeName === "IMG" && node.hasAttribute("data-original-src");
+    },
+    replacement: (_content, node) => {
+      const el = node as HTMLElement;
+      const src = el.getAttribute("data-original-src") || "";
+      const alt = el.getAttribute("alt") || "";
+      return `![${alt}](${src})`;
+    },
+  });
+
   // Mermaid diagrams — restore fenced code blocks from rendered <img> tags
   turndown.addRule("mermaidDiagram", {
     filter: (node) => {


### PR DESCRIPTION
## Summary

- **Image round-trip**: Preserve original image src in `data-original-src` attribute so code view shows real URLs instead of `data:` base64 URIs. Turndown rule restores original URL. Toggling back to rich view re-runs `rewriteImageUrls` + `loadAuthenticatedImages` to reload images.
- **028 — PR description**: Render PR description markdown in PRDetail view (was an empty `<div>`)
- **025 — Bubble robustness**: Validate target DOM element still exists before positioning, constrain bubble to right edge of container
- **029 — Remove stubs**: Replace `console.log` stubs in page.tsx with no-op callbacks

## Test plan

5 new automated tests for image round-trip:
- [x] Restores original src from data-original-src
- [x] Regular images unaffected
- [x] Alt text preserved
- [x] Empty alt text handled
- [x] Prefers data-original-src over data: URI

Manual:
- [ ] Open file with images → toggle code view → see real URLs not base64
- [ ] Toggle back → images re-render correctly
- [ ] Open a PR with a description → description renders as markdown
- [ ] Click link near right edge → bubble stays within viewport