### PR TITLE
fix: settings panel — classic PAT instructions

### DIFF
--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -169,15 +169,23 @@ export default function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
 
                   <div className="bg-[var(--surface-secondary)] rounded-lg p-3 mb-4">
                     <p className="text-xs text-[var(--text-secondary)] mb-2">
-                      <strong>How to create a token:</strong>
+                      <strong>How to create a classic token:</strong>
                     </p>
                     <ol className="text-xs text-[var(--text-muted)] space-y-1 list-decimal ml-4">
-                      <li>Go to GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens</li>
-                      <li>Click "Generate new token"</li>
-                      <li>Select the repositories you want to access</li>
-                      <li>Under Permissions, enable: Contents (Read), Pull Requests (Read & Write), Issues (Read & Write)</li>
-                      <li>Generate and paste below</li>
+                      <li>Go to GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)</li>
+                      <li>Click "Generate new token" → "Generate new token (classic)"</li>
+                      <li>Give it a note (e.g. "MarDoc") and set an expiration</li>
+                      <li>
+                        Check the <strong>repo</strong> scope — this single scope covers reading
+                        code, managing pull requests, and creating review comments
+                      </li>
+                      <li>Click "Generate token", copy the <code className="px-1 rounded bg-[var(--surface)]">ghp_…</code> value, and paste below</li>
                     </ol>
+                    <p className="text-[10px] text-[var(--text-muted)] mt-2 italic">
+                      Classic tokens are simpler than fine-grained ones — one scope, one click.
+                      If you already have a fine-grained token with Contents + Pull Requests +
+                      Issues permissions, it will also work.
+                    </p>
                   </div>
 
                   <label className="block text-sm font-medium text-[var(--text-primary)] mb-1.5">
@@ -188,7 +196,7 @@ export default function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
                       type="password"
                       value={tokenInput}
                       onChange={(e) => setTokenInput(e.target.value)}
-                      placeholder="github_pat_..."
+                      placeholder="ghp_..."
                       className="flex-1 px-3 py-2 text-sm rounded-lg border border-[var(--border)] bg-[var(--surface)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)] font-mono"
                       onKeyDown={(e) => {
                         if (e.key === "Enter") handleConnect();


### PR DESCRIPTION
## Summary

Switch the Settings → Connect GitHub onboarding from fine-grained PAT instructions to classic PAT instructions. Classic tokens are one scope, one click — fine-grained tokens require picking individual repos, setting per-permission access, and navigating a multi-step wizard that kills the first-time demo-to-real transition.

## What changed

- Rewrote the "How to create a token" list to walk users through:
  1. Tokens (classic) → Generate new token (classic)
  2. Note + expiration
  3. Check the `repo` scope — the single scope covers every capability MarDoc needs (read code, manage PRs, create review comments)
  4. Copy the `ghp_…` value
- Added a footnote clarifying that existing fine-grained tokens still work if the user has already set one up — the change is documentation, not a breaking change to the auth layer.
- Placeholder updated from `github_pat_...` to `ghp_...` to match the classic token prefix.

No behavior change in the auth layer itself — the fix is pure copy.

## Test plan

- [ ] Open Settings (demo mode is fine) → check the "How to create a token" list reads the classic-token flow
- [ ] The placeholder in the token input reads `ghp_...`
- [ ] Follow the steps on GitHub and paste a fresh classic `ghp_` token → repo list loads successfully
- [ ] An existing fine-grained token continues to authenticate successfully (no regression)