### PR TITLE
fix: re-render mermaid diagrams after comment poll updates DOM

### DIFF
--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -743,12 +743,15 @@ export default function DiffViewer({
   const contentRef = useRef<HTMLDivElement>(null);
   const htmlIframeRef = useRef<HTMLIFrameElement>(null);
   const commentInputRef = useRef<HTMLInputElement>(null);
-  // Post-render: fetch private repo images and render mermaid diagrams (markdown only)
+  // Post-render: fetch private repo images and render mermaid diagrams (markdown only).
+  // Must re-run when comments change because renderBlockHtml injects highlight marks,
+  // which causes React to replace the dangerouslySetInnerHTML DOM — wiping any
+  // previously rendered mermaid SVGs.
   useEffect(() => {
     if (!contentRef.current || fileIsHtml) return;
     loadAuthenticatedImages(contentRef.current);
     renderMermaidBlocks(contentRef.current);
-  }, [file, viewMode, fileIsHtml]);
+  }, [file, viewMode, fileIsHtml, comments]);
 
   // Listen for iframe resize messages (HTML file rendering)
   useEffect(() => {


### PR DESCRIPTION
## Summary

- The 30-second comment polling in PRDetail triggers React to re-apply `dangerouslySetInnerHTML` on diff blocks (because `renderBlockHtml` depends on comments for highlight marks). This wipes Mermaid SVGs that were injected via direct DOM manipulation by `renderMermaidBlocks()`.
- The useEffect that calls `renderMermaidBlocks` only depended on `[file, viewMode, fileIsHtml]`, so it never re-ran after comment-triggered DOM updates.
- Adds `comments` to the dependency array so Mermaid diagrams are re-rendered after each comment poll cycle.

## Test plan

- [ ] Open a PR containing a mermaid diagram
- [ ] Verify diagram renders correctly on load
- [ ] Wait 30+ seconds for comment poll to fire — diagram should remain rendered
- [ ] Add a comment, verify diagram still renders after comment updates