### PR TITLE
feat: keyboard cheatsheet (press ?)

### DIFF
--- a/src/__tests__/keyboard-shortcuts.test.ts
+++ b/src/__tests__/keyboard-shortcuts.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for the keyboard shortcut registry and cheatsheet helpers.
+ *
+ * The cheatsheet itself is a modal UI (opened with `?`), but all the
+ * interesting behavior is in the pure functions that back it: the static
+ * shortcut registry, grouping, filtering, and the predicate that decides
+ * whether a `?` keypress should actually open the modal (we bail when the
+ * user is typing in an input or editor so we don't steal their "?").
+ *
+ * Pure — no DOM mounting, no React.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  ALL_SHORTCUTS,
+  groupByCategory,
+  filterShortcuts,
+  shouldOpenCheatsheet,
+  type Shortcut,
+} from "@/lib/keyboard-shortcuts";
+
+describe("ALL_SHORTCUTS registry", () => {
+  it("is a non-empty list", () => {
+    expect(ALL_SHORTCUTS.length).toBeGreaterThan(0);
+  });
+
+  it("every entry has keys, description, and category", () => {
+    for (const s of ALL_SHORTCUTS) {
+      expect(s.keys.length).toBeGreaterThan(0);
+      expect(s.description.length).toBeGreaterThan(0);
+      expect(s.category.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("includes the canonical editor formatting shortcuts", () => {
+    const descriptions = ALL_SHORTCUTS.map((s) => s.description.toLowerCase());
+    expect(descriptions.some((d) => d.includes("bold"))).toBe(true);
+    expect(descriptions.some((d) => d.includes("italic"))).toBe(true);
+    expect(descriptions.some((d) => d.includes("undo"))).toBe(true);
+    expect(descriptions.some((d) => d.includes("redo"))).toBe(true);
+  });
+
+  it("includes the cheatsheet itself (`?` → open)", () => {
+    const entry = ALL_SHORTCUTS.find((s) =>
+      s.description.toLowerCase().includes("cheatsheet") ||
+      s.description.toLowerCase().includes("shortcut")
+    );
+    expect(entry).toBeDefined();
+    expect(entry!.keys).toContain("?");
+  });
+});
+
+// ─── groupByCategory ───────────────────────────────────────────────────
+
+describe("groupByCategory", () => {
+  const sample: Shortcut[] = [
+    { keys: ["⌘", "B"], description: "Bold", category: "Editor" },
+    { keys: ["⌘", "I"], description: "Italic", category: "Editor" },
+    { keys: ["j"], description: "Next file", category: "Review" },
+    { keys: ["k"], description: "Previous file", category: "Review" },
+  ];
+
+  it("groups shortcuts by their category", () => {
+    const grouped = groupByCategory(sample);
+    expect(Object.keys(grouped).sort()).toEqual(["Editor", "Review"]);
+    expect(grouped.Editor).toHaveLength(2);
+    expect(grouped.Review).toHaveLength(2);
+  });
+
+  it("preserves the order of shortcuts within each category", () => {
+    const grouped = groupByCategory(sample);
+    expect(grouped.Editor.map((s) => s.description)).toEqual(["Bold", "Italic"]);
+    expect(grouped.Review.map((s) => s.description)).toEqual(["Next file", "Previous file"]);
+  });
+
+  it("returns an empty object for empty input", () => {
+    expect(groupByCategory([])).toEqual({});
+  });
+});
+
+// ─── filterShortcuts ───────────────────────────────────────────────────
+
+describe("filterShortcuts", () => {
+  const sample: Shortcut[] = [
+    { keys: ["⌘", "B"], description: "Bold", category: "Editor" },
+    { keys: ["⌘", "I"], description: "Italic", category: "Editor" },
+    { keys: ["⌘", "K"], description: "Insert link", category: "Editor" },
+    { keys: ["?"], description: "Open keyboard cheatsheet", category: "Help" },
+  ];
+
+  it("returns all shortcuts for an empty query", () => {
+    expect(filterShortcuts(sample, "")).toHaveLength(4);
+    expect(filterShortcuts(sample, "   ")).toHaveLength(4);
+  });
+
+  it("filters by description substring", () => {
+    expect(filterShortcuts(sample, "bold")).toHaveLength(1);
+    expect(filterShortcuts(sample, "link")).toHaveLength(1);
+  });
+
+  it("is case-insensitive", () => {
+    expect(filterShortcuts(sample, "BOLD")).toHaveLength(1);
+    expect(filterShortcuts(sample, "Italic")).toHaveLength(1);
+  });
+
+  it("filters by key character", () => {
+    // Searching for "K" should match the Insert link shortcut (⌘K).
+    const matches = filterShortcuts(sample, "K");
+    expect(matches.some((s) => s.description === "Insert link")).toBe(true);
+  });
+
+  it("filters by category name", () => {
+    const matches = filterShortcuts(sample, "help");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].description).toContain("cheatsheet");
+  });
+
+  it("returns empty when nothing matches", () => {
+    expect(filterShortcuts(sample, "xyzzy")).toEqual([]);
+  });
+
+  it("matches a partial word in the middle of a description", () => {
+    expect(filterShortcuts(sample, "heet")).toHaveLength(1);
+  });
+});
+
+// ─── shouldOpenCheatsheet ─────────────────────────────────────────────
+
+describe("shouldOpenCheatsheet", () => {
+  function mockEvent(key: string, targetTag?: string, isContentEditable = false): any {
+    const target: any = {
+      tagName: targetTag,
+      isContentEditable,
+    };
+    return { key, target };
+  }
+
+  it("opens when `?` is pressed on the body", () => {
+    expect(shouldOpenCheatsheet(mockEvent("?", "BODY"))).toBe(true);
+  });
+
+  it("opens when `?` is pressed with no specific tag (document-level)", () => {
+    expect(shouldOpenCheatsheet(mockEvent("?"))).toBe(true);
+  });
+
+  it("does NOT open for a non-question key", () => {
+    expect(shouldOpenCheatsheet(mockEvent("a", "BODY"))).toBe(false);
+    expect(shouldOpenCheatsheet(mockEvent("/", "BODY"))).toBe(false);
+    expect(shouldOpenCheatsheet(mockEvent("Enter", "BODY"))).toBe(false);
+  });
+
+  it("does NOT open when typing in an <input>", () => {
+    // Otherwise asking a question in a comment would accidentally open the
+    // cheatsheet. The modal is a global UI concern — bail inside any text
+    // entry surface.
+    expect(shouldOpenCheatsheet(mockEvent("?", "INPUT"))).toBe(false);
+  });
+
+  it("does NOT open when typing in a <textarea>", () => {
+    expect(shouldOpenCheatsheet(mockEvent("?", "TEXTAREA"))).toBe(false);
+  });
+
+  it("does NOT open when typing in a contenteditable element (TipTap)", () => {
+    // The rich editor is contenteditable — pressing `?` there means
+    // inserting a question mark into the document, not opening a modal.
+    expect(shouldOpenCheatsheet(mockEvent("?", "DIV", true))).toBe(false);
+  });
+
+  it("does NOT open when typing in a <select>", () => {
+    expect(shouldOpenCheatsheet(mockEvent("?", "SELECT"))).toBe(false);
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useApp } from "@/lib/app-context";
 import Sidebar from "@/components/Sidebar";
 import Editor from "@/components/Editor";
@@ -9,6 +9,8 @@ import PRDetail from "@/components/PRDetail";
 import PRReview from "@/components/PRReview";
 import SettingsPanel from "@/components/SettingsPanel";
 import ThemeToggle from "@/components/ThemeToggle";
+import KeyboardCheatsheet from "@/components/KeyboardCheatsheet";
+import { shouldOpenCheatsheet } from "@/lib/keyboard-shortcuts";
 import {
   BookOpen,
   Settings,
@@ -16,6 +18,7 @@ import {
   GitPullRequest,
   Loader2,
   AlertCircle,
+  Keyboard,
 } from "lucide-react";
 
 export default function Home() {
@@ -38,6 +41,22 @@ export default function Home() {
   } = useApp();
 
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [cheatsheetOpen, setCheatsheetOpen] = useState(false);
+
+  // Global `?` opens the keyboard cheatsheet. shouldOpenCheatsheet is a
+  // pure predicate tested in keyboard-shortcuts.test.ts — it bails when
+  // the user is typing in an input / textarea / contenteditable so we
+  // never steal their "?" character.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (shouldOpenCheatsheet({ key: e.key, target: e.target as any })) {
+        e.preventDefault();
+        setCheatsheetOpen(true);
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
 
   return (
     <div className="h-screen flex flex-col">
@@ -68,6 +87,16 @@ export default function Home() {
               <AlertCircle size={12} />
               <span className="max-w-48 truncate">{error}</span>
             </div>
+          )}
+          {!isEmbedded && (
+            <button
+              onClick={() => setCheatsheetOpen(true)}
+              className="toolbar-btn"
+              title="Keyboard shortcuts (?)"
+              aria-label="Keyboard shortcuts"
+            >
+              <Keyboard size={16} />
+            </button>
           )}
           {!isEmbedded && (
             <button
@@ -183,6 +212,9 @@ export default function Home() {
 
       {/* Settings modal */}
       <SettingsPanel isOpen={settingsOpen} onClose={() => setSettingsOpen(false)} />
+
+      {/* Keyboard cheatsheet (triggered by `?`) */}
+      <KeyboardCheatsheet open={cheatsheetOpen} onClose={() => setCheatsheetOpen(false)} />
     </div>
   );
 }

--- a/src/components/KeyboardCheatsheet.tsx
+++ b/src/components/KeyboardCheatsheet.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { X, Keyboard } from "lucide-react";
+import {
+  ALL_SHORTCUTS,
+  filterShortcuts,
+  groupByCategory,
+} from "@/lib/keyboard-shortcuts";
+
+interface KeyboardCheatsheetProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Filterable keyboard shortcut reference, opened by pressing `?` anywhere
+ * that isn't a text-entry surface. Pure data comes from
+ * @/lib/keyboard-shortcuts — this component is just a shell around the
+ * registry so the data is unit-testable without mounting React.
+ */
+export default function KeyboardCheatsheet({ open, onClose }: KeyboardCheatsheetProps) {
+  const [query, setQuery] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Reset query every time the modal reopens so the next session starts
+  // from a clean slate — and focus the search input for keyboard-first use.
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      // Wait a tick for the modal to mount before focusing.
+      const t = setTimeout(() => inputRef.current?.focus(), 0);
+      return () => clearTimeout(t);
+    }
+  }, [open]);
+
+  // Esc closes the modal. We only mount this listener while open so we
+  // don't steal Esc from other components.
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open, onClose]);
+
+  const filtered = useMemo(
+    () => filterShortcuts(ALL_SHORTCUTS, query),
+    [query]
+  );
+  const grouped = useMemo(() => groupByCategory(filtered), [filtered]);
+  const categories = Object.keys(grouped);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+    >
+      <div
+        className="w-full max-w-lg max-h-[80vh] flex flex-col bg-[var(--surface)] border border-[var(--border)] rounded-lg shadow-xl overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--border)]">
+          <div className="flex items-center gap-2">
+            <Keyboard size={16} className="text-[var(--text-muted)]" />
+            <h2 className="text-sm font-semibold text-[var(--text-primary)]">
+              Keyboard shortcuts
+            </h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Search */}
+        <div className="px-4 py-3 border-b border-[var(--border)]">
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Filter shortcuts…"
+            className="w-full px-3 py-2 text-sm bg-[var(--surface-secondary)] border border-[var(--border)] rounded-md text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-1 focus:ring-[var(--accent)]"
+          />
+        </div>
+
+        {/* Shortcut list */}
+        <div className="flex-1 overflow-y-auto px-4 py-2">
+          {categories.length === 0 ? (
+            <p className="text-xs text-[var(--text-muted)] text-center py-6">
+              No shortcuts match &ldquo;{query}&rdquo;.
+            </p>
+          ) : (
+            categories.map((cat) => (
+              <div key={cat} className="mb-4">
+                <h3 className="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-2">
+                  {cat}
+                </h3>
+                <ul className="space-y-1">
+                  {grouped[cat].map((s, i) => (
+                    <li
+                      key={`${cat}-${i}`}
+                      className="flex items-center justify-between py-1 text-xs"
+                    >
+                      <span className="text-[var(--text-secondary)]">
+                        {s.description}
+                      </span>
+                      <span className="flex items-center gap-1 shrink-0">
+                        {s.keys.map((k, ki) => (
+                          <kbd
+                            key={ki}
+                            className="px-1.5 py-0.5 min-w-[1.5em] text-center font-mono text-[10px] rounded bg-[var(--surface-secondary)] border border-[var(--border)] text-[var(--text-primary)]"
+                          >
+                            {k}
+                          </kbd>
+                        ))}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="px-4 py-2 border-t border-[var(--border)] text-[10px] text-[var(--text-muted)] text-center">
+          Press{" "}
+          <kbd className="px-1 py-0.5 font-mono rounded bg-[var(--surface-secondary)] border border-[var(--border)]">
+            Esc
+          </kbd>{" "}
+          to close
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -1,0 +1,99 @@
+/**
+ * Keyboard shortcut registry + helpers for the cheatsheet modal.
+ *
+ * This file is pure data and pure functions — no React, no DOM mounting.
+ * The UI (KeyboardCheatsheet component) consumes this module to render a
+ * filterable list; the `shouldOpenCheatsheet` predicate decides whether a
+ * global `?` keypress should actually open the modal (we bail when the
+ * user is typing so we don't steal their "?").
+ *
+ * Tested in keyboard-shortcuts.test.ts.
+ */
+
+export type ShortcutCategory = "Editor" | "Review" | "Navigation" | "Help";
+
+export interface Shortcut {
+  keys: string[];
+  description: string;
+  category: ShortcutCategory;
+}
+
+/**
+ * The canonical shortcut list. Keep this in sync with the actual key
+ * handlers in Editor.tsx / DiffViewer.tsx / app-context.tsx — if a
+ * shortcut lives here and doesn't work, or works and isn't here, that's
+ * a bug.
+ */
+export const ALL_SHORTCUTS: Shortcut[] = [
+  // ─── Editor formatting ─────────────────────────────────────────────
+  { keys: ["⌘", "B"], description: "Bold", category: "Editor" },
+  { keys: ["⌘", "I"], description: "Italic", category: "Editor" },
+  { keys: ["⌘", "E"], description: "Inline code", category: "Editor" },
+  { keys: ["⌘", "K"], description: "Insert link", category: "Editor" },
+  { keys: ["⌘", "Z"], description: "Undo", category: "Editor" },
+  { keys: ["⌘", "⇧", "Z"], description: "Redo", category: "Editor" },
+  { keys: ["⌘", "↵"], description: "Finish editing block (suggest mode)", category: "Editor" },
+  { keys: ["Esc"], description: "Cancel editing block / close modal", category: "Editor" },
+
+  // ─── Review ─────────────────────────────────────────────────────────
+  { keys: ["Click", "Drag"], description: "Select text in diff to leave a comment", category: "Review" },
+  { keys: ["↵"], description: "Submit comment / reply", category: "Review" },
+
+  // ─── Help ───────────────────────────────────────────────────────────
+  { keys: ["?"], description: "Open keyboard cheatsheet", category: "Help" },
+];
+
+/**
+ * Group a list of shortcuts by their category, preserving input order
+ * within each group.
+ */
+export function groupByCategory(
+  shortcuts: Shortcut[]
+): Record<string, Shortcut[]> {
+  const out: Record<string, Shortcut[]> = {};
+  for (const s of shortcuts) {
+    if (!out[s.category]) out[s.category] = [];
+    out[s.category].push(s);
+  }
+  return out;
+}
+
+/**
+ * Filter a list of shortcuts by a free-form query string. Matches
+ * against description, key labels, and category name. Case-insensitive.
+ * Empty or whitespace-only query returns the list unchanged.
+ */
+export function filterShortcuts(
+  shortcuts: Shortcut[],
+  query: string
+): Shortcut[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return shortcuts;
+  return shortcuts.filter((s) => {
+    if (s.description.toLowerCase().includes(q)) return true;
+    if (s.category.toLowerCase().includes(q)) return true;
+    if (s.keys.some((k) => k.toLowerCase().includes(q))) return true;
+    return false;
+  });
+}
+
+/**
+ * Predicate: should a `?` keypress open the cheatsheet modal?
+ *
+ * Returns true only when the key is `?` AND the event is not targeting
+ * a text-entry surface (input, textarea, select, or contenteditable).
+ * Pure — takes a KeyboardEvent-shaped object so it can be unit-tested
+ * without a DOM.
+ */
+export function shouldOpenCheatsheet(event: {
+  key: string;
+  target: { tagName?: string; isContentEditable?: boolean } | null;
+}): boolean {
+  if (event.key !== "?") return false;
+  const target = event.target;
+  if (!target) return true;
+  if (target.isContentEditable) return false;
+  const tag = (target.tagName || "").toUpperCase();
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return false;
+  return true;
+}


### PR DESCRIPTION
## Summary

Third P1a item. Discoverable, filterable keyboard shortcut reference. Press `?` anywhere outside a text-entry surface (or click the keyboard icon in the top bar) to open a modal listing every shortcut the app binds.

## What changed

**`src/lib/keyboard-shortcuts.ts`** — pure data + pure helpers:
- `ALL_SHORTCUTS` — single source of truth for the registry. Categories: Editor, Review, Navigation, Help.
- `groupByCategory(shortcuts)` — preserves input order within each group.
- `filterShortcuts(shortcuts, query)` — case-insensitive, searches description, category name, and key labels.
- `shouldOpenCheatsheet(event)` — predicate that returns `true` only when the key is `?` AND the target is not an `<input>`, `<textarea>`, `<select>`, or contenteditable. **Critical behavior:** pressing `?` inside the TipTap editor or a comment input must type a literal `?`, not hijack it into the modal.

**`src/components/KeyboardCheatsheet.tsx`** — modal UI:
- Filterable search input, autofocused on open, resets on close.
- Grouped shortcut list with `<kbd>`-styled key chords.
- Esc closes, click-outside closes, accessible (`role="dialog"`, `aria-modal`, `aria-label`).

**`src/app/page.tsx`**:
- Global `keydown` listener calling `shouldOpenCheatsheet`.
- Keyboard icon next to Settings in the top bar for click-to-open.
- `<KeyboardCheatsheet>` mounted next to `<SettingsPanel>`.

## Tests

Test-first. 21 new tests in `keyboard-shortcuts.test.ts`:

- Registry contract: non-empty, every entry well-formed, includes the canonical editor formatting shortcuts, includes the `?` meta-entry
- `groupByCategory`: grouping correctness, order preservation, empty input
- `filterShortcuts`: empty query, description match, case-insensitivity, key-char match, category match, no-match, partial-word match
- `shouldOpenCheatsheet`: positive cases (BODY, document-level), negative cases (wrong key, INPUT, TEXTAREA, SELECT, contenteditable)

**Test count:** 240 → 261 (+21). Build clean.

## Test plan

- [ ] Press `?` on the welcome screen → modal opens
- [ ] Press `?` inside a file's TipTap editor → literal `?` is typed into the document, modal does NOT open
- [ ] Press `?` inside a comment textarea → literal `?`, modal does NOT open
- [ ] Click the keyboard icon in the top bar → modal opens
- [ ] Esc closes the modal
- [ ] Click outside the modal closes it
- [ ] Type in the search box → list filters live
- [ ] Search for "bold" → only Bold shortcut shows
- [ ] Search for "help" → only the `?` meta-entry shows
- [ ] Reopen the modal — search query is reset to empty
- [ ] Dark mode renders correctly