### PR TITLE
chore: relicense from MIT to Elastic License 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,97 @@
+Elastic License 2.0 (ELv2)
+
+Acceptance
+
+By using the software, you agree to all of the terms and conditions
+below.
+
+Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute,
+make available, and prepare derivative works of the software, in each
+case subject to the limitations and conditions below.
+
+Limitations
+
+You may not provide the software to third parties as a hosted or
+managed service, where the service provides users with access to any
+substantial set of the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key
+functionality in the software, and you may not remove or obscure any
+functionality in the software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or
+other notices of the licensor in the software. Any use of the
+licensor's trademarks is subject to applicable law.
+
+Patents
+
+The licensor grants you a license, under any patent claims the
+licensor can license, or becomes able to license, to make, have made,
+use, sell, offer for sale, import and have imported the software, in
+each case subject to the limitations and conditions in this license.
+This license does not cover any patent claims that you cause to be
+infringed by modifications or additions to the software. If you or
+your company make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your
+company makes such a claim, your patent license ends immediately for
+work on behalf of your company.
+
+Notices
+
+You must ensure that anyone who gets a copy of any part of the
+software from you also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies
+of the software prominent notices stating that you have modified the
+software.
+
+No Other Rights
+
+These terms do not imply any licenses other than those expressly
+granted in these terms.
+
+Termination
+
+If you use the software in violation of these terms, such use is not
+licensed, and your licenses will automatically terminate. If the
+licensor provides you with a notice of your violation, and you cease
+all violation of this license no later than 30 days after you receive
+that notice, your licenses will be reinstated retroactively. However,
+if you violate these terms after such reinstatement, any additional
+violation of these terms will cause your licenses to terminate
+automatically and permanently.
+
+No Liability
+
+As far as the law allows, the software comes as is, without any
+warranty or condition, and the licensor will not be liable to you for
+any damages arising out of these terms or the use or nature of the
+software, under any kind of legal claim.
+
+Definitions
+
+The "licensor" is the entity offering these terms, and the "software"
+is the software the licensor makes available under these terms,
+including any portion of it.
+
+"you" refers to the individual or entity agreeing to these terms.
+
+"your company" is any legal entity, sole proprietorship, or other
+kind of organization that you work for, plus all organizations that
+have control over, are under the control of, or are under common
+control with that organization. "control" means ownership of
+substantially all the assets of an entity, or the power to direct its
+management and policies by vote, contract, or otherwise. Control can
+be direct or indirect.
+
+"your licenses" are all the licenses granted to you for the software
+under these terms.
+
+"use" means anything you do with the software requiring one of your
+licenses.
+
+"trademark" means trademarks, service marks, and similar rights.

--- a/README.md
+++ b/README.md
@@ -63,4 +63,12 @@ Next.js 14, TipTap, Showdown, Octokit, and Tailwind CSS. Hosted on GitHub Pages.
 
 ## License
 
-MIT
+[Elastic License 2.0](./LICENSE) (ELv2).
+
+Source is available. You can read it, run it locally, self-host it
+for your own internal use, fork it, and contribute back. You
+**cannot** provide MarDoc to third parties as a hosted or managed
+service — that's a commercial right reserved for the maintainers.
+
+See [elastic.co/licensing/elastic-license](https://www.elastic.co/licensing/elastic-license)
+for the canonical text and FAQ.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "markdoc-editor",
   "version": "0.1.0",
   "private": true,
+  "license": "Elastic-2.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary

Switches MarDoc from MIT to **Elastic License 2.0** (ELv2), a source-available license with an explicit non-compete clause.

**What changes for users:**
- Anyone can still read the code, run it locally, self-host it for internal use, fork it, and contribute back.
- **Nobody else can ship MarDoc to third parties as a hosted or managed service.** That commercial right stays with the maintainers.
- Source remains fully visible. The project does not become closed source.

**Why:**
MIT means the first well-capitalized dev-tools company (GitHub, Microsoft, Google, Notion, Atlassian) could fork MarDoc, reskin it, and run it as a paid hosted service with zero obligation to the project. That's a real risk as the audience grows and it closes off the subscription monetization path. ELv2 preserves the source-available trust story the project needs (AI-generated docs in source control — users want to see the code, trust it won't disappear, and contribute back) while keeping the "ship it as a service" commercial right with the maintainers.

**Why ELv2 specifically (vs FSL, AGPL, BSL, Commons Clause):**
- **AGPL** — network-use clause barely triggers for a browser-only PWA, so the protection is weak in practice.
- **FSL / BSL** — time-bounded non-compete that auto-converts to Apache/MIT. Fine if you want eventual OSI-open-source; wrong when you want the non-compete to last the life of the project.
- **Commons Clause** — legally fuzzy, not well-tested.
- **ELv2** — permanent non-compete, source-available forever, battle-tested (Elastic, Redis, MinIO, Sentry), and the specific hosted-service clause maps cleanly onto MarDoc's threat model.

## What changed

- **`LICENSE`** added at repo root with the canonical ELv2 text from https://www.elastic.co/licensing/elastic-license.
- **`package.json`** — `"license": "Elastic-2.0"` (the SPDX identifier).
- **`README.md`** — License section now explains ELv2, what is and isn't allowed, and links to the canonical page for authoritative text.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 190 passed | 2 expected fail (no test changes)
- [ ] Verify `LICENSE` renders correctly on the repo root page
- [ ] Verify the README License section renders the link correctly