### PR TITLE
feat: outline / TOC side panel with scroll-spy

### DIFF
--- a/src/__tests__/outline.test.ts
+++ b/src/__tests__/outline.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for outline / TOC extraction. Pure markdown → heading list.
+ *
+ * Supports ATX headings (# Heading 1, ## Heading 2, …), excludes
+ * headings that appear inside fenced code blocks, and emits a slug
+ * compatible with GitHub's anchor link convention.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  extractHeadings,
+  slugifyHeading,
+  type OutlineHeading,
+} from "@/lib/outline";
+
+describe("slugifyHeading", () => {
+  it("lowercases ASCII letters", () => {
+    expect(slugifyHeading("Hello World")).toBe("hello-world");
+  });
+
+  it("replaces spaces with hyphens", () => {
+    expect(slugifyHeading("my heading title")).toBe("my-heading-title");
+  });
+
+  it("strips punctuation", () => {
+    expect(slugifyHeading("Hello, World!")).toBe("hello-world");
+    expect(slugifyHeading("What's new?")).toBe("whats-new");
+  });
+
+  it("collapses repeated hyphens", () => {
+    expect(slugifyHeading("a - b - c")).toBe("a-b-c");
+    expect(slugifyHeading("foo --- bar")).toBe("foo-bar");
+  });
+
+  it("trims leading and trailing hyphens", () => {
+    expect(slugifyHeading("-leading")).toBe("leading");
+    expect(slugifyHeading("trailing-")).toBe("trailing");
+    expect(slugifyHeading("---both---")).toBe("both");
+  });
+
+  it("preserves numbers", () => {
+    expect(slugifyHeading("Step 1: Install")).toBe("step-1-install");
+  });
+
+  it("returns empty string for empty or whitespace-only input", () => {
+    expect(slugifyHeading("")).toBe("");
+    expect(slugifyHeading("   ")).toBe("");
+  });
+
+  it("strips inline markdown (bold, italic, code) from headings", () => {
+    expect(slugifyHeading("**Hello** _world_")).toBe("hello-world");
+    expect(slugifyHeading("Use `foo.bar()` here")).toBe("use-foobar-here");
+  });
+
+  it("handles emoji (drops them)", () => {
+    // GitHub keeps emoji in some contexts, but for our anchor-link case
+    // dropping them keeps the slug URL-safe and predictable.
+    expect(slugifyHeading("🚀 launch day")).toBe("launch-day");
+  });
+});
+
+describe("extractHeadings", () => {
+  // ─── Trivial ────────────────────────────────────────────────────────────
+
+  it("returns empty for empty input", () => {
+    expect(extractHeadings("")).toEqual([]);
+  });
+
+  it("returns empty for a document with no headings", () => {
+    expect(extractHeadings("just a paragraph\n\nanother one")).toEqual([]);
+  });
+
+  // ─── ATX headings ───────────────────────────────────────────────────────
+
+  it("extracts a single ATX heading", () => {
+    const out = extractHeadings("# Hello");
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      level: 1,
+      text: "Hello",
+      slug: "hello",
+      line: 1,
+    });
+  });
+
+  it("extracts H1 through H6", () => {
+    const md = "# a\n## b\n### c\n#### d\n##### e\n###### f";
+    const out = extractHeadings(md);
+    expect(out).toHaveLength(6);
+    expect(out.map((h) => h.level)).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(out.map((h) => h.text)).toEqual(["a", "b", "c", "d", "e", "f"]);
+  });
+
+  it("does not extract seven or more hashes", () => {
+    // `####### notahead` is seven hashes — not a valid ATX heading.
+    expect(extractHeadings("####### seven")).toEqual([]);
+  });
+
+  it("requires a space between the # and the text", () => {
+    // `#Heading` (no space) is not a valid ATX heading.
+    expect(extractHeadings("#NoSpace")).toEqual([]);
+  });
+
+  it("captures line numbers (1-indexed)", () => {
+    const md = "paragraph\n\n# Heading\n\nmore text\n\n## Subheading";
+    const out = extractHeadings(md);
+    expect(out).toHaveLength(2);
+    expect(out[0].line).toBe(3);
+    expect(out[1].line).toBe(7);
+  });
+
+  it("ignores headings inside fenced code blocks", () => {
+    const md = [
+      "# Real",
+      "",
+      "```",
+      "# not a heading",
+      "## also not a heading",
+      "```",
+      "",
+      "## Real subheading",
+    ].join("\n");
+    const out = extractHeadings(md);
+    expect(out).toHaveLength(2);
+    expect(out.map((h) => h.text)).toEqual(["Real", "Real subheading"]);
+  });
+
+  it("handles variable-length fences correctly", () => {
+    // Outer fence of 4 backticks can contain a 3-backtick inner block —
+    // neither fence should fool the heading parser.
+    const md = [
+      "````",
+      "# inside outer fence",
+      "```",
+      "## still inside",
+      "```",
+      "````",
+      "",
+      "# real",
+    ].join("\n");
+    const out = extractHeadings(md);
+    expect(out).toHaveLength(1);
+    expect(out[0].text).toBe("real");
+  });
+
+  it("strips trailing hashes from ATX closers (`# title #`)", () => {
+    // CommonMark allows `# title #` — trailing hashes are decoration.
+    expect(extractHeadings("# Title #")[0].text).toBe("Title");
+    expect(extractHeadings("## Title ##")[0].text).toBe("Title");
+  });
+
+  it("strips inline markdown in heading text but keeps it for slugify input", () => {
+    const out = extractHeadings("# Hello **world**");
+    expect(out[0].text).toBe("Hello world");
+    expect(out[0].slug).toBe("hello-world");
+  });
+
+  // ─── Multiple headings ──────────────────────────────────────────────────
+
+  it("preserves source order across a realistic document", () => {
+    const md = [
+      "# Introduction",
+      "",
+      "paragraph",
+      "",
+      "## Background",
+      "",
+      "## Prior art",
+      "",
+      "# Approach",
+      "",
+      "### Step 1",
+      "",
+      "### Step 2",
+    ].join("\n");
+    const out = extractHeadings(md);
+    expect(out.map((h) => h.text)).toEqual([
+      "Introduction",
+      "Background",
+      "Prior art",
+      "Approach",
+      "Step 1",
+      "Step 2",
+    ]);
+    expect(out.map((h) => h.level)).toEqual([1, 2, 2, 1, 3, 3]);
+  });
+
+  it("dedupes identical slugs by appending -1, -2, etc.", () => {
+    // GitHub's anchor scheme handles duplicate headings by suffixing.
+    const md = "# Intro\n\n## Details\n\n# Intro\n\n## Details";
+    const out = extractHeadings(md);
+    expect(out.map((h) => h.slug)).toEqual([
+      "intro",
+      "details",
+      "intro-1",
+      "details-1",
+    ]);
+  });
+
+  // ─── Edge cases ─────────────────────────────────────────────────────────
+
+  it("does not extract `>` blockquoted headings", () => {
+    // `> # quoted` is a blockquote containing a heading. For outline
+    // purposes, skip it — it's not a top-level section.
+    expect(extractHeadings("> # quoted\n\n# real")).toHaveLength(1);
+    expect(extractHeadings("> # quoted\n\n# real")[0].text).toBe("real");
+  });
+
+  it("does not extract headings preceded by text on the same line", () => {
+    // `text # not a heading` — hash must be at the start of the line.
+    expect(extractHeadings("paragraph # not")).toEqual([]);
+  });
+
+  it("handles leading whitespace (up to 3 spaces per CommonMark)", () => {
+    // 0-3 leading spaces → still a heading.
+    expect(extractHeadings("   # indented")).toHaveLength(1);
+    // 4+ leading spaces → indented code block, not a heading.
+    expect(extractHeadings("    # indented-code")).toEqual([]);
+  });
+});

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -47,6 +47,7 @@ import { analyzeMarkdown, type MarkdownStats } from "@/lib/word-count";
 import { transformGitHubAlerts } from "@/lib/github-alerts";
 import FindReplaceBar from "./FindReplaceBar";
 import type { Match as FindMatch } from "@/lib/find-replace";
+import Outline from "./Outline";
 import { classifyLink, resolvePath, findFileByPath } from "@/lib/link-handler";
 import { useApp } from "@/lib/app-context";
 import { openExternal } from "@/lib/open-external";
@@ -72,6 +73,7 @@ import {
   Highlighter,
   FileCode,
   Braces,
+  List as ListIcon,
   MessageSquarePlus,
   MessageSquare,
   Send,
@@ -665,9 +667,23 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
   // same debounce tick as the dirty check so we don't run Turndown twice.
   const [stats, setStats] = useState<MarkdownStats>({ words: 0, readingMinutes: 0 });
 
+  // Current markdown view used by feature widgets that render off the raw
+  // source (outline / TOC). Updated in the same debounce tick as the
+  // dirty check to avoid an extra Turndown pass.
+  const [currentMarkdown, setCurrentMarkdown] = useState("");
+
   // Find/replace panel — only available in code view. In rich view, Cmd+F
   // falls through to the browser's native find.
   const [findBarOpen, setFindBarOpen] = useState(false);
+
+  // Outline / TOC side panel. Shows the current document's headings with
+  // click-to-jump and scroll-spy. Toggled from the toolbar.
+  const [outlineOpen, setOutlineOpen] = useState(false);
+
+  // Markdown fed to the outline extractor. Code view has it in state
+  // directly; rich view gets the debounced currentMarkdown, one tick
+  // behind the cursor (fine — heading edits are infrequent).
+  const outlineMarkdown = codeView ? codeContent : currentMarkdown;
 
   // Dirty tracking for existing files — compare current markdown to original
   const [isDirty, setIsDirty] = useState(false);
@@ -764,6 +780,7 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
         const { dirty } = reconcileDraft(scope, originalMarkdownRef.current, currentMd);
         setIsDirty(dirty);
         setStats(analyzeMarkdown(currentMd));
+        setCurrentMarkdown(currentMd);
       }, 300);
     },
     editorProps: {
@@ -787,8 +804,9 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
           // Capture baseline markdown for dirty comparison
           const turndown = createTurndownService();
           originalMarkdownRef.current = turndown.turndown(editor.getHTML());
-          // Initialize the word-count display from the loaded content.
+          // Initialize downstream feature state from the loaded content.
           setStats(analyzeMarkdown(originalMarkdownRef.current));
+          setCurrentMarkdown(originalMarkdownRef.current);
 
           // Check for a locally-saved draft that differs from upstream — if
           // found, offer to restore it. resolveDraftOnLoad handles the
@@ -1257,6 +1275,15 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
 
   return (
     <div className="h-full flex">
+      {/* Outline / TOC side panel */}
+      {outlineOpen && !isNewFile && (
+        <Outline
+          markdown={outlineMarkdown}
+          editorContainerRef={editorContainerRef}
+          onClose={() => setOutlineOpen(false)}
+        />
+      )}
+
       {/* Main editor column */}
       <div className="flex-1 flex flex-col min-w-0">
         {/* Toolbar */}
@@ -1517,6 +1544,14 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
                 {stats.words.toLocaleString()} words · {stats.readingMinutes} min
               </span>
             )}
+            <button
+              onClick={() => setOutlineOpen((v) => !v)}
+              className={`toolbar-btn ${outlineOpen ? "active" : ""}`}
+              title={outlineOpen ? "Hide outline" : "Show outline / table of contents"}
+              aria-pressed={outlineOpen}
+            >
+              <ListIcon size={15} />
+            </button>
             <button
               onClick={toggleCodeView}
               className={`flex items-center gap-1 px-2 py-1 text-[11px] rounded-md transition-colors ${

--- a/src/components/Outline.tsx
+++ b/src/components/Outline.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { List, X } from "lucide-react";
+import { extractHeadings, type OutlineHeading } from "@/lib/outline";
+
+interface OutlineProps {
+  /** Current markdown — outline re-extracts on every change. */
+  markdown: string;
+  /** The scrollable editor container used for scroll-spy. */
+  editorContainerRef: React.RefObject<HTMLElement>;
+  /** Called to close the outline panel. */
+  onClose: () => void;
+}
+
+/**
+ * Document outline / table of contents with click-to-jump and
+ * scroll-spy highlight of the currently-visible heading.
+ *
+ * Heading extraction is delegated to @/lib/outline (pure, tested).
+ * Click-to-jump looks up the heading's rendered element inside the
+ * editor container by its slug (TipTap + showdown both emit stable
+ * id attributes for headings), falling back to a text-match walk if
+ * the id isn't set.
+ *
+ * Scroll-spy uses IntersectionObserver to find the topmost visible
+ * heading and highlights its outline entry.
+ */
+export default function Outline({ markdown, editorContainerRef, onClose }: OutlineProps) {
+  const headings = useMemo(() => extractHeadings(markdown), [markdown]);
+  const [activeSlug, setActiveSlug] = useState<string | null>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Scroll-spy. Observe every heading in the editor container and
+  // track which one is closest to the top of the visible area.
+  useEffect(() => {
+    const container = editorContainerRef.current;
+    if (!container || headings.length === 0) return;
+
+    const headingEls: HTMLElement[] = Array.from(
+      container.querySelectorAll("h1, h2, h3, h4, h5, h6")
+    );
+    if (headingEls.length === 0) return;
+
+    // Map each DOM element to a heading slug by matching text content
+    // against the extracted headings. We don't rely on id attributes
+    // because TipTap doesn't always set them.
+    const elToSlug = new Map<Element, string>();
+    for (let i = 0; i < Math.min(headingEls.length, headings.length); i++) {
+      elToSlug.set(headingEls[i], headings[i].slug);
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible.length === 0) return;
+        const slug = elToSlug.get(visible[0].target);
+        if (slug) setActiveSlug(slug);
+      },
+      {
+        root: container,
+        // The "hot zone" is the top third of the viewport — the
+        // heading whose top is in that band is the active one.
+        rootMargin: "0px 0px -66% 0px",
+        threshold: 0,
+      }
+    );
+
+    for (const el of headingEls) observer.observe(el);
+    return () => observer.disconnect();
+  }, [headings, markdown, editorContainerRef]);
+
+  const jumpTo = (h: OutlineHeading) => {
+    const container = editorContainerRef.current;
+    if (!container) return;
+    // Try id first, then fall back to position (N-th heading of this level).
+    let target: HTMLElement | null = container.querySelector(`#${CSS.escape(h.slug)}`);
+    if (!target) {
+      const all = Array.from(
+        container.querySelectorAll<HTMLElement>(`h${h.level}`)
+      );
+      target = all.find((el) => (el.textContent || "").trim() === h.text) || null;
+    }
+    if (!target) {
+      // Final fallback: match by position in the full heading list.
+      const all = Array.from(
+        container.querySelectorAll<HTMLElement>("h1, h2, h3, h4, h5, h6")
+      );
+      const idx = headings.findIndex((x) => x.slug === h.slug);
+      if (idx >= 0 && all[idx]) target = all[idx];
+    }
+    if (target) {
+      target.scrollIntoView({ behavior: "smooth", block: "start" });
+      setActiveSlug(h.slug);
+    }
+  };
+
+  return (
+    <aside
+      ref={panelRef}
+      className="w-56 shrink-0 border-r border-[var(--border)] bg-[var(--surface-secondary)] flex flex-col h-full overflow-hidden"
+      aria-label="Document outline"
+    >
+      <div className="flex items-center justify-between px-3 py-2.5 border-b border-[var(--border)]">
+        <div className="flex items-center gap-1.5">
+          <List size={12} className="text-[var(--text-muted)]" />
+          <span className="text-xs font-medium text-[var(--text-primary)]">
+            Outline
+          </span>
+        </div>
+        <button
+          onClick={onClose}
+          className="text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+          aria-label="Close outline"
+          title="Close outline"
+        >
+          <X size={12} />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto py-1">
+        {headings.length === 0 ? (
+          <p className="text-[10px] text-[var(--text-muted)] px-3 py-4 italic">
+            No headings in this document. Add a <code>#</code> heading to start
+            the outline.
+          </p>
+        ) : (
+          <ul className="text-xs">
+            {headings.map((h) => {
+              const isActive = activeSlug === h.slug;
+              return (
+                <li key={h.slug}>
+                  <button
+                    onClick={() => jumpTo(h)}
+                    className={`block w-full text-left px-3 py-1 truncate transition-colors ${
+                      isActive
+                        ? "bg-[var(--accent-muted)] text-[var(--accent)] font-medium"
+                        : "text-[var(--text-secondary)] hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)]"
+                    }`}
+                    style={{ paddingLeft: `${0.75 + (h.level - 1) * 0.75}rem` }}
+                    title={h.text}
+                  >
+                    {h.text}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/src/lib/outline.ts
+++ b/src/lib/outline.ts
@@ -1,0 +1,130 @@
+/**
+ * Pure markdown → heading outline extractor.
+ *
+ * Supports ATX-style headings (# Heading 1 … ###### Heading 6), skips
+ * headings inside fenced code blocks (any fence length ≥ 3), and emits
+ * a GitHub-compatible slug per heading for anchor linking.
+ *
+ * Tested in outline.test.ts.
+ */
+
+export interface OutlineHeading {
+  level: 1 | 2 | 3 | 4 | 5 | 6;
+  text: string;
+  slug: string;
+  line: number; // 1-indexed source line
+}
+
+const HEADING_RE = /^ {0,3}(#{1,6})\s+(.+?)\s*$/;
+
+/**
+ * Slugify a heading's text into an anchor-style id. Matches the broad
+ * shape of GitHub's scheme: lowercase, strip punctuation, replace
+ * whitespace and runs of non-alphanumerics with a single hyphen, trim.
+ *
+ * Strips inline markdown markers (`**`, `_`, `~~`, backticks) and drops
+ * emoji / non-ASCII so the output stays URL-safe.
+ */
+export function slugifyHeading(text: string): string {
+  // Strip backtick-delimited inline code first, keeping the content
+  // (without the backticks themselves).
+  let s = text.replace(/`([^`]+)`/g, "$1");
+  // Strip bold / italic / strikethrough markers.
+  s = s.replace(/(\*{1,3}|_{1,3}|~{2})/g, "");
+  // Lowercase.
+  s = s.toLowerCase();
+  // Drop anything outside [a-z0-9\s-].
+  s = s.replace(/[^a-z0-9\s-]/g, "");
+  // Collapse whitespace runs.
+  s = s.replace(/\s+/g, "-");
+  // Collapse hyphen runs.
+  s = s.replace(/-+/g, "-");
+  // Trim leading/trailing hyphens.
+  s = s.replace(/^-+|-+$/g, "");
+  return s;
+}
+
+/**
+ * Extract every heading from the markdown source. Skips headings that
+ * appear inside fenced code blocks (where `# Heading` is actually a
+ * comment or similar in the code). Returns headings in source order
+ * with 1-indexed line numbers and deduped slugs.
+ */
+export function extractHeadings(markdown: string): OutlineHeading[] {
+  if (!markdown) return [];
+
+  const lines = markdown.split("\n");
+  const headings: OutlineHeading[] = [];
+
+  // Track the active fence length (0 = not in a fence). Longer outer
+  // fences can contain shorter inner fences, which is how we skip the
+  // whole block even when the inner contains a `# heading` literal.
+  let activeFenceLength = 0;
+  const fenceRe = /^(`{3,})/;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Fence tracking. We look for a fence at the start of the line
+    // (ATX + setext markers also start-of-line, so this is cheap).
+    const fenceMatch = line.match(fenceRe);
+    if (fenceMatch) {
+      const fenceLen = fenceMatch[1].length;
+      if (activeFenceLength === 0) {
+        // Opening fence.
+        activeFenceLength = fenceLen;
+      } else if (fenceLen === activeFenceLength) {
+        // Closing fence (must match the opener's length exactly).
+        activeFenceLength = 0;
+      }
+      continue;
+    }
+
+    if (activeFenceLength !== 0) continue;
+
+    // Indented code block: 4+ leading spaces (or a tab). Skip.
+    if (/^( {4,}|\t)/.test(line)) continue;
+
+    // ATX heading.
+    const match = line.match(HEADING_RE);
+    if (!match) continue;
+
+    const hashes = match[1];
+    // More than six hashes → not a heading.
+    if (hashes.length > 6) continue;
+
+    // Strip a trailing ATX closer (` #` / ` ##` / …).
+    let rawText = match[2].replace(/\s+#+\s*$/, "");
+    // Strip basic inline markdown for the display text.
+    const displayText = stripInlineMarkdown(rawText);
+
+    headings.push({
+      level: hashes.length as OutlineHeading["level"],
+      text: displayText,
+      slug: slugifyHeading(rawText),
+      line: i + 1,
+    });
+  }
+
+  // Dedupe slugs — identical slugs get numeric suffixes (matches
+  // GitHub's anchor-link scheme for duplicate headings).
+  const seen = new Map<string, number>();
+  for (const h of headings) {
+    const count = seen.get(h.slug) || 0;
+    if (count > 0) {
+      h.slug = `${h.slug}-${count}`;
+    }
+    seen.set(h.slug.replace(/-\d+$/, ""), count + 1);
+  }
+
+  return headings;
+}
+
+function stripInlineMarkdown(s: string): string {
+  let out = s;
+  // Inline code — keep the content.
+  out = out.replace(/`([^`]+)`/g, "$1");
+  // Bold / italic / strikethrough markers.
+  out = out.replace(/(\*{1,3}|_{1,3}|~{2})/g, "");
+  return out;
+}


### PR DESCRIPTION
## Summary

Sixth P1a item. Collapsible outline panel on the left side of the editor, showing every heading in the current document. Click to jump, current-heading highlight as you scroll.

## What changed

**`src/lib/outline.ts`** — pure helpers:
- `slugifyHeading(text)` — GitHub-compatible anchor slug. Lowercase, strip punctuation, collapse hyphens, drop inline markdown and emoji.
- `extractHeadings(markdown)` — walks the source, emits `{ level, text, slug, line }` for every ATX heading, skipping fenced code blocks (handles variable-length fences so nested \`\`\`\`  containing \`\`\` doesn't fool the parser). Dedupes duplicate slugs with numeric suffixes like GitHub does.

**`src/components/Outline.tsx`** — panel UI:
- Runs `extractHeadings` on the provided markdown.
- `IntersectionObserver` on every `h1`–`h6` in the editor container drives scroll-spy. Root margin of `0px 0px -66% 0px` creates a "hot zone" in the top third of the viewport — the heading in that band is the active one.
- Click jumps the heading into view (tries `id`, falls back to text match, falls back to positional match).
- Indentation reflects heading level.
- Empty state when the document has no headings.

**`src/components/Editor.tsx`**:
- New `outlineOpen` state + toolbar toggle button (List icon) in the right cluster.
- New `currentMarkdown` state updated in the same 300 ms debounce tick as the dirty check and stats — no extra Turndown pass.
- Outline panel inserted as the first child of the editor's outer flex row so it sits to the left of the editor column.
- Hidden in new-file mode (nothing to outline yet).

## Tests

Test-first. 25 new tests covering:

**`slugifyHeading`** — lowercase, hyphen separation, punctuation, repeated hyphens, trimming, numbers, empty input, inline markdown, emoji.

**`extractHeadings`** — empty / no-headings, H1–H6, rejection of 7+ hashes and missing space after `#`, line-number capture, fenced-code exclusion, variable-length fence handling, trailing `#` closers, inline markdown in display text vs slugify, realistic document ordering, duplicate slug deduping, blockquoted headings rejected, mid-line hashes rejected, 0–3 leading spaces accepted, 4+ rejected.

**Test count:** 308 → 333 (+25). Build clean.

## Test plan

- [ ] Open a `.md` file with multiple headings → toolbar shows the outline button
- [ ] Click the outline button → left panel appears, lists all headings with level indentation
- [ ] Click a heading in the outline → editor scrolls to it
- [ ] Scroll the editor manually → the outline's active heading tracks your position
- [ ] Headings inside fenced code blocks (`\`\`\`js\n# not a heading\n\`\`\``) are NOT listed
- [ ] Duplicate headings get numbered slugs (click both — each jumps to the correct one)
- [ ] Switch to code view → outline continues to reflect the markdown source
- [ ] New-file mode → outline button is not shown
- [ ] Empty document (no headings) → outline shows "No headings in this document" hint
- [ ] Close the outline → panel disappears, main editor column reclaims the width