### PR TITLE
feat: word count + reading time indicator

### DIFF
--- a/src/__tests__/word-count.test.ts
+++ b/src/__tests__/word-count.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for the word count + reading time helpers. Pure functions, tested
+ * before implementation so the contract is defined by the tests and not the
+ * code.
+ *
+ * Reading time uses a standard 200 words-per-minute, rounded up to the
+ * nearest whole minute, with a floor of 1 minute for any non-empty content.
+ */
+import { describe, it, expect } from "vitest";
+import { countWords, readingMinutes, analyzeMarkdown } from "@/lib/word-count";
+
+describe("countWords", () => {
+  // ─── Trivial ────────────────────────────────────────────────────────────
+
+  it("returns 0 for empty input", () => {
+    expect(countWords("")).toBe(0);
+  });
+
+  it("returns 0 for whitespace-only input", () => {
+    expect(countWords("   \n\t  \n")).toBe(0);
+  });
+
+  it("counts a single word", () => {
+    expect(countWords("hello")).toBe(1);
+  });
+
+  it("counts multiple space-separated words", () => {
+    expect(countWords("the quick brown fox")).toBe(4);
+  });
+
+  it("counts words separated by tabs and newlines", () => {
+    expect(countWords("one\ttwo\nthree")).toBe(3);
+  });
+
+  // ─── Markdown syntax (the whole point) ─────────────────────────────────
+
+  it("strips heading markers from word count", () => {
+    // "# Heading" should count as 1 word (Heading), not 2.
+    expect(countWords("# Heading")).toBe(1);
+    expect(countWords("## A Longer Heading")).toBe(3);
+  });
+
+  it("strips bold and italic markers", () => {
+    expect(countWords("**bold** word")).toBe(2);
+    expect(countWords("_italic_ word")).toBe(2);
+    expect(countWords("a **bold** b _italic_ c")).toBe(5);
+  });
+
+  it("strips inline code backticks but counts the content", () => {
+    expect(countWords("use `foo.bar()` here")).toBe(3);
+  });
+
+  it("excludes fenced code block content entirely", () => {
+    // Code blocks should not pad the word count — a README with a huge
+    // code example shouldn't claim a 20-minute read.
+    const md = "before\n\n```js\nconst x = 1;\nconsole.log(x);\n```\n\nafter";
+    expect(countWords(md)).toBe(2); // "before" + "after"
+  });
+
+  it("excludes indented code blocks", () => {
+    const md = "before\n\n    indented code\n    more code\n\nafter";
+    expect(countWords(md)).toBe(2);
+  });
+
+  it("counts link text but not URLs", () => {
+    expect(countWords("see [the docs](https://example.com/docs) here")).toBe(4);
+  });
+
+  it("ignores image alt text and URLs", () => {
+    // Images are visual; their alt is a11y metadata, not prose.
+    expect(countWords("before ![alt text](img.png) after")).toBe(2);
+  });
+
+  it("counts list items without the bullet", () => {
+    const md = "- item one\n- item two\n- item three";
+    expect(countWords(md)).toBe(6);
+  });
+
+  it("counts numbered list items without the numbers", () => {
+    const md = "1. first item\n2. second item\n3. third item";
+    expect(countWords(md)).toBe(6);
+  });
+
+  it("counts blockquote content", () => {
+    expect(countWords("> quoted text here")).toBe(3);
+  });
+
+  it("strips horizontal rules", () => {
+    expect(countWords("before\n\n---\n\nafter")).toBe(2);
+  });
+
+  it("counts table cell text without pipes or separators", () => {
+    const md = "| col a | col b |\n| --- | --- |\n| foo | bar |";
+    expect(countWords(md)).toBe(6);
+  });
+
+  it("counts URLs as one word when they appear in plain text", () => {
+    // A plain-text URL is a single token. We don't try to parse it out.
+    expect(countWords("visit https://example.com please")).toBe(3);
+  });
+
+  it("ignores HTML comments", () => {
+    expect(countWords("before <!-- hidden --> after")).toBe(2);
+  });
+
+  it("counts text inside ordinary HTML tags", () => {
+    expect(countWords("before <b>bold</b> after")).toBe(3);
+  });
+
+  // ─── Real documents ─────────────────────────────────────────────────────
+
+  it("counts a realistic mixed document", () => {
+    const md = [
+      "# Introduction",
+      "",
+      "This is the **first** paragraph of the document.",
+      "",
+      "## Code example",
+      "",
+      "```ts",
+      "const x = 42;",
+      "```",
+      "",
+      "- bullet one",
+      "- bullet two with [a link](https://example.com)",
+    ].join("\n");
+    // "Introduction" (1) + "This is the first paragraph of the document." (8)
+    // + "Code example" (2) + "bullet one" (2) + "bullet two with a link" (5) = 18
+    expect(countWords(md)).toBe(18);
+  });
+});
+
+describe("readingMinutes", () => {
+  it("returns 0 for 0 words", () => {
+    expect(readingMinutes(0)).toBe(0);
+  });
+
+  it("returns 1 for any non-zero count below 200 words", () => {
+    expect(readingMinutes(1)).toBe(1);
+    expect(readingMinutes(50)).toBe(1);
+    expect(readingMinutes(199)).toBe(1);
+  });
+
+  it("returns 1 for exactly 200 words", () => {
+    expect(readingMinutes(200)).toBe(1);
+  });
+
+  it("rounds up at the first word over the 200wpm boundary", () => {
+    expect(readingMinutes(201)).toBe(2);
+  });
+
+  it("rounds up for fractional minutes", () => {
+    expect(readingMinutes(500)).toBe(3); // 2.5 → 3
+    expect(readingMinutes(1000)).toBe(5);
+  });
+
+  it("handles large counts", () => {
+    expect(readingMinutes(5000)).toBe(25);
+  });
+});
+
+describe("analyzeMarkdown (convenience wrapper)", () => {
+  it("returns both words and reading minutes in one call", () => {
+    const md = "one two three four five six seven eight nine ten";
+    expect(analyzeMarkdown(md)).toEqual({ words: 10, readingMinutes: 1 });
+  });
+
+  it("returns 0/0 for an empty document", () => {
+    expect(analyzeMarkdown("")).toEqual({ words: 0, readingMinutes: 0 });
+  });
+
+  it("handles a longer document with code blocks and formatting", () => {
+    const md = [
+      "# Title",
+      "",
+      "Paragraph with **bold** and _italic_.",
+      "",
+      "```",
+      "lots of code that should not count",
+      "```",
+    ].join("\n");
+    // "Title" (1) + "Paragraph with bold and italic" (5) = 6 words
+    const result = analyzeMarkdown(md);
+    expect(result.words).toBe(6);
+    expect(result.readingMinutes).toBe(1);
+  });
+});

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -43,6 +43,7 @@ import {
   reconcileDraft,
   resolveDraftOnLoad,
 } from "@/lib/draft-store";
+import { analyzeMarkdown, type MarkdownStats } from "@/lib/word-count";
 import { classifyLink, resolvePath, findFileByPath } from "@/lib/link-handler";
 import { useApp } from "@/lib/app-context";
 import { openExternal } from "@/lib/open-external";
@@ -657,6 +658,10 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
   const [codeContent, setCodeContent] = useState("");
   const codeTextareaRef = useRef<HTMLTextAreaElement>(null);
 
+  // Word count + reading time — displayed in the toolbar. Recomputed in the
+  // same debounce tick as the dirty check so we don't run Turndown twice.
+  const [stats, setStats] = useState<MarkdownStats>({ words: 0, readingMinutes: 0 });
+
   // Dirty tracking for existing files — compare current markdown to original
   const [isDirty, setIsDirty] = useState(false);
   const originalMarkdownRef = useRef<string | null>(null);
@@ -751,6 +756,7 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
         const currentMd = turndown.turndown(editor.getHTML());
         const { dirty } = reconcileDraft(scope, originalMarkdownRef.current, currentMd);
         setIsDirty(dirty);
+        setStats(analyzeMarkdown(currentMd));
       }, 300);
     },
     editorProps: {
@@ -774,6 +780,8 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
           // Capture baseline markdown for dirty comparison
           const turndown = createTurndownService();
           originalMarkdownRef.current = turndown.turndown(editor.getHTML());
+          // Initialize the word-count display from the loaded content.
+          setStats(analyzeMarkdown(originalMarkdownRef.current));
 
           // Check for a locally-saved draft that differs from upstream — if
           // found, offer to restore it. resolveDraftOnLoad handles the
@@ -1467,6 +1475,16 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
             {submitError && (
               <span className="text-xs text-red-500 px-2">{submitError}</span>
             )}
+            {/* Word count + reading time. Hidden for empty documents so an
+                empty new-file toolbar doesn't carry "0 words". */}
+            {stats.words > 0 && (
+              <span
+                className="hidden sm:inline text-[10px] text-[var(--text-muted)] font-mono px-1.5 select-none"
+                title={`${stats.words.toLocaleString()} words · ~${stats.readingMinutes} min read`}
+              >
+                {stats.words.toLocaleString()} words · {stats.readingMinutes} min
+              </span>
+            )}
             <button
               onClick={toggleCodeView}
               className={`flex items-center gap-1 px-2 py-1 text-[11px] rounded-md transition-colors ${
@@ -1619,6 +1637,7 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
                     next
                   );
                   setIsDirty(dirty);
+                  setStats(analyzeMarkdown(next));
                 }}
                 onKeyDown={handleCodeViewKeyDown}
                 className="w-full min-h-[60vh] p-4 font-mono text-sm leading-relaxed bg-[var(--surface-secondary)] text-[var(--text-primary)] border border-[var(--border)] rounded-lg resize-y focus:outline-none focus:border-[var(--accent)]"

--- a/src/lib/word-count.ts
+++ b/src/lib/word-count.ts
@@ -1,0 +1,100 @@
+/**
+ * Word count + reading time for markdown documents.
+ *
+ * Not perfect — a full markdown parser would be more accurate, but we want a
+ * cheap pure function that runs on every keystroke without a heavy AST pass.
+ * The strategy is: strip markdown syntax and code blocks out of the source,
+ * then count whitespace-delimited tokens in what's left.
+ *
+ * Reading time uses a standard 200 words-per-minute, rounded up to the
+ * nearest whole minute, with a floor of 1 minute for any non-empty content.
+ *
+ * Pure — no DOM, no editor, no side effects. Tested in word-count.test.ts.
+ */
+
+const WORDS_PER_MINUTE = 200;
+
+export function countWords(markdown: string): number {
+  if (!markdown) return 0;
+  const stripped = stripMarkdown(markdown);
+  const trimmed = stripped.trim();
+  if (!trimmed) return 0;
+  return trimmed.split(/\s+/).length;
+}
+
+export function readingMinutes(words: number): number {
+  if (words <= 0) return 0;
+  return Math.max(1, Math.ceil(words / WORDS_PER_MINUTE));
+}
+
+export interface MarkdownStats {
+  words: number;
+  readingMinutes: number;
+}
+
+export function analyzeMarkdown(markdown: string): MarkdownStats {
+  const words = countWords(markdown);
+  return { words, readingMinutes: readingMinutes(words) };
+}
+
+/**
+ * Strip markdown syntax and content that shouldn't count toward the word
+ * count (fenced and indented code blocks, image alt text, URLs, HTML
+ * comments, heading/list/blockquote markers, table pipes, horizontal rules).
+ * Leaves behind plain text that can be tokenized by whitespace.
+ */
+function stripMarkdown(md: string): string {
+  let s = md;
+
+  // HTML comments — drop entirely.
+  s = s.replace(/<!--[\s\S]*?-->/g, " ");
+
+  // Fenced code blocks — drop entirely. Match any fence length >= 3 so
+  // nested ``` inside longer outer fences are handled.
+  s = s.replace(/^(`{3,})[^\n]*\n[\s\S]*?\n\1/gm, " ");
+
+  // Indented code blocks — lines starting with 4+ spaces or a tab.
+  // Conservative: only strips if the line is in a "block" position, which
+  // we approximate by requiring the previous line to be blank or start-of-
+  // document. For the word-count use case being slightly aggressive is OK.
+  s = s.replace(/(^|\n)(?: {4,}|\t)[^\n]*/g, "$1");
+
+  // Images — drop alt text and URL entirely. Do this before links so an
+  // image inside a link paragraph is cleanly removed.
+  s = s.replace(/!\[[^\]]*\]\([^)]*\)/g, " ");
+
+  // Links — keep the link text, drop the URL.
+  s = s.replace(/\[([^\]]+)\]\([^)]*\)/g, "$1");
+
+  // Reference-style links — keep the text, drop the reference.
+  s = s.replace(/\[([^\]]+)\]\[[^\]]*\]/g, "$1");
+
+  // Heading markers (# to ######) at start of line.
+  s = s.replace(/^#{1,6}\s+/gm, "");
+
+  // Blockquote markers.
+  s = s.replace(/^\s*>\s?/gm, "");
+
+  // Unordered list bullets.
+  s = s.replace(/^\s*[-*+]\s+/gm, "");
+
+  // Ordered list numbers.
+  s = s.replace(/^\s*\d+\.\s+/gm, "");
+
+  // Horizontal rules — lines of only -, _, or * (3+).
+  s = s.replace(/^\s*([-_*])\1{2,}\s*$/gm, " ");
+
+  // Table separators — lines of only |, -, :, and whitespace.
+  s = s.replace(/^\s*\|?[\s|:\-]+\|?\s*$/gm, " ");
+
+  // Table pipes — keep cell content, drop the delimiters.
+  s = s.replace(/\|/g, " ");
+
+  // Bold / italic / strikethrough markers (but keep the content).
+  s = s.replace(/(\*{1,3}|_{1,3}|~{2})/g, "");
+
+  // Inline code — drop the backticks but keep the content.
+  s = s.replace(/`([^`]+)`/g, "$1");
+
+  return s;
+}


### PR DESCRIPTION
## Summary

First item from the P1a editor table-stakes list: a small word count + reading time indicator in the editor toolbar.

## What changed

New pure helper `src/lib/word-count.ts` with three functions:

- `countWords(markdown)` — strips markdown syntax and code blocks, tokenizes on whitespace.
- `readingMinutes(words)` — 200 WPM, rounded up, minimum 1 minute for any non-empty document.
- `analyzeMarkdown(markdown)` — convenience wrapper returning both.

`Editor.tsx` wires the helper into the existing debounced `onUpdate` tick (no extra Turndown pass), the code-view textarea `onChange`, and the file-load `useEffect` so the label is correct before the user types. The label hides when `words === 0` so an empty new-file toolbar doesn't show "0 words · 0 min", and is hidden on narrow viewports via `sm:inline` to avoid toolbar wrap.

## Tests

Test-first: the contract was defined in `word-count.test.ts` before a line of implementation existed. 30 tests total, covering:

- Trivial: empty, whitespace-only, single/multi-word
- Markdown syntax stripping: headings, bold, italic, inline code, fenced code blocks, indented code blocks, links, images, list bullets, numbered lists, blockquotes, horizontal rules, tables, plain-text URLs, HTML comments, HTML tags
- Reading time rounding: 0, <200, =200, >200, fractional, large counts
- Realistic mixed document with exact expected count

**Test count:** 190 → 220 (+30). Build clean.

## Test plan

- [ ] Open an existing markdown file in the editor → toolbar shows "N words · N min" on the right
- [ ] Type content → count updates ~300ms after typing stops
- [ ] Switch to code view → count stays in sync when editing raw markdown
- [ ] New empty file → no "0 words" label shown (hidden when words=0)
- [ ] File with only a heading and a paragraph → count excludes `#` markers
- [ ] File with a large code block → reading time doesn't balloon (code excluded from count)
- [ ] Narrow viewport (mobile) → label hidden to keep the toolbar from wrapping