### PR TITLE
fix: re-render mermaid + restore list styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -87,8 +87,12 @@ body {
 .ProseMirror h2 { font-size: 1.5em; font-weight: 600; margin: 0.8em 0 0.4em; }
 .ProseMirror h3 { font-size: 1.25em; font-weight: 600; margin: 0.6em 0 0.3em; }
 
-.ProseMirror ul,
+.ProseMirror ul {
+  list-style-type: disc;
+  padding-left: 1.5em;
+}
 .ProseMirror ol {
+  list-style-type: decimal;
   padding-left: 1.5em;
 }
 
@@ -213,6 +217,21 @@ body {
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   margin: 1em 0;
+}
+
+/* List styles in diff content (Tailwind preflight strips defaults) */
+.diff-content ul {
+  list-style-type: disc;
+  padding-left: 1.5em;
+  margin: 0.5em 0;
+}
+.diff-content ol {
+  list-style-type: decimal;
+  padding-left: 1.5em;
+  margin: 0.5em 0;
+}
+.diff-content li {
+  margin: 0.25em 0;
 }
 
 /* Code blocks in diff content */

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -743,12 +743,15 @@ export default function DiffViewer({
   const contentRef = useRef<HTMLDivElement>(null);
   const htmlIframeRef = useRef<HTMLIFrameElement>(null);
   const commentInputRef = useRef<HTMLInputElement>(null);
-  // Post-render: fetch private repo images and render mermaid diagrams (markdown only)
+  // Post-render: fetch private repo images and render mermaid diagrams (markdown only).
+  // Must re-run when comments change because renderBlockHtml injects highlight marks,
+  // which causes React to replace the dangerouslySetInnerHTML DOM — wiping any
+  // previously rendered mermaid SVGs.
   useEffect(() => {
     if (!contentRef.current || fileIsHtml) return;
     loadAuthenticatedImages(contentRef.current);
     renderMermaidBlocks(contentRef.current);
-  }, [file, viewMode, fileIsHtml]);
+  }, [file, viewMode, fileIsHtml, comments]);
 
   // Listen for iframe resize messages (HTML file rendering)
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Re-render mermaid diagrams after comment poll updates the DOM
- Restore bullet and numbered list styling in both the TipTap editor and DiffViewer — Tailwind's preflight strips `list-style-type` from all `ul`/`ol` elements, and the scoped CSS never added it back

## Test plan
- [ ] Open a PR containing markdown with bullet lists — verify bullets render in the diff view
- [ ] Open a PR containing markdown with numbered lists — verify numbers render
- [ ] Open a file with lists in the editor — verify bullets/numbers render
- [ ] Verify mermaid diagrams re-render after comment poll updates
- [ ] Check both light and dark themes