### PR TITLE
feat: command palette (⌘⇧P)

### DIFF
--- a/src/__tests__/command-palette.test.ts
+++ b/src/__tests__/command-palette.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for the command-palette pure helpers — filtering, ranking, and
+ * the predicate that decides whether Cmd+Shift+P should open the palette.
+ *
+ * Contract is defined here test-first. The palette UI is a thin shell over
+ * these helpers and is covered by manual testing + typecheck, not by DOM
+ * tests.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  filterCommands,
+  shouldOpenCommandPalette,
+  type Command,
+} from "@/lib/command-palette";
+
+function cmd(overrides: Partial<Command>): Command {
+  return {
+    id: "test",
+    label: "Test",
+    handler: () => {},
+    ...overrides,
+  };
+}
+
+describe("filterCommands", () => {
+  const sample: Command[] = [
+    cmd({ id: "toggle-theme", label: "Toggle dark mode", category: "View", keywords: ["dark", "light", "theme"] }),
+    cmd({ id: "settings", label: "Open Settings", category: "Preferences" }),
+    cmd({ id: "new-file", label: "New file", category: "File", keywords: ["create"] }),
+    cmd({ id: "help", label: "Keyboard shortcuts", category: "Help" }),
+  ];
+
+  it("returns all commands for empty or whitespace-only query", () => {
+    expect(filterCommands(sample, "")).toHaveLength(4);
+    expect(filterCommands(sample, "   ")).toHaveLength(4);
+  });
+
+  it("filters by label substring", () => {
+    const matches = filterCommands(sample, "settings");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].id).toBe("settings");
+  });
+
+  it("is case-insensitive", () => {
+    expect(filterCommands(sample, "SETTINGS")).toHaveLength(1);
+    expect(filterCommands(sample, "SeTtInGs")).toHaveLength(1);
+  });
+
+  it("filters by category name", () => {
+    const matches = filterCommands(sample, "view");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].id).toBe("toggle-theme");
+  });
+
+  it("filters by keyword list", () => {
+    // "dark" appears in keywords for toggle-theme
+    const matches = filterCommands(sample, "dark");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].id).toBe("toggle-theme");
+  });
+
+  it("filters by alternate keyword", () => {
+    const matches = filterCommands(sample, "create");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].id).toBe("new-file");
+  });
+
+  it("matches a partial substring inside the label", () => {
+    expect(filterCommands(sample, "board")).toHaveLength(1); // "Keyboard shortcuts"
+  });
+
+  it("returns empty when nothing matches", () => {
+    expect(filterCommands(sample, "xyzzy")).toEqual([]);
+  });
+
+  // ─── Ranking ────────────────────────────────────────────────────────────
+
+  it("ranks label-start matches above mid-label matches", () => {
+    const cmds: Command[] = [
+      cmd({ id: "a", label: "Export file" }),
+      cmd({ id: "b", label: "Expand block" }),
+      cmd({ id: "c", label: "Commit an express PR" }),
+    ];
+    // Query "exp" should prefer the commands where "exp" starts a word
+    // ("Export" and "Expand") over mid-word matches ("express").
+    const matches = filterCommands(cmds, "exp");
+    expect(matches).toHaveLength(3);
+    expect(matches[0].id).not.toBe("c"); // The mid-word match should sink
+  });
+
+  it("ranks exact label match highest", () => {
+    const cmds: Command[] = [
+      cmd({ id: "a", label: "New file" }),
+      cmd({ id: "b", label: "Open a new file from URL" }),
+    ];
+    const matches = filterCommands(cmds, "new file");
+    expect(matches[0].id).toBe("a"); // exact match wins
+  });
+});
+
+// ─── shouldOpenCommandPalette ──────────────────────────────────────────
+
+describe("shouldOpenCommandPalette", () => {
+  function mockEvent(
+    key: string,
+    opts: { meta?: boolean; ctrl?: boolean; shift?: boolean; tag?: string; ce?: boolean } = {}
+  ): any {
+    return {
+      key,
+      metaKey: !!opts.meta,
+      ctrlKey: !!opts.ctrl,
+      shiftKey: !!opts.shift,
+      target: { tagName: opts.tag, isContentEditable: !!opts.ce },
+    };
+  }
+
+  it("opens on ⌘⇧P (macOS convention)", () => {
+    expect(shouldOpenCommandPalette(mockEvent("P", { meta: true, shift: true }))).toBe(true);
+  });
+
+  it("opens on Ctrl+Shift+P (Windows/Linux convention)", () => {
+    expect(shouldOpenCommandPalette(mockEvent("P", { ctrl: true, shift: true }))).toBe(true);
+  });
+
+  it("accepts lowercase `p` (some browsers report this)", () => {
+    expect(shouldOpenCommandPalette(mockEvent("p", { meta: true, shift: true }))).toBe(true);
+  });
+
+  it("does NOT open without the Shift modifier", () => {
+    // ⌘P is browser Print — we don't want to hijack it.
+    expect(shouldOpenCommandPalette(mockEvent("P", { meta: true }))).toBe(false);
+  });
+
+  it("does NOT open without the Cmd or Ctrl modifier", () => {
+    expect(shouldOpenCommandPalette(mockEvent("P", { shift: true }))).toBe(false);
+  });
+
+  it("does NOT open on a different key", () => {
+    expect(shouldOpenCommandPalette(mockEvent("K", { meta: true, shift: true }))).toBe(false);
+  });
+
+  it("opens even when focus is in an input (modifier is explicit)", () => {
+    // Unlike bare `?`, a three-key chord is unambiguous and safe to fire
+    // regardless of focus.
+    expect(
+      shouldOpenCommandPalette(mockEvent("P", { meta: true, shift: true, tag: "INPUT" }))
+    ).toBe(true);
+    expect(
+      shouldOpenCommandPalette(mockEvent("P", { meta: true, shift: true, tag: "TEXTAREA" }))
+    ).toBe(true);
+    expect(
+      shouldOpenCommandPalette(mockEvent("P", { meta: true, shift: true, ce: true }))
+    ).toBe(true);
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { useApp } from "@/lib/app-context";
+import { useTheme } from "@/lib/theme-context";
 import Sidebar from "@/components/Sidebar";
 import Editor from "@/components/Editor";
 import HtmlViewer from "@/components/HtmlViewer";
@@ -10,7 +11,9 @@ import PRReview from "@/components/PRReview";
 import SettingsPanel from "@/components/SettingsPanel";
 import ThemeToggle from "@/components/ThemeToggle";
 import KeyboardCheatsheet from "@/components/KeyboardCheatsheet";
+import CommandPalette from "@/components/CommandPalette";
 import { shouldOpenCheatsheet } from "@/lib/keyboard-shortcuts";
+import { shouldOpenCommandPalette, type Command } from "@/lib/command-palette";
 import {
   BookOpen,
   Settings,
@@ -38,17 +41,69 @@ export default function Home() {
     repoFiles,
     pullRequests,
     isEmbedded,
+    createNewFile,
   } = useApp();
+  const { toggleTheme } = useTheme();
 
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [cheatsheetOpen, setCheatsheetOpen] = useState(false);
+  const [paletteOpen, setPaletteOpen] = useState(false);
 
-  // Global `?` opens the keyboard cheatsheet. shouldOpenCheatsheet is a
-  // pure predicate tested in keyboard-shortcuts.test.ts — it bails when
-  // the user is typing in an input / textarea / contenteditable so we
-  // never steal their "?" character.
+  // Palette command registry. Built here because the commands close over
+  // the state setters and context actions available at the page level —
+  // opening Settings, toggling theme, starting a new file, etc. Keep this
+  // in sync with the cheatsheet where shortcuts overlap.
+  const paletteCommands = useMemo<Command[]>(
+    () => [
+      {
+        id: "open-settings",
+        label: "Open Settings",
+        category: "App",
+        keywords: ["preferences", "token", "github"],
+        handler: () => setSettingsOpen(true),
+      },
+      {
+        id: "open-cheatsheet",
+        label: "Show keyboard shortcuts",
+        category: "Help",
+        keywords: ["help", "keys", "bindings", "?"],
+        shortcut: ["?"],
+        handler: () => setCheatsheetOpen(true),
+      },
+      {
+        id: "toggle-theme",
+        label: "Toggle dark mode",
+        category: "View",
+        keywords: ["dark", "light", "theme", "appearance"],
+        handler: () => toggleTheme(),
+      },
+      {
+        id: "new-file",
+        label: "New file",
+        category: "File",
+        keywords: ["create", "add", "markdown"],
+        handler: () => createNewFile(),
+      },
+      {
+        id: "go-home",
+        label: "Go to home / welcome screen",
+        category: "Navigation",
+        keywords: ["back", "welcome", "start"],
+        handler: () => setCurrentView("editor"),
+      },
+    ],
+    [toggleTheme, createNewFile, setCurrentView]
+  );
+
+  // Global keyboard handler for `?` (cheatsheet) and ⌘⇧P (command
+  // palette). Both predicates are pure and unit-tested.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
+      if (shouldOpenCommandPalette(e as any)) {
+        e.preventDefault();
+        setPaletteOpen(true);
+        return;
+      }
       if (shouldOpenCheatsheet({ key: e.key, target: e.target as any })) {
         e.preventDefault();
         setCheatsheetOpen(true);
@@ -215,6 +270,13 @@ export default function Home() {
 
       {/* Keyboard cheatsheet (triggered by `?`) */}
       <KeyboardCheatsheet open={cheatsheetOpen} onClose={() => setCheatsheetOpen(false)} />
+
+      {/* Command palette (triggered by ⌘⇧P) */}
+      <CommandPalette
+        open={paletteOpen}
+        commands={paletteCommands}
+        onClose={() => setPaletteOpen(false)}
+      />
     </div>
   );
 }

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Command as CommandIcon } from "lucide-react";
+import { filterCommands, type Command } from "@/lib/command-palette";
+
+interface CommandPaletteProps {
+  open: boolean;
+  commands: Command[];
+  onClose: () => void;
+}
+
+/**
+ * Generic command palette modal. The palette itself is dumb — it renders
+ * a filterable, keyboard-navigable list of commands and calls the
+ * command's handler when selected. Commands are supplied by the caller so
+ * this component has no knowledge of any specific app feature.
+ *
+ * Keyboard behavior:
+ *   - Autofocuses the search input on open
+ *   - ↑ / ↓ navigates the list, wrapping at the ends
+ *   - Enter executes the selected command and closes the palette
+ *   - Esc closes without executing
+ *   - Click an item to execute
+ *   - Click outside the panel to close
+ *
+ * Filtering and ranking live in @/lib/command-palette (tested
+ * separately), so this shell stays thin.
+ */
+export default function CommandPalette({ open, commands, onClose }: CommandPaletteProps) {
+  const [query, setQuery] = useState("");
+  const [selectedIdx, setSelectedIdx] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  // Reset on open: clear the query, focus the input, reset selection.
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      setSelectedIdx(0);
+      const t = setTimeout(() => inputRef.current?.focus(), 0);
+      return () => clearTimeout(t);
+    }
+  }, [open]);
+
+  const filtered = useMemo(() => filterCommands(commands, query), [commands, query]);
+
+  // Clamp the selection if filtered length shrinks while the user types.
+  useEffect(() => {
+    if (selectedIdx >= filtered.length) {
+      setSelectedIdx(filtered.length > 0 ? filtered.length - 1 : 0);
+    }
+  }, [filtered.length, selectedIdx]);
+
+  // Scroll the selected item into view when it changes.
+  useEffect(() => {
+    if (!listRef.current) return;
+    const item = listRef.current.querySelector<HTMLLIElement>(
+      `li[data-idx="${selectedIdx}"]`
+    );
+    if (item) item.scrollIntoView({ block: "nearest" });
+  }, [selectedIdx]);
+
+  const executeSelected = () => {
+    const cmd = filtered[selectedIdx];
+    if (!cmd) return;
+    onClose();
+    // Defer the handler so the modal unmounts cleanly before the command
+    // takes effect (some handlers open other modals).
+    setTimeout(() => {
+      void cmd.handler();
+    }, 0);
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-start justify-center pt-[15vh] bg-black/50"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Command palette"
+    >
+      <div
+        className="w-full max-w-xl max-h-[70vh] flex flex-col bg-[var(--surface)] border border-[var(--border)] rounded-lg shadow-xl overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Search input */}
+        <div className="flex items-center gap-2 px-4 py-3 border-b border-[var(--border)]">
+          <CommandIcon size={14} className="text-[var(--text-muted)] shrink-0" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setSelectedIdx(0);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "ArrowDown") {
+                e.preventDefault();
+                setSelectedIdx((i) => (filtered.length === 0 ? 0 : (i + 1) % filtered.length));
+              } else if (e.key === "ArrowUp") {
+                e.preventDefault();
+                setSelectedIdx((i) =>
+                  filtered.length === 0 ? 0 : (i - 1 + filtered.length) % filtered.length
+                );
+              } else if (e.key === "Enter") {
+                e.preventDefault();
+                executeSelected();
+              } else if (e.key === "Escape") {
+                e.preventDefault();
+                onClose();
+              }
+            }}
+            placeholder="Type a command or search…"
+            className="flex-1 min-w-0 bg-transparent text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none"
+          />
+        </div>
+
+        {/* Command list */}
+        <div className="flex-1 overflow-y-auto py-2">
+          {filtered.length === 0 ? (
+            <p className="text-xs text-[var(--text-muted)] text-center py-6 px-4">
+              No commands match &ldquo;{query}&rdquo;.
+            </p>
+          ) : (
+            <ul ref={listRef}>
+              {filtered.map((cmd, i) => (
+                <li
+                  key={cmd.id}
+                  data-idx={i}
+                  onClick={executeSelected}
+                  onMouseEnter={() => setSelectedIdx(i)}
+                  className={`px-4 py-2 cursor-pointer transition-colors flex items-center justify-between ${
+                    i === selectedIdx
+                      ? "bg-[var(--accent-muted)]"
+                      : "hover:bg-[var(--surface-hover)]"
+                  }`}
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      {cmd.category && (
+                        <span className="text-[9px] uppercase tracking-wider text-[var(--text-muted)] shrink-0">
+                          {cmd.category}
+                        </span>
+                      )}
+                      <span
+                        className={`text-xs truncate ${
+                          i === selectedIdx
+                            ? "text-[var(--text-primary)] font-medium"
+                            : "text-[var(--text-primary)]"
+                        }`}
+                      >
+                        {cmd.label}
+                      </span>
+                    </div>
+                    {cmd.description && (
+                      <div className="text-[10px] text-[var(--text-muted)] mt-0.5 truncate">
+                        {cmd.description}
+                      </div>
+                    )}
+                  </div>
+                  {cmd.shortcut && cmd.shortcut.length > 0 && (
+                    <span className="flex items-center gap-1 shrink-0 ml-4">
+                      {cmd.shortcut.map((k, ki) => (
+                        <kbd
+                          key={ki}
+                          className="px-1.5 py-0.5 min-w-[1.5em] text-center font-mono text-[10px] rounded bg-[var(--surface-secondary)] border border-[var(--border)] text-[var(--text-secondary)]"
+                        >
+                          {k}
+                        </kbd>
+                      ))}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="px-4 py-2 border-t border-[var(--border)] text-[10px] text-[var(--text-muted)] flex items-center justify-between">
+          <span>
+            <kbd className="px-1 py-0.5 font-mono rounded bg-[var(--surface-secondary)] border border-[var(--border)]">
+              ↑↓
+            </kbd>{" "}
+            navigate{" "}
+            <kbd className="px-1 py-0.5 font-mono rounded bg-[var(--surface-secondary)] border border-[var(--border)]">
+              ↵
+            </kbd>{" "}
+            run{" "}
+            <kbd className="px-1 py-0.5 font-mono rounded bg-[var(--surface-secondary)] border border-[var(--border)]">
+              Esc
+            </kbd>{" "}
+            close
+          </span>
+          <span>{filtered.length} command{filtered.length === 1 ? "" : "s"}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/command-palette.ts
+++ b/src/lib/command-palette.ts
@@ -1,0 +1,105 @@
+/**
+ * Command palette primitives: the Command shape, a ranked filter, and
+ * the keyboard predicate.
+ *
+ * Pure — no React, no DOM mounting. The palette UI (CommandPalette
+ * component) consumes these helpers. Tested in command-palette.test.ts.
+ */
+
+export interface Command {
+  /** Stable id, used as a React key and for programmatic dispatch. */
+  id: string;
+  /** Label shown in the palette list. */
+  label: string;
+  /** Optional longer description shown under the label. */
+  description?: string;
+  /** Grouping category shown as a small header above the item. */
+  category?: string;
+  /** Extra search terms — things the user might type that don't appear
+   *  in the label ("dark" / "light" for a toggle-theme command, etc.). */
+  keywords?: string[];
+  /** Display-only key chord (e.g., ["⌘", "⇧", "P"]). Not executed. */
+  shortcut?: string[];
+  /** Invoked when the user selects this command. */
+  handler: () => void | Promise<void>;
+}
+
+/**
+ * Filter and rank commands against a free-form query.
+ *
+ * Matches are checked against label, category, and keywords (case-
+ * insensitive substring). Ranking prefers:
+ *   1. Exact label match
+ *   2. Label starts with the query
+ *   3. Query matches at a word boundary in the label
+ *   4. Anywhere else (label, category, keywords)
+ *
+ * Empty / whitespace query returns the input list unchanged.
+ */
+export function filterCommands(commands: Command[], query: string): Command[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return commands;
+
+  const scored: Array<{ cmd: Command; score: number }> = [];
+
+  for (const cmd of commands) {
+    const label = cmd.label.toLowerCase();
+    const category = (cmd.category || "").toLowerCase();
+    const keywords = (cmd.keywords || []).map((k) => k.toLowerCase());
+
+    let score = 0;
+    if (label === q) {
+      score = 100;
+    } else if (label.startsWith(q)) {
+      score = 80;
+    } else if (matchesWordBoundary(label, q)) {
+      score = 60;
+    } else if (label.includes(q)) {
+      score = 40;
+    } else if (category.includes(q)) {
+      score = 20;
+    } else if (keywords.some((k) => k.includes(q))) {
+      score = 10;
+    }
+
+    if (score > 0) {
+      scored.push({ cmd, score });
+    }
+  }
+
+  // Higher score first; preserve input order on ties.
+  scored.sort((a, b) => b.score - a.score);
+  return scored.map((s) => s.cmd);
+}
+
+function matchesWordBoundary(text: string, query: string): boolean {
+  // Check if `query` appears at the start of any word in `text`.
+  // Words are separated by whitespace or punctuation.
+  const idx = text.indexOf(query);
+  if (idx === -1) return false;
+  if (idx === 0) return true;
+  const before = text.charAt(idx - 1);
+  return !/[a-z0-9]/i.test(before);
+}
+
+/**
+ * Predicate: should a keypress open the command palette?
+ *
+ * Matches Cmd+Shift+P (macOS) and Ctrl+Shift+P (Windows/Linux), case-
+ * insensitive on the key. Requires the Shift modifier so plain ⌘P
+ * (print) still works as the browser expects.
+ *
+ * Pure — takes a KeyboardEvent-shaped object.
+ */
+export function shouldOpenCommandPalette(event: {
+  key: string;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+  target?: unknown;
+}): boolean {
+  const hasCommand = !!event.metaKey || !!event.ctrlKey;
+  if (!hasCommand) return false;
+  if (!event.shiftKey) return false;
+  return event.key === "P" || event.key === "p";
+}

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -42,6 +42,7 @@ export const ALL_SHORTCUTS: Shortcut[] = [
 
   // ─── Help ───────────────────────────────────────────────────────────
   { keys: ["?"], description: "Open keyboard cheatsheet", category: "Help" },
+  { keys: ["⌘", "⇧", "P"], description: "Open command palette", category: "Help" },
 ];
 
 /**


### PR DESCRIPTION
## Summary

Fifth P1a item. Adds a VS Code-style filterable command palette opened with `⌘⇧P` (`Ctrl+Shift+P` on Windows/Linux).

**Binding note:** the original plan specified `⌘K`, but TipTap's link extension already owns `⌘K` in the rich editor. `⌘⇧P` is the standard VS Code binding, unambiguous, and doesn't conflict with anything.

## What the palette does

Opens a centered modal with a search input and a filterable list of commands. Each command has a label, optional category, optional keywords, optional display-only shortcut, and a handler. Keyboard-first: `↑`/`↓` navigates (wrapping), `Enter` runs, `Esc` closes. Click-outside to close, click-to-run.

**Commands registered at launch:**
- Open Settings
- Show keyboard shortcuts
- Toggle dark mode
- New file
- Go to home / welcome screen

Additional commands will be added piecewise as new features land. The registry lives in `page.tsx` so commands can close over state setters and context actions.

## What changed

**`src/lib/command-palette.ts`** — pure helpers:
- `Command` interface
- `filterCommands(commands, query)` — ranked filter. Ranking: exact label match > label starts with query > word-boundary match > anywhere in label > category > keywords. Input order preserved on score ties.
- `shouldOpenCommandPalette(event)` — predicate matching `⌘⇧P` / `Ctrl+⇧+P`, case-insensitive on the key. Requires the Shift modifier so plain `⌘P` (print) still works.

**`src/components/CommandPalette.tsx`** — generic modal. Zero knowledge of any specific command; callers supply the registry. Handler dispatch is deferred with `setTimeout(0)` so the palette unmounts before the handler runs (important for handlers that open other modals like Settings).

**`src/app/page.tsx`** — command registry + keydown listener. The `⌘⇧P` check runs before the `?` cheatsheet check and short-circuits on match.

**`src/lib/keyboard-shortcuts.ts`** — adds "⌘⇧P — Open command palette" to the Help category so the palette is discoverable from the `?` overlay.

## Tests

Test-first. 17 new tests:

**`filterCommands`** — empty query, label substring, case-insensitive, category match, keyword match, partial substring, no-match, exact-label-wins ranking, label-start-beats-mid-word ranking.

**`shouldOpenCommandPalette`** — ⌘⇧P, Ctrl+⇧+P, lowercase `p`, missing Shift (plain ⌘P = print), missing modifier, wrong key, and the "modifier is explicit enough to fire in an input/textarea/contenteditable" positive cases.

**Test count:** 291 → 308 (+17). Build clean.

## Test plan

- [ ] Press `⌘⇧P` anywhere → palette opens, search input focused
- [ ] Type "dark" → toggle-theme command is selected
- [ ] Press `Enter` → theme toggles, palette closes
- [ ] Reopen, type "set" → Open Settings selected
- [ ] Press `Enter` → Settings modal opens (palette closes cleanly before Settings mounts)
- [ ] `↑`/`↓` navigates and wraps around
- [ ] Mouse-hovering an item moves the selection highlight to it
- [ ] `Esc` closes without running anything
- [ ] Click outside the panel closes it
- [ ] Plain `⌘P` still triggers the browser Print dialog (not hijacked)
- [ ] `⌘⇧P` in a comment textarea still opens the palette
- [ ] Cheatsheet (`?`) shows the "Open command palette" entry