### PR TITLE
feat: HTML document rendering + mermaid theme upgrade

### DIFF
--- a/docs/features/031-html-document-rendering.md
+++ b/docs/features/031-html-document-rendering.md
@@ -1,0 +1,44 @@
+# 031 — HTML Document Rendering
+
+## Value
+
+AI-generated HTML documents (research reports, cost analyses, architecture guides) are beautiful, self-contained files with custom CSS, mermaid diagrams, and rich layouts. But checking them into GitHub for PR review means reviewers see raw HTML source — they can't see the rendered document, judge content correctness, or comment meaningfully. MarDoc already solves this for markdown; extending to HTML makes these documents reviewable.
+
+## Acceptance Criteria
+
+- [x] HTML files (`.html`, `.htm`) appear in the sidebar file tree alongside markdown files
+- [x] HTML files appear in PR changed-files lists
+- [x] Clicking an HTML file renders it in a sandboxed iframe with full CSS/JS support
+- [x] Mermaid diagrams via CDN render correctly inside HTML documents
+- [x] "View Source" toggle shows the raw HTML
+- [x] Fullscreen toggle available for HTML viewer
+- [x] PR DiffViewer shows "Rendered" (iframe) and "Source Diff" modes for HTML files
+- [x] Base/Head toggle in rendered mode lets reviewers compare versions
+- [x] GitHub token is not accessible from the iframe (sandbox security)
+- [x] Demo mode includes a sample HTML file and a mock PR with HTML changes
+- [x] Relative asset URLs rewritten to raw.githubusercontent.com for repo files
+- [x] Existing markdown rendering is not affected
+
+## Dependencies
+
+None — builds on existing infrastructure.
+
+## Implementation Notes
+
+**File type gates** (`src/lib/file-types.ts`):
+- Shared helpers: `isDocumentFile()`, `isHtmlFile()`, `isMarkdownFile()`
+- Used in `github-api.ts` (tree, PR files, PR counts) and `Sidebar.tsx` (file input, empty states)
+
+**HtmlViewer** (`src/components/HtmlViewer.tsx`):
+- `<iframe srcdoc={content} sandbox="allow-scripts" />` — scripts execute but can't access parent localStorage
+- Resize script injected via postMessage for auto-height
+- Asset URL rewriting for relative paths in repo context
+
+**DiffViewer HTML support** (`src/components/DiffViewer.tsx`):
+- `isHtmlFile` detection at component level
+- Two HTML-specific view modes: Rendered (iframe with base/head toggle) and Source Diff (line diff)
+- Markdown-specific processing (Showdown, mermaid blocks) skipped for HTML files
+
+**Routing** (`src/lib/app-context.tsx`, `src/app/page.tsx`):
+- New `ViewMode: "html-viewer"` routes HTML files to HtmlViewer instead of Editor
+- All file-opening paths (openFile, openLocalFile, VS Code embed) detect HTML

--- a/docs/features/032-mermaid-theme-upgrade.md
+++ b/docs/features/032-mermaid-theme-upgrade.md
@@ -1,0 +1,30 @@
+# 032 — Mermaid Theme Upgrade
+
+## Value
+
+Mermaid diagrams rendered with the default theme look bland and disconnected from the app's design. AI-generated HTML documents demonstrate that `theme: 'base'` with custom `themeVariables` produces dramatically better output. Adopting this approach in MarDoc's markdown renderer improves diagram quality across both the Editor and DiffViewer.
+
+## Acceptance Criteria
+
+- [x] Mermaid diagrams render with custom themed colors (blues, teals, ambers) in light mode
+- [x] Mermaid diagrams render with complementary dark palette in dark mode
+- [x] Theme automatically syncs when user toggles light/dark mode
+- [x] Flowcharts use `curve: 'basis'` for smoother edges
+- [x] Sequence diagrams have increased actor/message margins for readability
+- [x] Diagram container has subtle background and rounded corners
+- [x] Existing mermaid round-trip preservation is not affected
+
+## Dependencies
+
+None.
+
+## Implementation Notes
+
+**Single file change** (`src/lib/mermaid.ts`):
+- `LIGHT_THEME_VARS` and `DARK_THEME_VARS` constants with full `themeVariables` objects
+- `getMermaidConfig(isDark)` builds the config with `theme: "base"` and layout options
+- `syncMermaidTheme()` detects dark mode from `document.documentElement.classList` and re-initializes only when theme changes
+- Both `preRenderMermaid` and `renderMermaidBlocks` call `syncMermaidTheme()` before rendering
+
+**CSS update** (`src/app/globals.css`):
+- `.mermaid-diagram` gets subtle background, padding, and border-radius

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -246,7 +246,10 @@ body {
 .mermaid-diagram {
   display: flex;
   justify-content: center;
-  padding: 1rem 0;
+  padding: 1.5rem;
+  background: var(--bg-secondary, var(--surface));
+  border-radius: 8px;
+  margin: 1rem 0;
 }
 
 .mermaid-diagram svg {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import { useApp } from "@/lib/app-context";
 import Sidebar from "@/components/Sidebar";
 import Editor from "@/components/Editor";
+import HtmlViewer from "@/components/HtmlViewer";
 import PRDetail from "@/components/PRDetail";
 import PRReview from "@/components/PRReview";
 import SettingsPanel from "@/components/SettingsPanel";
@@ -101,6 +102,22 @@ export default function Home() {
                 repoFullName={currentRepo || undefined}
                 branch={selectedBranch}
                 onContentChange={() => {}}
+              />
+            )
+          ) : currentView === "html-viewer" && selectedFile ? (
+            loadingContent ? (
+              <div className="h-full flex items-center justify-center">
+                <div className="flex items-center gap-2 text-[var(--text-muted)]">
+                  <Loader2 size={18} className="animate-spin" />
+                  <span className="text-sm">Loading {selectedFile.name}...</span>
+                </div>
+              </div>
+            ) : (
+              <HtmlViewer
+                content={fileContent}
+                filePath={selectedFile.path}
+                repoFullName={currentRepo || undefined}
+                branch={selectedBranch}
               />
             )
           ) : currentView === "pr-diff" && selectedPR ? (

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -41,6 +41,7 @@ import { openExternal } from "@/lib/open-external";
 import { renderMermaidBlocks } from "@/lib/mermaid";
 import { highlightCodeBlocks } from "@/lib/highlight";
 import { useWideFormat } from "@/lib/use-wide-format";
+import { isHtmlFile } from "@/lib/file-types";
 
 interface DiffViewerProps {
   file: PRFile;
@@ -720,6 +721,9 @@ export default function DiffViewer({
   onAcceptSuggestion,
 }: DiffViewerProps) {
   const [viewMode, setViewMode] = useState<"rendered" | "split" | "suggest" | "preview">("rendered");
+  const [htmlViewMode, setHtmlViewMode] = useState<"rendered" | "source">("rendered");
+  const [htmlShowBase, setHtmlShowBase] = useState(false);
+  const fileIsHtml = isHtmlFile(file.path);
   const [showPanel, setShowPanel] = useState(true);
   const { wide, toggle: toggleWide } = useWideFormat();
   const { isEmbedded } = useApp();
@@ -737,13 +741,74 @@ export default function DiffViewer({
   const editTextareaRef = useRef<HTMLTextAreaElement>(null);
 
   const contentRef = useRef<HTMLDivElement>(null);
+  const htmlIframeRef = useRef<HTMLIFrameElement>(null);
   const commentInputRef = useRef<HTMLInputElement>(null);
-  // Post-render: fetch private repo images and render mermaid diagrams
+  // Post-render: fetch private repo images and render mermaid diagrams (markdown only)
   useEffect(() => {
-    if (!contentRef.current) return;
+    if (!contentRef.current || fileIsHtml) return;
     loadAuthenticatedImages(contentRef.current);
     renderMermaidBlocks(contentRef.current);
-  }, [file, viewMode]);
+  }, [file, viewMode, fileIsHtml]);
+
+  // Listen for iframe resize messages (HTML file rendering)
+  useEffect(() => {
+    if (!fileIsHtml) return;
+    const iframe = htmlIframeRef.current;
+    if (!iframe) return;
+    const handleMessage = (event: MessageEvent) => {
+      if (event.data?.type === "mardoc-iframe-resize" && typeof event.data.height === "number") {
+        iframe.style.height = `${event.data.height + 20}px`;
+      }
+    };
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, [fileIsHtml, htmlViewMode, htmlShowBase]);
+
+  // Prepare HTML srcdoc with injected resize script
+  const htmlSrcdoc = useMemo(() => {
+    if (!fileIsHtml) return "";
+    const raw = htmlShowBase ? file.baseContent : file.headContent;
+    const resizeScript = `<script>(function(){function p(){window.parent.postMessage({type:'mardoc-iframe-resize',height:document.documentElement.scrollHeight},'*')}window.addEventListener('load',function(){setTimeout(p,100)});new MutationObserver(p).observe(document.body,{childList:true,subtree:true,attributes:true});setTimeout(p,500);setTimeout(p,2000)})()</script>`;
+    if (raw.includes("</body>")) return raw.replace("</body>", `${resizeScript}</body>`);
+    return raw + resizeScript;
+  }, [fileIsHtml, file.baseContent, file.headContent, htmlShowBase]);
+
+  // Simple source diff for HTML files
+  const htmlSourceDiff = useMemo(() => {
+    if (!fileIsHtml) return [];
+    const baseLines = file.baseContent.split("\n");
+    const headLines = file.headContent.split("\n");
+    const result: { type: "context" | "add" | "remove"; text: string }[] = [];
+
+    // Simple line-by-line diff (good enough for source view)
+    const baseSet = new Set(baseLines);
+    const headSet = new Set(headLines);
+
+    let bi = 0, hi = 0;
+    while (bi < baseLines.length || hi < headLines.length) {
+      if (bi < baseLines.length && hi < headLines.length && baseLines[bi] === headLines[hi]) {
+        result.push({ type: "context", text: headLines[hi] });
+        bi++; hi++;
+      } else if (hi < headLines.length && !baseSet.has(headLines[hi])) {
+        result.push({ type: "add", text: headLines[hi] });
+        hi++;
+      } else if (bi < baseLines.length && !headSet.has(baseLines[bi])) {
+        result.push({ type: "remove", text: baseLines[bi] });
+        bi++;
+      } else {
+        // Modified line — show as remove + add
+        if (bi < baseLines.length) {
+          result.push({ type: "remove", text: baseLines[bi] });
+          bi++;
+        }
+        if (hi < headLines.length) {
+          result.push({ type: "add", text: headLines[hi] });
+          hi++;
+        }
+      }
+    }
+    return result;
+  }, [fileIsHtml, file.baseContent, file.headContent]);
 
   // Map PR comments into panel format for display
   const allPanelComments: PanelComment[] = useMemo(() => {
@@ -1120,54 +1185,81 @@ export default function DiffViewer({
             {wide ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
           </button>
 
-          <div className="flex items-center gap-1 bg-[var(--surface-secondary)] rounded-md p-0.5">
-            <button
-              onClick={() => setViewMode("rendered")}
-              className={`text-xs px-2.5 py-1 rounded transition-colors ${
-                viewMode === "rendered"
-                  ? "bg-[var(--surface)] text-[var(--text-primary)] shadow-sm"
-                  : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
-              }`}
-            >
-              Inline Diff
-            </button>
-            <button
-              onClick={() => setViewMode("split")}
-              className={`text-xs px-2.5 py-1 rounded transition-colors ${
-                viewMode === "split"
-                  ? "bg-[var(--surface)] text-[var(--text-primary)] shadow-sm"
-                  : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
-              }`}
-            >
-              Side by Side
-            </button>
-            <button
-              onClick={() => setViewMode("suggest")}
-              className={`text-xs px-2.5 py-1 rounded transition-colors flex items-center gap-1 ${
-                viewMode === "suggest"
-                  ? "bg-[var(--surface)] text-[var(--text-primary)] shadow-sm"
-                  : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
-              }`}
-            >
-              <Pencil size={10} />
-              Suggest
-              {pendingSuggestions.length > 0 && (
-                <span className="ml-0.5 px-1.5 py-0 text-[9px] rounded-full bg-[var(--accent)] text-white font-medium">
-                  {pendingSuggestions.length}
-                </span>
-              )}
-            </button>
-            <button
-              onClick={() => setViewMode("preview")}
-              className={`text-xs px-2.5 py-1 rounded transition-colors ${
-                viewMode === "preview"
-                  ? "bg-[var(--surface)] text-[var(--text-primary)] shadow-sm"
-                  : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
-              }`}
-            >
-              Preview
-            </button>
-          </div>
+          {fileIsHtml ? (
+            <div className="flex items-center gap-1 bg-[var(--surface-secondary)] rounded-md p-0.5">
+              <button
+                onClick={() => setHtmlViewMode("rendered")}
+                className={`text-xs px-2.5 py-1 rounded transition-colors flex items-center gap-1 ${
+                  htmlViewMode === "rendered"
+                    ? "bg-[var(--surface)] text-[var(--text-primary)] shadow-sm"
+                    : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+                }`}
+              >
+                <Eye size={10} />
+                Rendered
+              </button>
+              <button
+                onClick={() => setHtmlViewMode("source")}
+                className={`text-xs px-2.5 py-1 rounded transition-colors flex items-center gap-1 ${
+                  htmlViewMode === "source"
+                    ? "bg-[var(--surface)] text-[var(--text-primary)] shadow-sm"
+                    : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+                }`}
+              >
+                <FileCode size={10} />
+                Source Diff
+              </button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-1 bg-[var(--surface-secondary)] rounded-md p-0.5">
+              <button
+                onClick={() => setViewMode("rendered")}
+                className={`text-xs px-2.5 py-1 rounded transition-colors ${
+                  viewMode === "rendered"
+                    ? "bg-[var(--surface)] text-[var(--text-primary)] shadow-sm"
+                    : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+                }`}
+              >
+                Inline Diff
+              </button>
+              <button
+                onClick={() => setViewMode("split")}
+                className={`text-xs px-2.5 py-1 rounded transition-colors ${
+                  viewMode === "split"
+                    ? "bg-[var(--surface)] text-[var(--text-primary)] shadow-sm"
+                    : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+                }`}
+              >
+                Side by Side
+              </button>
+              <button
+                onClick={() => setViewMode("suggest")}
+                className={`text-xs px-2.5 py-1 rounded transition-colors flex items-center gap-1 ${
+                  viewMode === "suggest"
+                    ? "bg-[var(--surface)] text-[var(--text-primary)] shadow-sm"
+                    : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+                }`}
+              >
+                <Pencil size={10} />
+                Suggest
+                {pendingSuggestions.length > 0 && (
+                  <span className="ml-0.5 px-1.5 py-0 text-[9px] rounded-full bg-[var(--accent)] text-white font-medium">
+                    {pendingSuggestions.length}
+                  </span>
+                )}
+              </button>
+              <button
+                onClick={() => setViewMode("preview")}
+                className={`text-xs px-2.5 py-1 rounded transition-colors ${
+                  viewMode === "preview"
+                    ? "bg-[var(--surface)] text-[var(--text-primary)] shadow-sm"
+                    : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+                }`}
+              >
+                Preview
+              </button>
+            </div>
+          )}
         </div>
       </div>
 
@@ -1224,7 +1316,75 @@ export default function DiffViewer({
       <div className="flex-1 flex overflow-hidden">
         {/* Main diff content */}
         <div className="flex-1 overflow-y-auto">
-          {viewMode === "rendered" ? (
+          {fileIsHtml ? (
+            /* HTML file rendering */
+            htmlViewMode === "rendered" ? (
+              <div className="h-full flex flex-col">
+                {/* Base/Head toggle for rendered HTML */}
+                {file.baseContent && file.headContent && (
+                  <div className="flex items-center gap-2 px-4 py-2 border-b border-[var(--border)] bg-[var(--bg-secondary,var(--surface))]">
+                    <span className="text-[10px] text-[var(--text-muted)]">Showing:</span>
+                    <button
+                      onClick={() => setHtmlShowBase(false)}
+                      className={`text-xs px-2 py-0.5 rounded transition-colors ${
+                        !htmlShowBase
+                          ? "bg-[var(--diff-add)] text-[var(--diff-add-text)] font-medium"
+                          : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+                      }`}
+                    >
+                      Head (new)
+                    </button>
+                    <button
+                      onClick={() => setHtmlShowBase(true)}
+                      className={`text-xs px-2 py-0.5 rounded transition-colors ${
+                        htmlShowBase
+                          ? "bg-[var(--diff-remove)] text-[var(--diff-remove-text)] font-medium"
+                          : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+                      }`}
+                    >
+                      Base (old)
+                    </button>
+                  </div>
+                )}
+                <div className="flex-1 overflow-auto">
+                  <iframe
+                    ref={htmlIframeRef}
+                    srcDoc={htmlSrcdoc}
+                    sandbox="allow-scripts"
+                    title={file.path}
+                    className="w-full border-0"
+                    style={{ minHeight: "100%", height: "100%" }}
+                  />
+                </div>
+              </div>
+            ) : (
+              /* Source diff for HTML files */
+              <div className={wide ? "mx-auto px-12 py-6" : "max-w-5xl mx-auto px-8 py-6"}>
+                <div className="text-[10px] text-[var(--text-muted)] mb-4">
+                  Raw HTML source diff — switch to Rendered to see the visual output
+                </div>
+                <pre className="text-xs font-mono leading-relaxed">
+                  {htmlSourceDiff.map((line, idx) => (
+                    <div
+                      key={idx}
+                      className={
+                        line.type === "add"
+                          ? "bg-[var(--diff-add)] text-[var(--diff-add-text)]"
+                          : line.type === "remove"
+                          ? "bg-[var(--diff-remove)] text-[var(--diff-remove-text)]"
+                          : ""
+                      }
+                    >
+                      <span className="inline-block w-4 text-[var(--text-muted)] select-none">
+                        {line.type === "add" ? "+" : line.type === "remove" ? "-" : " "}
+                      </span>
+                      {line.text}
+                    </div>
+                  ))}
+                </pre>
+              </div>
+            )
+          ) : viewMode === "rendered" ? (
             <div className="relative" ref={contentRef}>
               {/* Floating selection toolbar */}
               <FloatingToolbar

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -6,7 +6,7 @@ import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
 import TaskList from "@tiptap/extension-task-list";
 import TaskItem from "@tiptap/extension-task-item";
-import Image from "@tiptap/extension-image";
+import BaseImage from "@tiptap/extension-image";
 import Link from "@tiptap/extension-link";
 import Highlight from "@tiptap/extension-highlight";
 import Typography from "@tiptap/extension-typography";
@@ -20,6 +20,22 @@ import Showdown from "showdown";
 import { createTurndownService } from "@/lib/turndown";
 
 const lowlight = createLowlight(common);
+
+// Extend TipTap Image to preserve data attributes needed for round-trip fidelity
+const Image = BaseImage.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      "data-mermaid-source": { default: null, parseHTML: (el) => el.getAttribute("data-mermaid-source"), renderHTML: (attrs) => attrs["data-mermaid-source"] ? { "data-mermaid-source": attrs["data-mermaid-source"] } : {} },
+      "data-original-src": { default: null, parseHTML: (el) => el.getAttribute("data-original-src"), renderHTML: (attrs) => attrs["data-original-src"] ? { "data-original-src": attrs["data-original-src"] } : {} },
+      "data-gh-owner": { default: null, parseHTML: (el) => el.getAttribute("data-gh-owner"), renderHTML: (attrs) => attrs["data-gh-owner"] ? { "data-gh-owner": attrs["data-gh-owner"] } : {} },
+      "data-gh-repo": { default: null, parseHTML: (el) => el.getAttribute("data-gh-repo"), renderHTML: (attrs) => attrs["data-gh-repo"] ? { "data-gh-repo": attrs["data-gh-repo"] } : {} },
+      "data-gh-ref": { default: null, parseHTML: (el) => el.getAttribute("data-gh-ref"), renderHTML: (attrs) => attrs["data-gh-ref"] ? { "data-gh-ref": attrs["data-gh-ref"] } : {} },
+      "data-gh-path": { default: null, parseHTML: (el) => el.getAttribute("data-gh-path"), renderHTML: (attrs) => attrs["data-gh-path"] ? { "data-gh-path": attrs["data-gh-path"] } : {} },
+    };
+  },
+});
+
 import { rewriteImageUrls, loadAuthenticatedImages, createReviewPR, createInlineComment, mapSelectionToLines, fetchFileContent, createFileAsPR, commitFileToPRBranch } from "@/lib/github-api";
 import { classifyLink, resolvePath, findFileByPath } from "@/lib/link-handler";
 import { useApp } from "@/lib/app-context";

--- a/src/components/HtmlViewer.tsx
+++ b/src/components/HtmlViewer.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import React, { useMemo, useRef, useState, useEffect } from "react";
+import { Code2, Eye, Maximize2, Minimize2 } from "lucide-react";
+
+interface HtmlViewerProps {
+  content: string;
+  filePath: string;
+  repoFullName?: string;
+  branch?: string;
+}
+
+/**
+ * Rewrite relative asset URLs (images, links) in HTML content so they
+ * resolve against the GitHub raw content CDN.
+ */
+function rewriteHtmlAssetUrls(
+  html: string,
+  repoFullName: string,
+  ref: string,
+  filePath: string
+): string {
+  const [owner, repo] = repoFullName.split("/");
+  const fileDir = filePath.split("/").slice(0, -1).join("/");
+
+  function resolveRelative(src: string): string | null {
+    if (/^(https?:\/\/|data:|#|mailto:|javascript:)/i.test(src)) return null;
+
+    let resolvedPath: string;
+    if (src.startsWith("/")) {
+      resolvedPath = src.slice(1);
+    } else {
+      const parts = [...fileDir.split("/").filter(Boolean), ...src.split("/")];
+      const resolved: string[] = [];
+      for (const p of parts) {
+        if (p === ".." && resolved.length) resolved.pop();
+        else if (p !== "." && p !== "") resolved.push(p);
+      }
+      resolvedPath = resolved.join("/");
+    }
+
+    return `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${resolvedPath}`;
+  }
+
+  // Rewrite src and href attributes on img, link, script, a, source, video, audio
+  return html.replace(
+    /(<(?:img|link|script|source|video|audio)\s[^>]*?(?:src|href)=")([^"]+)("[^>]*?>)/gi,
+    (_match, before, url, after) => {
+      const resolved = resolveRelative(url);
+      return resolved ? `${before}${resolved}${after}` : _match;
+    }
+  );
+}
+
+export default function HtmlViewer({ content, filePath, repoFullName, branch }: HtmlViewerProps) {
+  const [viewSource, setViewSource] = useState(false);
+  const [fullscreen, setFullscreen] = useState(false);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const fileName = filePath.split("/").pop() || filePath;
+
+  const processedContent = useMemo(() => {
+    if (!content) return "";
+    if (repoFullName && branch) {
+      return rewriteHtmlAssetUrls(content, repoFullName, branch, filePath);
+    }
+    return content;
+  }, [content, repoFullName, branch, filePath]);
+
+  // Auto-resize iframe to fit content
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe || viewSource) return;
+
+    const handleLoad = () => {
+      try {
+        // With sandbox="allow-scripts" (no allow-same-origin),
+        // we can't access iframe.contentDocument directly.
+        // Instead, inject a resize script into the srcdoc that posts height.
+      } catch {
+        // Expected — cross-origin iframe
+      }
+    };
+
+    iframe.addEventListener("load", handleLoad);
+    return () => iframe.removeEventListener("load", handleLoad);
+  }, [viewSource, processedContent]);
+
+  // Inject a postMessage-based resize script into the srcdoc
+  const srcdoc = useMemo(() => {
+    if (!processedContent) return "";
+    const resizeScript = `
+<script>
+(function() {
+  function postHeight() {
+    var h = document.documentElement.scrollHeight;
+    window.parent.postMessage({ type: 'mardoc-iframe-resize', height: h }, '*');
+  }
+  window.addEventListener('load', function() { setTimeout(postHeight, 100); });
+  new MutationObserver(postHeight).observe(document.body, { childList: true, subtree: true, attributes: true });
+  // Also post after mermaid renders (can take a moment)
+  setTimeout(postHeight, 500);
+  setTimeout(postHeight, 2000);
+})();
+</script>`;
+
+    // Insert resize script before </body> or at end
+    if (processedContent.includes("</body>")) {
+      return processedContent.replace("</body>", `${resizeScript}</body>`);
+    }
+    return processedContent + resizeScript;
+  }, [processedContent]);
+
+  // Listen for resize messages from the iframe
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe || viewSource) return;
+
+    const handleMessage = (event: MessageEvent) => {
+      if (event.data?.type === "mardoc-iframe-resize" && typeof event.data.height === "number") {
+        iframe.style.height = `${event.data.height + 20}px`;
+      }
+    };
+
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, [viewSource]);
+
+  // Toggle fullscreen
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    if (fullscreen && !document.fullscreenElement) {
+      container.requestFullscreen?.();
+    } else if (!fullscreen && document.fullscreenElement) {
+      document.exitFullscreen?.();
+    }
+
+    const handleFullscreenChange = () => {
+      if (!document.fullscreenElement) setFullscreen(false);
+    };
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    return () => document.removeEventListener("fullscreenchange", handleFullscreenChange);
+  }, [fullscreen]);
+
+  return (
+    <div ref={containerRef} className="h-full flex flex-col bg-[var(--surface)]">
+      {/* Toolbar */}
+      <div className="flex items-center justify-between px-4 py-2 border-b border-[var(--border)] bg-[var(--bg-secondary,var(--surface))]">
+        <span className="text-sm font-medium text-[var(--text)] truncate">{fileName}</span>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => setViewSource(!viewSource)}
+            className={`toolbar-btn ${viewSource ? "bg-[var(--accent)]/10 text-[var(--accent)]" : ""}`}
+            title={viewSource ? "Rendered view" : "View source"}
+          >
+            {viewSource ? <Eye size={16} /> : <Code2 size={16} />}
+          </button>
+          <button
+            onClick={() => setFullscreen(!fullscreen)}
+            className="toolbar-btn"
+            title={fullscreen ? "Exit fullscreen" : "Fullscreen"}
+          >
+            {fullscreen ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
+          </button>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto">
+        {viewSource ? (
+          <pre className="p-4 text-sm font-mono text-[var(--text)] whitespace-pre-wrap break-words overflow-auto">
+            <code>{content}</code>
+          </pre>
+        ) : (
+          <iframe
+            ref={iframeRef}
+            srcDoc={srcdoc}
+            sandbox="allow-scripts"
+            title={fileName}
+            className="w-full border-0"
+            style={{ minHeight: "100%", height: "100%" }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -479,7 +479,7 @@ export default function Sidebar() {
                 </div>
               ) : prFileTree.length === 0 ? (
                 <p className="text-xs text-[var(--text-muted)] text-center py-4">
-                  {prFileFilter ? "No files matching filter." : "No markdown files changed."}
+                  {prFileFilter ? "No files matching filter." : "No document files changed."}
                 </p>
               ) : (
                 <div className="space-y-0.5">
@@ -503,7 +503,7 @@ export default function Sidebar() {
             <div className="text-center py-8 px-3">
               <p className="text-sm text-[var(--text-muted)]">
                 {currentRepo
-                  ? "No markdown files found in this repository."
+                  ? "No document files found in this repository."
                   : "Open Settings to connect a repository."}
               </p>
             </div>
@@ -528,7 +528,7 @@ export default function Sidebar() {
                   <input
                     ref={fileInputRef}
                     type="file"
-                    accept=".md,.mdx,.markdown"
+                    accept=".md,.mdx,.markdown,.html,.htm"
                     onChange={handleLocalFileSelect}
                     className="hidden"
                   />

--- a/src/lib/app-context.tsx
+++ b/src/lib/app-context.tsx
@@ -6,6 +6,7 @@ import { initOctokit, fetchRepoTree, fetchPullRequests, fetchFileContent, fetchP
 import { repoFiles as mockFiles, pullRequests as mockPRs, findFile, flattenFiles } from "./mock-data";
 import { parseHash, buildFileHash, buildPRHash, buildRepoHash } from "./hash-router";
 import * as safeStorage from "./safe-storage";
+import { isHtmlFile } from "./file-types";
 
 interface AppState {
   // Auth
@@ -172,7 +173,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       };
       setSelectedFile(localFile);
       setSelectedPR(null);
-      setCurrentView("editor");
+      setCurrentView(isHtmlFile(data.fileName) ? "html-viewer" : "editor");
       setFileContent(data.fileContent);
     }
   }, []);
@@ -333,7 +334,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     async (file: RepoFile) => {
       setSelectedFile(file);
       setSelectedPR(null);
-      setCurrentView("editor");
+      setCurrentView(isHtmlFile(file.name) ? "html-viewer" : "editor");
 
       // Update URL hash
       if (currentRepo) {
@@ -412,7 +413,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     setSelectedPR(null);
     setPRBranchForNewFile(null);
     setPRNumberForNewFile(null);
-    setCurrentView("editor");
+    setCurrentView(isHtmlFile(name) ? "html-viewer" : "editor");
     setFileContent(content);
   }, []);
 

--- a/src/lib/file-types.ts
+++ b/src/lib/file-types.ts
@@ -1,0 +1,14 @@
+/** Shared file-type detection helpers. */
+
+export function isMarkdownFile(name: string): boolean {
+  return name.endsWith(".md") || name.endsWith(".mdx");
+}
+
+export function isHtmlFile(name: string): boolean {
+  return name.endsWith(".html") || name.endsWith(".htm");
+}
+
+/** Returns true for any file type MarDoc can render (markdown or HTML). */
+export function isDocumentFile(name: string): boolean {
+  return isMarkdownFile(name) || isHtmlFile(name);
+}

--- a/src/lib/github-api.ts
+++ b/src/lib/github-api.ts
@@ -2,6 +2,7 @@
 
 import { Octokit } from "@octokit/rest";
 import { RepoFile, PullRequest, PRFile, PRComment } from "@/types";
+import { isDocumentFile } from "@/lib/file-types";
 
 let octokitInstance: Octokit | null = null;
 
@@ -105,8 +106,8 @@ export async function fetchRepoTree(
       const parts = path.split("/");
       const name = parts[parts.length - 1];
 
-      // Only show markdown files and their parent directories
-      const isMarkdown = name.endsWith(".md") || name.endsWith(".mdx");
+      // Only show document files and their parent directories
+      const isMarkdown = isDocumentFile(name);
       const isDir = item.type === "tree";
 
       const file: RepoFile = {
@@ -253,7 +254,7 @@ export async function fetchPRMarkdownCounts(
       const prData = result.repository[`pr${i}`];
       if (prData?.files?.nodes) {
         const mdCount = prData.files.nodes.filter(
-          (f: any) => /\.(md|mdx)$/i.test(f.path)
+          (f: any) => isDocumentFile(f.path)
         ).length;
         counts.set(prData.number, mdCount);
       }
@@ -282,9 +283,9 @@ export async function fetchPRFiles(
     per_page: 100,
   });
 
-  // Filter to markdown files only
+  // Filter to document files only (markdown + HTML)
   const mdFiles = files.filter(
-    (f) => f.filename.endsWith(".md") || f.filename.endsWith(".mdx")
+    (f) => isDocumentFile(f.filename)
   );
 
   const prDetail = await octokit.pulls.get({

--- a/src/lib/mermaid.ts
+++ b/src/lib/mermaid.ts
@@ -1,19 +1,81 @@
 "use client";
 
+const LIGHT_THEME_VARS = {
+  primaryColor: "#E6F1FB",
+  primaryTextColor: "#0C447C",
+  primaryBorderColor: "#85B7EB",
+  secondaryColor: "#E1F5EE",
+  secondaryTextColor: "#085041",
+  secondaryBorderColor: "#5DCAA5",
+  tertiaryColor: "#FAEEDA",
+  tertiaryTextColor: "#633806",
+  tertiaryBorderColor: "#FAC775",
+  lineColor: "#5F5E5A",
+  textColor: "#2C2C2A",
+  fontSize: "14px",
+  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+  noteTextColor: "#2C2C2A",
+  noteBkgColor: "#F1EFE8",
+  noteBorderColor: "#B4B2A9",
+};
+
+const DARK_THEME_VARS = {
+  primaryColor: "#363949",
+  primaryTextColor: "#bd93f9",
+  primaryBorderColor: "#6272a4",
+  secondaryColor: "#1e3a2a",
+  secondaryTextColor: "#50fa7b",
+  secondaryBorderColor: "#50fa7b",
+  tertiaryColor: "#3d1a1e",
+  tertiaryTextColor: "#ffb86c",
+  tertiaryBorderColor: "#ff79c6",
+  lineColor: "#6272a4",
+  textColor: "#f8f8f2",
+  fontSize: "14px",
+  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+  noteTextColor: "#f8f8f2",
+  noteBkgColor: "#44475a",
+  noteBorderColor: "#6272a4",
+};
+
+function detectDarkMode(): boolean {
+  return typeof document !== "undefined" &&
+    document.documentElement.classList.contains("dark");
+}
+
+function getMermaidConfig(isDark: boolean) {
+  return {
+    startOnLoad: false,
+    theme: "base" as const,
+    securityLevel: "loose" as const,
+    themeVariables: isDark ? DARK_THEME_VARS : LIGHT_THEME_VARS,
+    flowchart: { curve: "basis" as const, padding: 16 },
+    sequence: { actorMargin: 60, messageMargin: 40 },
+  };
+}
+
 let mermaidReady: Promise<typeof import("mermaid")["default"]> | null = null;
+let lastDark: boolean | null = null;
 
 function getMermaid() {
   if (!mermaidReady) {
+    const isDark = detectDarkMode();
+    lastDark = isDark;
     mermaidReady = import("mermaid").then((m) => {
-      m.default.initialize({
-        startOnLoad: false,
-        theme: "default",
-        securityLevel: "loose",
-      });
+      m.default.initialize(getMermaidConfig(isDark));
       return m.default;
     });
   }
   return mermaidReady;
+}
+
+/** Re-initialize mermaid with the current theme. Call before rendering. */
+async function syncMermaidTheme(): Promise<void> {
+  const isDark = detectDarkMode();
+  if (isDark === lastDark) return;
+  lastDark = isDark;
+  const mermaid = await getMermaid();
+  mermaid.initialize(getMermaidConfig(isDark));
 }
 
 const MERMAID_KEYWORDS = /^(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|gantt|pie|gitgraph|journey|mindmap|timeline|quadrantChart|sankey|block|xychart|C4Context)\b/;
@@ -35,6 +97,7 @@ export async function preRenderMermaid(html: string): Promise<string> {
   );
   if (codeBlocks.length === 0) return html;
 
+  await syncMermaidTheme();
   const mermaid = await getMermaid();
 
   for (let i = 0; i < codeBlocks.length; i++) {
@@ -81,6 +144,7 @@ export async function renderMermaidBlocks(container: HTMLElement): Promise<void>
   });
   if (codeBlocks.length === 0) return;
 
+  await syncMermaidTheme();
   const mermaid = await getMermaid();
 
   for (let i = 0; i < codeBlocks.length; i++) {

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -1,5 +1,80 @@
 import { RepoFile, PullRequest } from "@/types";
 
+const MOCK_HTML_DOC = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Architecture Overview — MarDoc</title>
+<script type="module">
+import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+mermaid.initialize({ startOnLoad: true, theme: 'base', themeVariables: {
+  primaryColor: '#E6F1FB', primaryTextColor: '#0C447C', primaryBorderColor: '#85B7EB',
+  secondaryColor: '#E1F5EE', lineColor: '#5F5E5A', textColor: '#2C2C2A', fontSize: '14px'
+}});
+<\/script>
+<style>
+  :root { --bg: #FAFAF8; --surface: #FFFFFF; --border: #E2E0D8; --text: #1A1A18; --accent: #185FA5; }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: var(--bg); color: var(--text); line-height: 1.7; font-size: 15px; }
+  .page { max-width: 800px; margin: 0 auto; padding: 40px 24px 80px; }
+  h1 { font-size: 28px; font-weight: 700; margin-bottom: 8px; }
+  h2 { font-size: 20px; font-weight: 600; margin: 32px 0 12px; padding-bottom: 8px; border-bottom: 1px solid var(--border); }
+  p { margin-bottom: 16px; }
+  .card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 20px; margin: 16px 0; }
+  .card .label { font-size: 11px; text-transform: uppercase; letter-spacing: 1px; color: #888; font-weight: 600; margin-bottom: 4px; }
+  .card .value { font-size: 16px; font-weight: 600; }
+  .diagram { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 20px; margin: 20px 0; }
+  .diagram-title { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px; color: #888; margin-bottom: 12px; }
+  code { font-family: "SFMono-Regular", Consolas, monospace; font-size: 13px; background: #F1EFE8; padding: 2px 6px; border-radius: 3px; }
+</style>
+</head>
+<body>
+<div class="page">
+  <h1>MarDoc Architecture Overview</h1>
+  <p>A browser-only PWA that transforms markdown review on GitHub into a rich document experience.</p>
+
+  <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin: 24px 0;">
+    <div class="card"><div class="label">Runtime</div><div class="value">Browser-only</div></div>
+    <div class="card"><div class="label">Framework</div><div class="value">Next.js 14</div></div>
+    <div class="card"><div class="label">Editor</div><div class="value">TipTap 2.11</div></div>
+  </div>
+
+  <h2>System Flow</h2>
+  <div class="diagram">
+    <div class="diagram-title">Request lifecycle</div>
+    <pre class="mermaid">
+flowchart LR
+  A["Browser"] -->|"GitHub API"| B["Octokit"]
+  B --> C["Repo Files"]
+  B --> D["Pull Requests"]
+  C --> E["TipTap Editor"]
+  D --> F["DiffViewer"]
+  E -->|"Turndown"| G["Markdown Commit"]
+  F --> H["Inline Comments"]
+  style A fill:#E6F1FB,stroke:#85B7EB,color:#0C447C
+  style B fill:#FAEEDA,stroke:#FAC775,color:#633806
+  style E fill:#E1F5EE,stroke:#5DCAA5,color:#085041
+  style F fill:#E1F5EE,stroke:#5DCAA5,color:#085041
+    </pre>
+  </div>
+
+  <h2>Key Design Decisions</h2>
+  <p><strong>Zero backend.</strong> Everything runs in the browser. Static export to GitHub Pages via Next.js. The GitHub API (via <code>Octokit</code>) is the only external dependency.</p>
+  <p><strong>Markdown-first.</strong> The source of truth is always <code>.md</code> files in a repo. The editor renders markdown but round-trips back to markdown for commits.</p>
+  <p><strong>Progressive enhancement.</strong> The app works in demo mode with zero config. Adding a GitHub PAT unlocks real repos.</p>
+</div>
+</body>
+</html>`;
+
+const MOCK_HTML_DOC_V2 = MOCK_HTML_DOC.replace(
+  "<h2>Key Design Decisions</h2>",
+  `<h2>HTML Document Support</h2>
+  <p><strong>New in v0.4:</strong> MarDoc now renders HTML documents alongside markdown. AI-generated reports, architecture guides, and styled documents render beautifully in the viewer.</p>
+
+  <h2>Key Design Decisions</h2>`
+);
+
 export const repoFiles: RepoFile[] = [
   {
     id: "1",
@@ -187,6 +262,13 @@ Generate a new token following the steps above, then update it in mardoc.app Set
 
 *Need help? Open an issue at [github.com/mardoc-io/mardoc-io.github.io](https://github.com/mardoc-io/mardoc-io.github.io/issues).*
 `,
+      },
+      {
+        id: "9",
+        name: "architecture-overview.html",
+        path: "docs/architecture-overview.html",
+        type: "file",
+        content: MOCK_HTML_DOC,
       },
       {
         id: "8",
@@ -704,6 +786,26 @@ The editor supports GitHub webhooks for real-time synchronization. Configure you
 ### Known Issues
 - GitHub API integration is mocked (coming in v0.2.0)
 - Real-time collaboration not yet supported`,
+      },
+    ],
+    comments: [],
+  },
+  {
+    id: "pr-4",
+    number: 37,
+    title: "Add architecture overview as HTML document",
+    author: "joe.barnett",
+    status: "open",
+    createdAt: "2026-04-05T09:00:00Z",
+    baseBranch: "main",
+    headBranch: "docs/html-architecture",
+    description: "Adds a rich HTML architecture overview with mermaid diagrams, styled cards, and visual layout — demonstrating MarDoc's new HTML rendering support.",
+    files: [
+      {
+        path: "docs/architecture-overview.html",
+        status: "modified",
+        baseContent: MOCK_HTML_DOC,
+        headContent: MOCK_HTML_DOC_V2,
       },
     ],
     comments: [],

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,4 +59,4 @@ export interface PendingSuggestion {
   endLine: number;
 }
 
-export type ViewMode = "editor" | "pr-list" | "pr-diff" | "pr-review";
+export type ViewMode = "editor" | "pr-list" | "pr-diff" | "pr-review" | "html-viewer";


### PR DESCRIPTION
## Summary
- HTML document rendering in file viewer and PR DiffViewer via sandboxed iframe
- Mermaid theme upgrade with custom light/dark palettes
- Fix TipTap stripping data-mermaid-source (broke mermaid round-trip on code view toggle)

## Test plan
- [ ] Demo mode: architecture-overview.html renders with mermaid
- [ ] Demo PR #37: Rendered/Source Diff modes for HTML
- [ ] Mermaid themed colors in light and dark mode
- [ ] Code view toggle preserves mermaid source
- [ ] npm run build succeeds