### PR TITLE
feat: find/replace in code view (⌘F)

### DIFF
--- a/src/__tests__/find-replace.test.ts
+++ b/src/__tests__/find-replace.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for the find/replace helpers — pure string-level operations used
+ * by the code-view find bar. Written test-first so the contract is
+ * defined here before any caller exists.
+ *
+ * Rich-view find/replace is deliberately out of scope for this module.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  findAll,
+  replaceAt,
+  replaceAll,
+  type FindOptions,
+  type Match,
+} from "@/lib/find-replace";
+
+describe("findAll", () => {
+  // ─── Trivial ────────────────────────────────────────────────────────────
+
+  it("returns empty when the query is empty", () => {
+    expect(findAll("any text", "")).toEqual([]);
+  });
+
+  it("returns empty when the text is empty", () => {
+    expect(findAll("", "foo")).toEqual([]);
+  });
+
+  it("returns empty when the query is not found", () => {
+    expect(findAll("hello world", "xyzzy")).toEqual([]);
+  });
+
+  // ─── Basic matches ──────────────────────────────────────────────────────
+
+  it("finds a single match and returns its span", () => {
+    const matches = findAll("hello world", "world");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toEqual({ start: 6, end: 11 });
+  });
+
+  it("finds multiple non-overlapping matches", () => {
+    const matches = findAll("foo bar foo baz foo", "foo");
+    expect(matches).toHaveLength(3);
+    expect(matches[0]).toEqual({ start: 0, end: 3 });
+    expect(matches[1]).toEqual({ start: 8, end: 11 });
+    expect(matches[2]).toEqual({ start: 16, end: 19 });
+  });
+
+  it("returns matches in ascending order of start position", () => {
+    const matches = findAll("aaa", "a");
+    expect(matches.map((m) => m.start)).toEqual([0, 1, 2]);
+  });
+
+  // ─── Case sensitivity ───────────────────────────────────────────────────
+
+  it("is case-insensitive by default", () => {
+    const matches = findAll("Hello HELLO hello", "hello");
+    expect(matches).toHaveLength(3);
+  });
+
+  it("honors caseSensitive: true", () => {
+    const matches = findAll("Hello HELLO hello", "hello", { caseSensitive: true });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].start).toBe(12);
+  });
+
+  // ─── Special regex characters in literal queries ───────────────────────
+
+  it("escapes regex metacharacters when regex is off", () => {
+    // `.` must match a literal dot, not any character.
+    const matches = findAll("a.b axb", ".", { regex: false });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].start).toBe(1);
+  });
+
+  it("treats $ and ^ as literals in non-regex mode", () => {
+    const matches = findAll("price is $10", "$10");
+    expect(matches).toHaveLength(1);
+  });
+
+  it("treats parentheses as literals in non-regex mode", () => {
+    expect(findAll("call foo() here", "()").length).toBe(1);
+  });
+
+  // ─── Regex mode ─────────────────────────────────────────────────────────
+
+  it("interprets the query as a regex when regex: true", () => {
+    const matches = findAll("cat rat bat mat", "[cb]at", { regex: true });
+    expect(matches).toHaveLength(2);
+  });
+
+  it("returns empty for an invalid regex instead of throwing", () => {
+    // Unbalanced paren — previously this would crash the find panel.
+    expect(findAll("any text", "(invalid", { regex: true })).toEqual([]);
+  });
+
+  it("handles zero-width regex matches without infinite-looping", () => {
+    // `^` matches at every line start — our finder must advance past
+    // zero-width matches or the loop runs forever.
+    const matches = findAll("line\nline\nline", "^", { regex: true });
+    expect(matches).toEqual([]); // zero-width matches skipped entirely
+  });
+
+  // ─── Whole word ─────────────────────────────────────────────────────────
+
+  it("honors wholeWord: true", () => {
+    const matches = findAll("car cart scar", "car", { wholeWord: true });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].start).toBe(0);
+  });
+
+  it("wholeWord considers punctuation as a boundary", () => {
+    const matches = findAll("cat, cats (cat).", "cat", { wholeWord: true });
+    // "cat" at 0, "cat" at 11 — "cats" is not a whole-word match.
+    expect(matches).toHaveLength(2);
+  });
+
+  // ─── Combinations ───────────────────────────────────────────────────────
+
+  it("combines caseSensitive + wholeWord", () => {
+    const matches = findAll("Foo foo FOO bar", "foo", {
+      caseSensitive: true,
+      wholeWord: true,
+    });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].start).toBe(4);
+  });
+});
+
+describe("replaceAt", () => {
+  it("replaces the text at a single match position", () => {
+    const text = "hello world";
+    const match: Match = { start: 6, end: 11 };
+    expect(replaceAt(text, match, "there")).toBe("hello there");
+  });
+
+  it("handles an empty replacement (delete at the match)", () => {
+    expect(replaceAt("foo bar baz", { start: 4, end: 7 }, "")).toBe("foo  baz");
+  });
+
+  it("handles a replacement longer than the original", () => {
+    expect(replaceAt("x", { start: 0, end: 1 }, "expanded")).toBe("expanded");
+  });
+
+  it("handles a replacement at the start of the text", () => {
+    expect(replaceAt("abc", { start: 0, end: 1 }, "X")).toBe("Xbc");
+  });
+
+  it("handles a replacement at the end of the text", () => {
+    expect(replaceAt("abc", { start: 2, end: 3 }, "X")).toBe("abX");
+  });
+});
+
+describe("replaceAll", () => {
+  it("replaces every match of a literal query", () => {
+    expect(replaceAll("foo bar foo baz foo", "foo", "qux")).toBe("qux bar qux baz qux");
+  });
+
+  it("returns text unchanged when there are no matches", () => {
+    expect(replaceAll("hello", "xyz", "abc")).toBe("hello");
+  });
+
+  it("returns text unchanged when the query is empty", () => {
+    expect(replaceAll("hello", "", "abc")).toBe("hello");
+  });
+
+  it("preserves the position of unmatched content", () => {
+    // Regression: a left-to-right naive replacement would shift indices.
+    // Replacing short→long then long→short must still produce correct text.
+    const input = "abc abc abc";
+    const result = replaceAll(input, "abc", "XYZW");
+    expect(result).toBe("XYZW XYZW XYZW");
+  });
+
+  it("honors caseSensitive", () => {
+    expect(replaceAll("Foo foo FOO", "foo", "bar", { caseSensitive: true })).toBe(
+      "Foo bar FOO"
+    );
+  });
+
+  it("honors regex mode", () => {
+    const input = "2024-01-15 and 2025-12-31";
+    expect(
+      replaceAll(input, "\\d{4}-\\d{2}-\\d{2}", "DATE", { regex: true })
+    ).toBe("DATE and DATE");
+  });
+
+  it("honors wholeWord", () => {
+    expect(replaceAll("car cart scar", "car", "bus", { wholeWord: true })).toBe(
+      "bus cart scar"
+    );
+  });
+
+  it("handles replacement text that contains the query", () => {
+    // "a" → "aa" should not infinite-loop or double-expand.
+    expect(replaceAll("a a a", "a", "aa")).toBe("aa aa aa");
+  });
+});

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -45,6 +45,8 @@ import {
 } from "@/lib/draft-store";
 import { analyzeMarkdown, type MarkdownStats } from "@/lib/word-count";
 import { transformGitHubAlerts } from "@/lib/github-alerts";
+import FindReplaceBar from "./FindReplaceBar";
+import type { Match as FindMatch } from "@/lib/find-replace";
 import { classifyLink, resolvePath, findFileByPath } from "@/lib/link-handler";
 import { useApp } from "@/lib/app-context";
 import { openExternal } from "@/lib/open-external";
@@ -663,6 +665,10 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
   // same debounce tick as the dirty check so we don't run Turndown twice.
   const [stats, setStats] = useState<MarkdownStats>({ words: 0, readingMinutes: 0 });
 
+  // Find/replace panel — only available in code view. In rich view, Cmd+F
+  // falls through to the browser's native find.
+  const [findBarOpen, setFindBarOpen] = useState(false);
+
   // Dirty tracking for existing files — compare current markdown to original
   const [isDirty, setIsDirty] = useState(false);
   const originalMarkdownRef = useRef<string | null>(null);
@@ -921,8 +927,33 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
         wrapSelection("[", `](${selected ? "" : "url"})`);
         break;
       }
+      case "f":
+        e.preventDefault();
+        setFindBarOpen(true);
+        break;
     }
   }, [wrapSelection, codeContent]);
+
+  // Handler for FindReplaceBar — when the user navigates to a match, scroll
+  // the code textarea to it and select the matched range.
+  const handleMatchFocused = useCallback((match: FindMatch) => {
+    const textarea = codeTextareaRef.current;
+    if (!textarea) return;
+    textarea.focus();
+    textarea.setSelectionRange(match.start, match.end);
+    // Scroll the match into view. setSelectionRange doesn't auto-scroll in
+    // all browsers, so we measure the match's line and jump scrollTop.
+    const before = codeContent.slice(0, match.start);
+    const lineNumber = (before.match(/\n/g) || []).length;
+    const lineHeight = parseFloat(getComputedStyle(textarea).lineHeight || "20");
+    textarea.scrollTop = Math.max(0, lineNumber * lineHeight - textarea.clientHeight / 2);
+  }, [codeContent]);
+
+  // Leaving code view closes the find bar. Opening the bar requires being
+  // in code view, and the bar only operates on codeContent.
+  useEffect(() => {
+    if (!codeView) setFindBarOpen(false);
+  }, [codeView]);
 
   const handleStartComment = useCallback((selectedText: string) => {
     setPendingSelection(selectedText);
@@ -1623,6 +1654,27 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
                   </button>
                 </div>
               </div>
+            )}
+
+            {codeView && findBarOpen && (
+              <FindReplaceBar
+                text={codeContent}
+                onTextChange={(next) => {
+                  setCodeContent(next);
+                  const { dirty } = reconcileDraft(
+                    draftScopeRef.current,
+                    originalMarkdownRef.current,
+                    next
+                  );
+                  setIsDirty(dirty);
+                  setStats(analyzeMarkdown(next));
+                }}
+                onClose={() => {
+                  setFindBarOpen(false);
+                  codeTextareaRef.current?.focus();
+                }}
+                onMatchFocused={handleMatchFocused}
+              />
             )}
 
             {codeView ? (

--- a/src/components/FindReplaceBar.tsx
+++ b/src/components/FindReplaceBar.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Search, Replace as ReplaceIcon, X, ChevronUp, ChevronDown, CaseSensitive, Regex, WholeWord } from "lucide-react";
+import { findAll, replaceAt, replaceAll, type FindOptions, type Match } from "@/lib/find-replace";
+
+interface FindReplaceBarProps {
+  /** The current text being searched (e.g., codeContent from the editor). */
+  text: string;
+  /** Called when a replace or replace-all rewrites the text. */
+  onTextChange: (next: string) => void;
+  /** Called when the bar should close (Esc pressed, X clicked). */
+  onClose: () => void;
+  /** Called when the current match changes so the editor can scroll/select. */
+  onMatchFocused?: (match: Match) => void;
+}
+
+/**
+ * Code-view find/replace panel. Renders a horizontal bar with search +
+ * replace inputs, option toggles (case / regex / whole word), and
+ * next/prev/replace/replace-all controls.
+ *
+ * All state lives locally in the component — the parent just hands in
+ * `text` and receives `onTextChange(next)` when a replace occurs.
+ *
+ * Logic is delegated to @/lib/find-replace, which is tested in isolation.
+ */
+export default function FindReplaceBar({
+  text,
+  onTextChange,
+  onClose,
+  onMatchFocused,
+}: FindReplaceBarProps) {
+  const [query, setQuery] = useState("");
+  const [replacement, setReplacement] = useState("");
+  const [options, setOptions] = useState<FindOptions>({});
+  const [currentIdx, setCurrentIdx] = useState(0);
+  const findInputRef = useRef<HTMLInputElement>(null);
+
+  // Focus the find input on mount so the user can start typing immediately.
+  useEffect(() => {
+    findInputRef.current?.focus();
+    findInputRef.current?.select();
+  }, []);
+
+  // Recompute matches whenever the query, options, or underlying text
+  // changes. Reset the current index if it would now point out of bounds.
+  const matches = useMemo(() => findAll(text, query, options), [text, query, options]);
+  useEffect(() => {
+    if (currentIdx >= matches.length) {
+      setCurrentIdx(matches.length > 0 ? matches.length - 1 : 0);
+    }
+  }, [matches.length, currentIdx]);
+
+  // Notify the editor when the focused match changes so it can scroll the
+  // textarea and select the matched range.
+  useEffect(() => {
+    if (matches.length > 0 && onMatchFocused) {
+      onMatchFocused(matches[currentIdx]);
+    }
+  }, [currentIdx, matches, onMatchFocused]);
+
+  const goNext = () => {
+    if (matches.length === 0) return;
+    setCurrentIdx((i) => (i + 1) % matches.length);
+  };
+  const goPrev = () => {
+    if (matches.length === 0) return;
+    setCurrentIdx((i) => (i - 1 + matches.length) % matches.length);
+  };
+
+  const doReplace = () => {
+    if (matches.length === 0) return;
+    const match = matches[currentIdx];
+    const next = replaceAt(text, match, replacement);
+    onTextChange(next);
+    // After replacing, advance to what is now at the same index (which
+    // will be the next original match, since we removed the current one).
+    // The matches memo will recompute on the next render.
+  };
+
+  const doReplaceAll = () => {
+    if (matches.length === 0) return;
+    const next = replaceAll(text, query, replacement, options);
+    onTextChange(next);
+    setCurrentIdx(0);
+  };
+
+  const toggle = (key: keyof FindOptions) => {
+    setOptions((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const matchStatus =
+    matches.length === 0
+      ? query
+        ? "No matches"
+        : ""
+      : `${currentIdx + 1} / ${matches.length}`;
+
+  return (
+    <div
+      className="sticky top-0 z-20 bg-[var(--surface)] border-b border-[var(--border)] px-3 py-2 flex items-center gap-2 flex-wrap"
+      role="search"
+      aria-label="Find and replace"
+      onKeyDown={(e) => {
+        if (e.key === "Escape") {
+          e.preventDefault();
+          onClose();
+        }
+      }}
+    >
+      {/* Find input */}
+      <div className="flex items-center gap-1 flex-1 min-w-0 max-w-md">
+        <Search size={12} className="text-[var(--text-muted)] shrink-0" />
+        <input
+          ref={findInputRef}
+          type="text"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setCurrentIdx(0);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              if (e.shiftKey) goPrev();
+              else goNext();
+            }
+          }}
+          placeholder="Find"
+          className="flex-1 min-w-0 px-2 py-1 text-xs bg-[var(--surface-secondary)] border border-[var(--border)] rounded text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-1 focus:ring-[var(--accent)]"
+        />
+        <span className="text-[10px] text-[var(--text-muted)] font-mono min-w-[3.5em] text-right shrink-0">
+          {matchStatus}
+        </span>
+      </div>
+
+      {/* Option toggles */}
+      <div className="flex items-center gap-0.5">
+        <button
+          onClick={() => toggle("caseSensitive")}
+          className={`p-1 rounded text-[var(--text-muted)] hover:bg-[var(--surface-hover)] transition-colors ${
+            options.caseSensitive ? "bg-[var(--accent-muted)] text-[var(--accent)]" : ""
+          }`}
+          title="Match case"
+          aria-pressed={!!options.caseSensitive}
+        >
+          <CaseSensitive size={14} />
+        </button>
+        <button
+          onClick={() => toggle("wholeWord")}
+          className={`p-1 rounded text-[var(--text-muted)] hover:bg-[var(--surface-hover)] transition-colors ${
+            options.wholeWord ? "bg-[var(--accent-muted)] text-[var(--accent)]" : ""
+          }`}
+          title="Whole word"
+          aria-pressed={!!options.wholeWord}
+        >
+          <WholeWord size={14} />
+        </button>
+        <button
+          onClick={() => toggle("regex")}
+          className={`p-1 rounded text-[var(--text-muted)] hover:bg-[var(--surface-hover)] transition-colors ${
+            options.regex ? "bg-[var(--accent-muted)] text-[var(--accent)]" : ""
+          }`}
+          title="Regular expression"
+          aria-pressed={!!options.regex}
+        >
+          <Regex size={14} />
+        </button>
+      </div>
+
+      {/* Navigate */}
+      <div className="flex items-center gap-0.5">
+        <button
+          onClick={goPrev}
+          disabled={matches.length === 0}
+          className="p-1 rounded text-[var(--text-muted)] hover:bg-[var(--surface-hover)] transition-colors disabled:opacity-30"
+          title="Previous match (Shift+Enter)"
+        >
+          <ChevronUp size={14} />
+        </button>
+        <button
+          onClick={goNext}
+          disabled={matches.length === 0}
+          className="p-1 rounded text-[var(--text-muted)] hover:bg-[var(--surface-hover)] transition-colors disabled:opacity-30"
+          title="Next match (Enter)"
+        >
+          <ChevronDown size={14} />
+        </button>
+      </div>
+
+      {/* Replace input */}
+      <div className="flex items-center gap-1 flex-1 min-w-0 max-w-md">
+        <ReplaceIcon size={12} className="text-[var(--text-muted)] shrink-0" />
+        <input
+          type="text"
+          value={replacement}
+          onChange={(e) => setReplacement(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              doReplace();
+            }
+          }}
+          placeholder="Replace"
+          className="flex-1 min-w-0 px-2 py-1 text-xs bg-[var(--surface-secondary)] border border-[var(--border)] rounded text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-1 focus:ring-[var(--accent)]"
+        />
+      </div>
+
+      {/* Replace actions */}
+      <div className="flex items-center gap-1">
+        <button
+          onClick={doReplace}
+          disabled={matches.length === 0}
+          className="text-[10px] px-2 py-1 rounded border border-[var(--border)] text-[var(--text-secondary)] hover:bg-[var(--surface-hover)] disabled:opacity-30 transition-colors"
+        >
+          Replace
+        </button>
+        <button
+          onClick={doReplaceAll}
+          disabled={matches.length === 0}
+          className="text-[10px] px-2 py-1 rounded bg-[var(--accent)] text-white hover:bg-[var(--accent-hover)] disabled:opacity-30 transition-colors"
+        >
+          Replace all
+        </button>
+      </div>
+
+      {/* Close */}
+      <button
+        onClick={onClose}
+        className="p-1 text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+        aria-label="Close find bar"
+        title="Close (Esc)"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/src/lib/find-replace.ts
+++ b/src/lib/find-replace.ts
@@ -1,0 +1,95 @@
+/**
+ * Pure string-level find/replace used by the code-view find bar.
+ *
+ * All functions in this module are pure and testable without a DOM.
+ * The UI (FindReplaceBar) consumes them to implement the actual panel.
+ *
+ * Rich-view find/replace would need a TipTap extension or custom
+ * ProseMirror plugin and is deliberately out of scope here — in rich
+ * view, Cmd+F falls through to the browser's native Find.
+ */
+
+export interface FindOptions {
+  caseSensitive?: boolean;
+  regex?: boolean;
+  wholeWord?: boolean;
+}
+
+export interface Match {
+  start: number;
+  end: number;
+}
+
+/**
+ * Locate every non-overlapping match of `query` in `text`. Returns an
+ * empty array for empty input, invalid regex, or no matches. Zero-width
+ * regex matches are skipped (so `^` in regex mode doesn't infinite-loop).
+ */
+export function findAll(
+  text: string,
+  query: string,
+  options: FindOptions = {}
+): Match[] {
+  if (!query || !text) return [];
+
+  let pattern: RegExp;
+  try {
+    if (options.regex) {
+      pattern = new RegExp(query, options.caseSensitive ? "g" : "gi");
+    } else {
+      const escaped = escapeRegex(query);
+      const wrapped = options.wholeWord ? `\\b${escaped}\\b` : escaped;
+      pattern = new RegExp(wrapped, options.caseSensitive ? "g" : "gi");
+    }
+  } catch {
+    // Invalid regex — treat as "no matches" rather than blowing up the UI.
+    return [];
+  }
+
+  const matches: Match[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = pattern.exec(text)) !== null) {
+    if (m[0].length === 0) {
+      // Zero-width match: skip it entirely and advance the lastIndex so
+      // the loop terminates. We don't emit zero-width matches because
+      // "replace" on them is meaningless.
+      pattern.lastIndex++;
+      continue;
+    }
+    matches.push({ start: m.index, end: m.index + m[0].length });
+  }
+  return matches;
+}
+
+/**
+ * Replace the text at `match` with `replacement`. Pure — doesn't mutate.
+ */
+export function replaceAt(text: string, match: Match, replacement: string): string {
+  return text.slice(0, match.start) + replacement + text.slice(match.end);
+}
+
+/**
+ * Replace every occurrence of `query` in `text` with `replacement`. Uses
+ * findAll + replaceAt, walking matches from right to left so earlier
+ * indices stay valid as we rewrite.
+ */
+export function replaceAll(
+  text: string,
+  query: string,
+  replacement: string,
+  options: FindOptions = {}
+): string {
+  if (!query) return text;
+  const matches = findAll(text, query, options);
+  if (matches.length === 0) return text;
+
+  let result = text;
+  for (let i = matches.length - 1; i >= 0; i--) {
+    result = replaceAt(result, matches[i], replacement);
+  }
+  return result;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -30,6 +30,7 @@ export const ALL_SHORTCUTS: Shortcut[] = [
   { keys: ["⌘", "I"], description: "Italic", category: "Editor" },
   { keys: ["⌘", "E"], description: "Inline code", category: "Editor" },
   { keys: ["⌘", "K"], description: "Insert link", category: "Editor" },
+  { keys: ["⌘", "F"], description: "Find and replace (code view)", category: "Editor" },
   { keys: ["⌘", "Z"], description: "Undo", category: "Editor" },
   { keys: ["⌘", "⇧", "Z"], description: "Redo", category: "Editor" },
   { keys: ["⌘", "↵"], description: "Finish editing block (suggest mode)", category: "Editor" },


### PR DESCRIPTION
## Summary

Fourth P1a item. Adds a find/replace panel to the code view editor with case-sensitivity, whole-word, and regex toggles, plus next/prev navigation and replace-one / replace-all.

Rich view is explicitly out of scope for this PR. In rich view, `⌘F` falls through to the browser's native Find — a reasonable default. A TipTap-aware rich-view integration needs either a community extension (new dep → explicit confirmation) or a custom ProseMirror plugin (sizable) and will be its own PR.

## Usage

- In code view, press `⌘F` (or `Ctrl+F` on Windows/Linux) to open the find bar
- Type a query — matches highlight live, counter shows `N / total`
- `Enter` / `Shift+Enter` jumps next / previous
- `Esc` or the `X` button closes
- Toggles: case-sensitive, whole word, regex
- Leaving code view auto-closes the bar

## What changed

**`src/lib/find-replace.ts`** — pure string helpers:
- `findAll(text, query, options)` — returns match spans, handles regex / literal / case / wholeWord, skips zero-width regex matches, returns `[]` for invalid regex
- `replaceAt(text, match, replacement)` — single-span rewrite
- `replaceAll(text, query, replacement, options)` — walks matches right-to-left so indices stay valid

**`src/components/FindReplaceBar.tsx`** — panel UI. Thin shell over the pure helpers so behavior is testable in isolation. Autofocuses the find input on mount.

**`Editor.tsx`**:
- `⌘F` case added to `handleCodeViewKeyDown` → opens the bar
- `handleMatchFocused` scrolls the textarea to the current match and selects its range
- Leaving code view auto-closes the bar

**`src/lib/keyboard-shortcuts.ts`** — cheatsheet entry: `⌘F → Find and replace (code view)` with explicit scope note.

## Tests

Test-first. 30 new tests in `find-replace.test.ts`:

**`findAll`** — empty query / empty text / no match, single & multi-match with ordering, case-insensitive default, `caseSensitive: true`, regex metacharacter escaping in literal mode, regex mode, invalid regex returns `[]`, zero-width regex (infinite-loop guard), whole word with punctuation boundaries, combinations.

**`replaceAt`** — start / middle / end positions, delete (empty replacement), expansion.

**`replaceAll`** — no-op cases, right-to-left index preservation, case-sensitive, regex, whole-word, replacement containing the query (no re-match).

**Test count:** 261 → 291 (+30). Build clean.

## Test plan

- [ ] Switch editor to code view, press `⌘F` → bar appears, find input focused
- [ ] Type a query that exists in the file → match counter ticks up, current match selected in textarea
- [ ] Press `Enter` → advances to next match, textarea scrolls if match is off-screen
- [ ] `Shift+Enter` → previous match, wraps around
- [ ] Toggle case-sensitive → match count changes as expected
- [ ] Toggle whole-word → partial-word matches drop
- [ ] Toggle regex → try `\d+` to match any number
- [ ] Invalid regex `(unclosed` → count shows "No matches" instead of crashing
- [ ] Type a replacement, click Replace → current match is replaced, advances to next
- [ ] Replace all → every match replaced, counter resets
- [ ] Press `Esc` → bar closes, focus returns to textarea
- [ ] Switch to rich view → bar disappears, `⌘F` opens browser's native find
- [ ] Cheatsheet (`?`) → shows `⌘F — Find and replace (code view)` entry