### PR TITLE
fix: preserve file view when embed init loads repo

### DIFF
--- a/docs/features/017-vscode-extension.md
+++ b/docs/features/017-vscode-extension.md
@@ -2,13 +2,13 @@
 
 ## Value
 
-MarDoc as a rich markdown editor and PR reviewer inside VS Code. The extension loads mardoc.app in a WebView, passes workspace context, and provides an "Edit with MarDoc" right-click action on markdown files. Git operations (commit, branch, push) stay in VS Code where they belong — MarDoc handles rendering, editing, and PR review.
+MarDoc as a rich document editor and PR reviewer inside VS Code. The extension loads mardoc.app in a WebView, passes workspace context, and provides an "Edit with MarDoc" right-click action on document files (markdown and HTML). Git operations (commit, branch, push) stay in VS Code where they belong — MarDoc handles rendering, editing, and PR review.
 
 ## Acceptance Criteria
 
 ### Extension
 - "MarDoc: Open" command launches mardoc.app in a WebView panel
-- "Edit with MarDoc" in the explorer context menu for `.md` / `.mdx` files — opens the file in MarDoc beside the editor
+- "Edit with MarDoc" in the explorer context menu for `.md`, `.mdx`, `.html`, `.htm` files — opens the file in MarDoc beside the editor
 - Extension detects workspace GitHub remote and branch from git
 - Extension gets a GitHub token via `vscode.authentication.getSession('github')`
 - On load, passes repo, branch, token, and theme to the app via `postMessage`
@@ -20,6 +20,7 @@ MarDoc as a rich markdown editor and PR reviewer inside VS Code. The extension l
 - PR tab stays — browse, review, diff, comment on PRs
 - Save writes to disk (via postMessage to extension), not to GitHub API
 - Auth section hidden when token is provided externally
+- HTML files route to HtmlViewer (sandboxed iframe), markdown files route to Editor — app-side routing already implemented
 
 ## Dependencies
 
@@ -33,6 +34,8 @@ MarDoc as a rich markdown editor and PR reviewer inside VS Code. The extension l
 - Message types: `ready` (app → extension), `init` (extension → app), `file:save` (app → extension)
 - Bridge module in the app detects embed mode, hides file tree, routes save to postMessage instead of GitHub API
 - Bridge is a no-op when not embedded — zero impact on the web app
+- The `init` message handler in `app-context.tsx` already detects HTML files and routes to HtmlViewer — the extension just sends `{ type: "init", fileName, fileContent, filePath }` regardless of file type
+- `package.json` context menu `when` clause: `resourceExtname =~ /\\.(md|mdx|html|htm)$/`
 
 ## Future Stories (not this one)
 

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1053,6 +1053,29 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
     }
   }, [repoFullName, isDemoMode, editor, filePath, isLocalFile, editFilePath, editPRTitle, codeView, codeContent, refreshRepo]);
 
+  // Save to disk via VS Code extension (embed mode only)
+  const [savingToDisk, setSavingToDisk] = useState(false);
+  const handleEmbeddedSave = useCallback(() => {
+    if (!editor || !isEmbedded) return;
+
+    let markdown: string;
+    if (codeView) {
+      markdown = codeContent;
+    } else {
+      const turndown = createTurndownService();
+      const html = editor.getHTML();
+      markdown = turndown.turndown(html);
+    }
+
+    // Resolve the file path — strip __local__/ prefix if present
+    const savePath = filePath.replace(/^__local__\//, "");
+
+    setSavingToDisk(true);
+    window.parent.postMessage({ type: "file:save", filePath: savePath, content: markdown }, "*");
+    setIsDirty(false);
+    setTimeout(() => setSavingToDisk(false), 500);
+  }, [editor, isEmbedded, codeView, codeContent, filePath]);
+
   // Click handler — intercept clicks on <a> and <img> tags in the editor
   const handleEditorClick = useCallback((e: React.MouseEvent) => {
     const el = e.target as HTMLElement;
@@ -1319,8 +1342,20 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
                 {isAddingToPR ? "Add to PR" : "Save to Repo"}
               </button>
             )}
-            {/* Submit edits as PR — when file is dirty */}
-            {!isNewFile && isDirty && !submittedPR && (
+            {/* Save to disk — embed mode */}
+            {isEmbedded && isDirty && (
+              <button
+                onClick={handleEmbeddedSave}
+                disabled={savingToDisk}
+                className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs rounded-md bg-[var(--accent)] text-white hover:bg-[var(--accent-hover)] disabled:opacity-50 transition-colors"
+                title="Save file to disk"
+              >
+                <Save size={13} />
+                {savingToDisk ? "Saving..." : "Save"}
+              </button>
+            )}
+            {/* Submit edits as PR — when file is dirty (non-embedded) */}
+            {!isEmbedded && !isNewFile && isDirty && !submittedPR && (
               <button
                 onClick={() => { const repoPath = isLocalFile ? (localFileName || "") : filePath; setEditPRTitle(`${isLocalFile ? "Add" : "Update"} ${repoPath}`); setEditFilePath(repoPath); setShowEditPRModal(true); }}
                 className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs rounded-md bg-[var(--accent)] text-white hover:bg-[var(--accent-hover)] transition-colors"

--- a/src/lib/app-context.tsx
+++ b/src/lib/app-context.tsx
@@ -164,6 +164,8 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     }
 
     if (data.fileName && data.fileContent) {
+      // Real file provided — exit demo mode even without a token
+      setIsDemoMode(false);
       const localPath = data.filePath || data.fileName;
       const localFile: RepoFile = {
         id: `local-${Date.now()}`,

--- a/src/lib/app-context.tsx
+++ b/src/lib/app-context.tsx
@@ -149,7 +149,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   // Embed mode: listen for postMessage from VS Code extension
-  const pendingInitRef = useRef<{ owner: string; repo: string; branch: string; token: string } | null>(null);
+  const pendingInitRef = useRef<{ owner: string; repo: string; branch: string; token: string; fileName?: string } | null>(null);
 
   const applyInitData = useCallback((data: Record<string, any>) => {
     setIsEmbedded(true);
@@ -282,12 +282,31 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     }
   }, [currentRepo, loadPRs]);
 
-  // Embed mode: process pending init repo after token and setCurrentRepo are ready
+  // Embed mode: process pending init repo after token and setCurrentRepo are ready.
+  // Preserve any file that was already opened by applyInitData.
   useEffect(() => {
     if (!pendingInitRef.current || !githubToken) return;
     const { owner, repo } = pendingInitRef.current;
+    const hadFile = !!pendingInitRef.current.fileName;
     pendingInitRef.current = null;
-    setCurrentRepo(`${owner}/${repo}`);
+
+    // Load repo context (file tree, PRs, branches) in background
+    setCurrentRepo(`${owner}/${repo}`).then(() => {
+      // setCurrentRepo may reset the view — restore if a file was opened
+      if (hadFile && vsCodeInitData?.fileName) {
+        const name = vsCodeInitData.fileName;
+        const localPath = vsCodeInitData.filePath || name;
+        setSelectedFile({
+          id: `local-${Date.now()}`,
+          name,
+          path: `__local__/${localPath}`,
+          type: "file",
+        });
+        setSelectedPR(null);
+        setCurrentView(isHtmlFile(name) ? "html-viewer" : "editor");
+        setFileContent(vsCodeInitData.fileContent || "");
+      }
+    });
   }, [githubToken, setCurrentRepo]);
 
   // Auto-restore: hash route wins over localStorage

--- a/src/lib/theme-context.tsx
+++ b/src/lib/theme-context.tsx
@@ -7,11 +7,13 @@ type Theme = "light" | "dark";
 
 interface ThemeContextType {
   theme: Theme;
+  setTheme: (theme: Theme) => void;
   toggleTheme: () => void;
 }
 
 const ThemeContext = createContext<ThemeContextType>({
   theme: "light",
+  setTheme: () => {},
   toggleTheme: () => {},
 });
 
@@ -27,6 +29,22 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
       setTheme("dark");
     }
+  }, []);
+
+  // Listen for theme messages from VS Code extension
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      const data = event.data;
+      if (!data) return;
+      if (data.type === "theme:change" && (data.theme === "light" || data.theme === "dark")) {
+        setTheme(data.theme);
+      }
+      if (data.type === "init" && (data.theme === "light" || data.theme === "dark")) {
+        setTheme(data.theme);
+      }
+    };
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
   }, []);
 
   useEffect(() => {
@@ -45,7 +63,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
       {children}
     </ThemeContext.Provider>
   );


### PR DESCRIPTION
## Summary
When the VS Code extension sends both a file AND repo context in the init message, `setCurrentRepo` was resetting the view after `applyInitData` had already opened the file. Now restores the selected file after repo loading completes.

## Test plan
- [ ] Right-click HTML/MD file in VS Code → Edit with MarDoc → file renders (not welcome screen)
- [ ] PR list still loads in sidebar while file is displayed