### PR TITLE
feat: footnotes — [^label] refs + definitions

### DIFF
--- a/src/__tests__/footnotes.test.ts
+++ b/src/__tests__/footnotes.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for footnote transformation. transformFootnotes is a PRE-processor
+ * on the markdown source (not a post-processor on HTML like alerts) because
+ * Showdown's own reference-link handling mangles `[^label]: body` — it
+ * parses `[^a]` / `[^a]: First.` as a reference-link shortcut and emits
+ * `<a href="First.">^a</a>`. Pre-processing strips definitions out before
+ * Showdown ever sees them.
+ *
+ * Transformation rules:
+ *   - Numbered in order of FIRST reference in the source
+ *   - Definition bodies resolved once, even if referenced multiple times
+ *   - Unreferenced definitions are dropped (not rendered)
+ *   - References replaced inline with <sup><a href="#fn-N">N</a></sup>
+ *   - A footnotes section is appended at the end with back-links
+ */
+import { describe, it, expect } from "vitest";
+import Showdown from "showdown";
+import { transformFootnotes } from "@/lib/footnotes";
+
+function runThroughShowdown(md: string): string {
+  const sd = new Showdown.Converter({ tables: true, strikethrough: true, ghCodeBlocks: true });
+  return sd.makeHtml(transformFootnotes(md));
+}
+
+describe("transformFootnotes — pre-processor", () => {
+  // ─── No-op cases ────────────────────────────────────────────────────────
+
+  it("returns empty input unchanged", () => {
+    expect(transformFootnotes("")).toBe("");
+  });
+
+  it("returns a document with no footnotes unchanged", () => {
+    const md = "# Heading\n\nJust a paragraph. No footnotes.";
+    expect(transformFootnotes(md)).toBe(md);
+  });
+
+  // ─── Reference replacement ─────────────────────────────────────────────
+
+  it("replaces a single reference with a sup/anchor", () => {
+    const md = "Paragraph[^1].\n\n[^1]: The body.";
+    const out = transformFootnotes(md);
+    expect(out).toContain('<sup class="footnote-ref"');
+    expect(out).toContain('id="fnref-1"');
+    expect(out).toContain('href="#fn-1"');
+    expect(out).toContain(">1</a>");
+    // The inline `[^1]` token must be gone.
+    expect(out).not.toContain("[^1]");
+  });
+
+  it("numbers references in order of first appearance", () => {
+    // "b" appears first in the text; "a" appears second. The numbering
+    // must follow document order, not alphabetical or definition order.
+    const md = "First ref[^b] then[^a].\n\n[^a]: A.\n[^b]: B.";
+    const out = transformFootnotes(md);
+    const bIdx = out.indexOf('id="fnref-1"');
+    const aIdx = out.indexOf('id="fnref-2"');
+    expect(bIdx).toBeGreaterThan(-1);
+    expect(aIdx).toBeGreaterThan(aIdx > -1 ? bIdx : -1);
+    // Body "B." should be labelled 1, body "A." should be labelled 2.
+    expect(out).toMatch(/id="fn-1"[\s\S]*B\./);
+    expect(out).toMatch(/id="fn-2"[\s\S]*A\./);
+  });
+
+  it("numbers references starting from 1 per document", () => {
+    const md = "x[^a] y[^b] z[^c].\n\n[^a]: 1.\n[^b]: 2.\n[^c]: 3.";
+    const out = transformFootnotes(md);
+    expect(out).toContain('id="fnref-1"');
+    expect(out).toContain('id="fnref-2"');
+    expect(out).toContain('id="fnref-3"');
+  });
+
+  it("reuses the same number for repeated references to the same label", () => {
+    // `[^1]` appears twice in the body but has one definition — both
+    // references should link to the same `#fn-1`.
+    const md = "One[^1], two[^1].\n\n[^1]: Single def.";
+    const out = transformFootnotes(md);
+    const matches = out.match(/href="#fn-1"/g) || [];
+    expect(matches.length).toBe(2);
+    // Only one footnote body should appear.
+    const bodyMatches = out.match(/id="fn-1"/g) || [];
+    expect(bodyMatches.length).toBe(1);
+  });
+
+  // ─── Definition stripping ──────────────────────────────────────────────
+
+  it("removes definition lines from the document body", () => {
+    const md = "Paragraph[^1].\n\n[^1]: Body text.";
+    const out = transformFootnotes(md);
+    // The literal `[^1]: Body text.` string must NOT appear in the
+    // prose area (it gets moved to the footnotes section with different
+    // formatting).
+    expect(out).not.toContain("[^1]: Body text.");
+  });
+
+  it("drops unreferenced definitions entirely", () => {
+    const md = "Paragraph.\n\n[^orphan]: Unused body.";
+    const out = transformFootnotes(md);
+    expect(out).not.toContain("Unused body");
+    expect(out).not.toContain("orphan");
+    expect(out).not.toContain("footnote");
+  });
+
+  it("does not transform a reference with no matching definition", () => {
+    // If there's no `[^missing]: ...` anywhere, leave the inline token
+    // as literal text. This matches Pandoc's behavior.
+    const md = "Paragraph [^missing] here.";
+    const out = transformFootnotes(md);
+    expect(out).toContain("[^missing]");
+    expect(out).not.toContain("footnote-ref");
+  });
+
+  // ─── Footnotes section ────────────────────────────────────────────────
+
+  it("appends a footnotes section at the end", () => {
+    const md = "Paragraph[^1].\n\n[^1]: Body.";
+    const out = transformFootnotes(md);
+    expect(out).toContain('<section class="footnotes"');
+    expect(out).toContain("<ol");
+    expect(out).toContain('id="fn-1"');
+    expect(out).toContain("Body");
+  });
+
+  it("each definition has a back-link to its reference", () => {
+    const md = "Paragraph[^1].\n\n[^1]: Body.";
+    const out = transformFootnotes(md);
+    expect(out).toContain('href="#fnref-1"');
+    expect(out).toContain("footnote-back");
+  });
+
+  it("omits the footnotes section when no references are resolved", () => {
+    // The word "footnote" appears in the source, so we assert against the
+    // HTML markers the transform would add — not the literal word.
+    const md = "No footnotes here. Just text.";
+    const out = transformFootnotes(md);
+    expect(out).not.toContain("<section");
+    expect(out).not.toContain("fnref-");
+  });
+
+  it("omits the footnotes section when every reference is missing its definition", () => {
+    const md = "A [^one] B [^two] C.";
+    const out = transformFootnotes(md);
+    expect(out).not.toContain("<section");
+    expect(out).not.toContain("fnref-");
+  });
+
+  // ─── Integration with Showdown ────────────────────────────────────────
+
+  it("end-to-end through Showdown: references render as live links", () => {
+    const md = "Paragraph[^1].\n\n[^1]: The body.";
+    const html = runThroughShowdown(md);
+    expect(html).toContain('<sup class="footnote-ref"');
+    expect(html).toContain('href="#fn-1"');
+    // The body "The body." should appear inside the footnotes section.
+    expect(html).toContain("The body");
+    // The inline `[^1]` literal must be gone.
+    expect(html).not.toContain("[^1]");
+  });
+
+  it("end-to-end: two references with swapped alphabetical order", () => {
+    // This is the case that mangled under raw Showdown (`<a href="First.">`).
+    // Post-transform, it should be clean.
+    const md = "Two refs[^a] and[^b].\n\n[^a]: First.\n[^b]: Second.";
+    const html = runThroughShowdown(md);
+    expect(html).toContain("First");
+    expect(html).toContain("Second");
+    // No bogus reference-link leaks.
+    expect(html).not.toContain('href="First');
+    expect(html).not.toContain('href="Second');
+  });
+
+  // ─── Edge cases ───────────────────────────────────────────────────────
+
+  it("ignores `[^label]` inside fenced code blocks", () => {
+    const md = [
+      "Real ref[^1].",
+      "",
+      "```",
+      "Code with [^1] literal.",
+      "```",
+      "",
+      "[^1]: Body.",
+    ].join("\n");
+    const out = transformFootnotes(md);
+    // The code-block literal should NOT have been transformed.
+    expect(out).toContain("[^1] literal");
+    // The real reference in the paragraph should be transformed.
+    expect(out).toContain('id="fnref-1"');
+  });
+
+  it("allows alphanumeric + hyphen + underscore labels", () => {
+    const md = "A[^foo-1] B[^bar_2] C[^baz3].\n\n[^foo-1]: 1\n[^bar_2]: 2\n[^baz3]: 3";
+    const out = transformFootnotes(md);
+    expect(out).toContain('id="fnref-1"');
+    expect(out).toContain('id="fnref-2"');
+    expect(out).toContain('id="fnref-3"');
+  });
+
+  it("handles inline formatting inside definition bodies", () => {
+    const md = "x[^1].\n\n[^1]: Body with **bold** and _italic_.";
+    const html = runThroughShowdown(md);
+    expect(html).toContain("<strong>bold</strong>");
+    expect(html).toContain("<em>italic</em>");
+  });
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -543,3 +543,56 @@ body {
 .dark .markdown-alert-warning { border-left-color: #f1fa8c; }
 .dark .markdown-alert-caution > .markdown-alert-title { color: #ff5555; }
 .dark .markdown-alert-caution { border-left-color: #ff5555; }
+
+/* ─── Footnotes ──────────────────────────────────────────────────────────
+ * Pre-processed by @/lib/footnotes into inline <sup class="footnote-ref">
+ * links and a trailing <section class="footnotes"> block. CSS gives the
+ * section visual separation and styles the tiny back-link arrows.
+ */
+.footnote-ref {
+  font-size: 0.75em;
+  vertical-align: super;
+  line-height: 0;
+}
+.footnote-ref a {
+  text-decoration: none;
+  color: var(--accent);
+  padding: 0 0.1em;
+}
+.footnote-ref a:hover {
+  text-decoration: underline;
+}
+
+.footnotes {
+  margin-top: 2em;
+  padding-top: 1em;
+  border-top: 1px solid var(--border);
+  font-size: 0.9em;
+  color: var(--text-secondary);
+}
+.footnotes ol {
+  list-style-type: decimal;
+  padding-left: 1.5em;
+  margin: 0.5em 0;
+}
+.footnotes li {
+  margin: 0.4em 0;
+  padding-left: 0.25em;
+}
+.footnotes li:target {
+  /* When the user clicks a [^N] reference, the browser jumps to the
+   * <li id="fn-N">. Highlight it briefly so the target is obvious. */
+  background-color: var(--accent-muted);
+  border-radius: 4px;
+  padding: 0.25em 0.5em;
+  transition: background-color 0.3s ease;
+}
+.footnote-back {
+  text-decoration: none;
+  color: var(--text-muted);
+  margin-left: 0.4em;
+  font-size: 0.85em;
+}
+.footnote-back:hover {
+  color: var(--accent);
+}

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -46,6 +46,7 @@ import { isHtmlFile } from "@/lib/file-types";
 import { extractCommentSuggestions, mergeSuggestions } from "@/lib/suggestion-extract";
 import { parseSuggestionBody } from "@/lib/suggestion-body";
 import { transformGitHubAlerts } from "@/lib/github-alerts";
+import { transformFootnotes } from "@/lib/footnotes";
 
 interface DiffViewerProps {
   file: PRFile;
@@ -165,7 +166,9 @@ const diffShowdownConverter = new Showdown.Converter({
 });
 
 function blockToHtml(block: string): string {
-  return highlightCodeBlocks(transformGitHubAlerts(diffShowdownConverter.makeHtml(block)));
+  return highlightCodeBlocks(
+    transformGitHubAlerts(diffShowdownConverter.makeHtml(transformFootnotes(block)))
+  );
 }
 
 function computeWordDiff(oldText: string, newText: string): string {

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/lib/draft-store";
 import { analyzeMarkdown, type MarkdownStats } from "@/lib/word-count";
 import { transformGitHubAlerts } from "@/lib/github-alerts";
+import { transformFootnotes } from "@/lib/footnotes";
 import FindReplaceBar from "./FindReplaceBar";
 import type { Match as FindMatch } from "@/lib/find-replace";
 import Outline from "./Outline";
@@ -128,7 +129,7 @@ const showdownConverter = new Showdown.Converter({
 });
 
 function markdownToHtml(md: string, repoFullName?: string, branch?: string, filePath?: string): string {
-  const html = transformGitHubAlerts(showdownConverter.makeHtml(md));
+  const html = transformGitHubAlerts(showdownConverter.makeHtml(transformFootnotes(md)));
   if (repoFullName && branch && filePath) {
     return rewriteImageUrls(html, repoFullName, branch, filePath);
   }
@@ -860,7 +861,7 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
       setCodeView(true);
       editor.setEditable(false);
     } else {
-      let rawHtml = transformGitHubAlerts(showdownConverter.makeHtml(codeContent));
+      let rawHtml = transformGitHubAlerts(showdownConverter.makeHtml(transformFootnotes(codeContent)));
       if (repoFullName && branch && filePath) {
         rawHtml = rewriteImageUrls(rawHtml, repoFullName, branch, filePath);
       }

--- a/src/components/PRDetail.tsx
+++ b/src/components/PRDetail.tsx
@@ -27,6 +27,7 @@ import {
 import { mergeFreshComments } from "@/lib/comment-merge";
 import { buildSuggestionBody, parseSuggestionBody } from "@/lib/suggestion-body";
 import { transformGitHubAlerts } from "@/lib/github-alerts";
+import { transformFootnotes } from "@/lib/footnotes";
 import DiffViewer from "./DiffViewer";
 import Showdown from "showdown";
 
@@ -535,7 +536,11 @@ export default function PRDetail({ pr, onBack }: PRDetailProps) {
           {pr.description && (
             <div
               className="mt-2 text-sm text-[var(--text-secondary)] prose prose-sm dark:prose-invert max-w-none max-h-40 overflow-y-auto border-t border-[var(--border)] pt-2"
-              dangerouslySetInnerHTML={{ __html: transformGitHubAlerts(descriptionConverter.makeHtml(pr.description)) }}
+              dangerouslySetInnerHTML={{
+                __html: transformGitHubAlerts(
+                  descriptionConverter.makeHtml(transformFootnotes(pr.description))
+                ),
+              }}
             />
           )}
         </div>

--- a/src/lib/footnotes.ts
+++ b/src/lib/footnotes.ts
@@ -1,0 +1,194 @@
+import Showdown from "showdown";
+
+/**
+ * Markdown pre-processor for GitHub-style footnotes.
+ *
+ * Input:
+ *     Paragraph[^1].
+ *
+ *     [^1]: The footnote body.
+ *
+ * Output (markdown, to be fed into Showdown):
+ *     Paragraph<sup class="footnote-ref" id="fnref-1">
+ *       <a href="#fn-1">1</a>
+ *     </sup>.
+ *
+ *     <section class="footnotes">
+ *       <ol>
+ *         <li id="fn-1">The footnote body. <a class="footnote-back" href="#fnref-1">↩</a></li>
+ *       </ol>
+ *     </section>
+ *
+ * Why pre-process? Showdown has no native footnote support, and its
+ * reference-link parser actively mangles `[^label]: body` into
+ * `<a href="body">^label</a>`. Stripping definitions and rewriting
+ * references before Showdown sees them is the only clean fix.
+ *
+ * Numbering follows document order of first reference. Repeated
+ * references to the same label share a number. Unreferenced definitions
+ * are dropped. A reference without a matching definition is left as
+ * literal text (Pandoc's behavior).
+ *
+ * Pure — no DOM. Tested in footnotes.test.ts.
+ */
+
+// [^label]: body  — definition line. Label: alphanumeric, hyphen,
+// underscore. Anything after the colon is the body.
+const DEFINITION_RE = /^\[\^([A-Za-z0-9_-]+)\]:\s*(.+)$/gm;
+
+// [^label] — inline reference (not preceded by `\` escape).
+const REFERENCE_RE = /\[\^([A-Za-z0-9_-]+)\]/g;
+
+// Fenced code block. We strip code blocks before scanning for references
+// so `[^1]` inside a code example isn't transformed.
+const FENCE_RE = /^(`{3,})[^\n]*\n[\s\S]*?\n\1\s*$/gm;
+
+// Inner Showdown pass used to render each footnote body's inline
+// markdown (bold, italic, links, inline code) into HTML. Block HTML
+// inside the footnotes <section> is not re-processed by the caller's
+// Showdown, so we have to pre-render the bodies ourselves.
+const bodyConverter = new Showdown.Converter({
+  strikethrough: true,
+  simpleLineBreaks: true,
+  literalMidWordUnderscores: true,
+});
+
+function renderBodyInline(body: string): string {
+  const html = bodyConverter.makeHtml(body).trim();
+  // Strip the outer <p> wrapper so we end up with inline content that
+  // sits cleanly inside a <li>.
+  return html.replace(/^<p>([\s\S]*?)<\/p>$/, "$1");
+}
+
+export function transformFootnotes(md: string): string {
+  if (!md) return md;
+
+  // Step 1: collect definitions. Use a separate source with code blocks
+  // stripped so `[^label]: body` lines inside code don't count.
+  const withoutCode = md.replace(FENCE_RE, (match) => "\n".repeat(match.split("\n").length - 1));
+
+  const definitions = new Map<string, string>();
+  withoutCode.replace(DEFINITION_RE, (_full, label: string, body: string) => {
+    // First definition wins if there are duplicates.
+    if (!definitions.has(label)) {
+      definitions.set(label, body.trim());
+    }
+    return "";
+  });
+
+  // Step 2: walk the code-stripped source with definition lines also
+  // stripped — otherwise the `[^label]` inside a definition line itself
+  // would count as a "first reference" and pull an unreferenced
+  // definition into the output. Numbering follows document order of
+  // first body reference.
+  const withoutDefs = withoutCode.replace(DEFINITION_RE, "");
+  const labelToNumber = new Map<string, number>();
+
+  if (definitions.size > 0) {
+    let next = 1;
+    let match: RegExpExecArray | null;
+    const refRe = new RegExp(REFERENCE_RE.source, "g");
+    while ((match = refRe.exec(withoutDefs)) !== null) {
+      const label = match[1];
+      if (!definitions.has(label)) continue;
+      if (labelToNumber.has(label)) continue;
+      labelToNumber.set(label, next++);
+    }
+  }
+
+  // Step 3: rewrite the original source. We always strip definition
+  // lines (even unreferenced ones, so orphan definitions don't leak
+  // into the rendered document). References to resolved labels become
+  // <sup> markers; references without a matching definition are left
+  // as literal text.
+  const parts = splitOnCodeFences(md);
+  const rewritten: string[] = [];
+  for (const part of parts) {
+    if (part.isCode) {
+      rewritten.push(part.text);
+      continue;
+    }
+    let text = part.text;
+    // Strip definition lines — leave a blank line in their place so
+    // neighboring paragraphs don't merge.
+    text = text.replace(DEFINITION_RE, "");
+    // Replace inline references.
+    text = text.replace(REFERENCE_RE, (tok, label: string) => {
+      const num = labelToNumber.get(label);
+      if (num === undefined) return tok; // unresolved — pass through
+      return `<sup class="footnote-ref" id="fnref-${num}"><a href="#fn-${num}">${num}</a></sup>`;
+    });
+    rewritten.push(text);
+  }
+  const body = rewritten.join("").replace(/\n{3,}/g, "\n\n").trim();
+
+  // Step 4: build the footnotes section in numeric order — but only if
+  // we actually have referenced definitions. Each body is pre-rendered
+  // through a nested Showdown pass so inline markdown (bold, italic,
+  // links, code) works inside the <li>; Showdown doesn't re-process
+  // markdown inside block HTML, so we can't defer this.
+  if (labelToNumber.size === 0) {
+    return body;
+  }
+
+  const sorted = Array.from(labelToNumber.entries()).sort((a, b) => a[1] - b[1]);
+  const items = sorted
+    .map(([label, num]) => {
+      const defBody = definitions.get(label) || "";
+      const rendered = renderBodyInline(defBody);
+      return `<li id="fn-${num}">${rendered} <a class="footnote-back" href="#fnref-${num}">↩</a></li>`;
+    })
+    .join("\n");
+
+  const section = `\n\n<section class="footnotes">\n<ol>\n${items}\n</ol>\n</section>\n`;
+
+  return body + section;
+}
+
+/**
+ * Split markdown into alternating code and non-code segments so the
+ * transformer can skip fenced code blocks entirely. Fences are matched
+ * on variable length (≥3 backticks).
+ */
+function splitOnCodeFences(md: string): Array<{ isCode: boolean; text: string }> {
+  const parts: Array<{ isCode: boolean; text: string }> = [];
+  const lines = md.split("\n");
+  let activeFence = 0;
+  let buffer: string[] = [];
+  let bufferIsCode = false;
+
+  const flush = () => {
+    if (buffer.length > 0) {
+      parts.push({ isCode: bufferIsCode, text: buffer.join("\n") + "\n" });
+      buffer = [];
+    }
+  };
+
+  for (const line of lines) {
+    const fence = line.match(/^(`{3,})/);
+    if (fence) {
+      const len = fence[1].length;
+      if (activeFence === 0) {
+        // Opening fence — flush the prose buffer, then start collecting
+        // the code block.
+        flush();
+        bufferIsCode = true;
+        buffer.push(line);
+        activeFence = len;
+      } else if (len === activeFence) {
+        // Closing fence — finish the code block.
+        buffer.push(line);
+        flush();
+        bufferIsCode = false;
+        activeFence = 0;
+      } else {
+        // Different-length fence inside an active fence — just content.
+        buffer.push(line);
+      }
+      continue;
+    }
+    buffer.push(line);
+  }
+  flush();
+  return parts;
+}


### PR DESCRIPTION
## Summary

Seventh P1a item. MarDoc now renders GitHub-style footnotes everywhere markdown is rendered.

**Syntax:**
\`\`\`
Here is a claim[^1] that needs a citation[^src].

[^1]: Supporting fact.
[^src]: Source: *Title*, Author, 2024.
\`\`\`

**Renders as:**
- Inline `<sup class="footnote-ref">` with an anchor linking to the corresponding footnote body
- A trailing `<section class="footnotes"><ol>` with each body numbered in document order of first reference
- Back-link arrow (↩) from each body to its reference
- `:target` highlight on the list item so a clicked reference briefly flashes the body

## What changed

**Pre-processor strategy** (not a post-processor like alerts): Showdown's reference-link parser actively mangles `[^label]: body` into `<a href="body">^label</a>`. The fix has to run before Showdown ever sees the source.

- **`src/lib/footnotes.ts`** — `transformFootnotes(md)` extracts definitions, replaces inline references with `<sup>` HTML, strips definition lines, and appends a `<section class="footnotes">` block with back-links. Footnote bodies inside the section are pre-rendered with a nested Showdown pass so inline markdown (bold, italic, links, code) works.
- **`Editor.tsx`** — `markdownToHtml` + `toggleCodeView` wrap `showdownConverter.makeHtml(transformFootnotes(md))`
- **`DiffViewer.tsx`** — `blockToHtml` wraps the same
- **`PRDetail.tsx`** — PR description block wraps the same
- **`globals.css`** — styles for `.footnote-ref`, `.footnotes`, `.footnote-back`, plus a `:target` highlight

## Numbering rules

- Ordered by first-reference in document order (not by definition order)
- Repeated references to the same label share a number and all link to the same body
- Unreferenced definitions are **dropped** (matches Pandoc)
- Unresolved references (`[^foo]` with no `[^foo]: …` definition) pass through as literal text (matches Pandoc)
- Labels inside fenced code blocks are ignored

## Tests

Test-first. 18 new tests in `footnotes.test.ts`:

- No-op cases (empty, no footnotes)
- Single / multiple references with correct numbering order (labels alphabetically out-of-order in the test)
- Reused labels share numbers
- Definition stripping (referenced, unreferenced, orphan dropped)
- Unresolved reference passes through literally
- Footnotes section emission + back-links
- Omission when nothing resolves (unreferenced-only, all-unresolved)
- End-to-end through Showdown, including the exact swapped-label case that was broken under raw Showdown
- Fenced code block exclusion
- Alphanumeric + hyphen + underscore labels
- Inline formatting inside definition bodies (bold, italic)

**Test count:** 333 → 351 (+18). Build clean.

## Test plan

- [ ] Editor: type a `[^1]` reference and a `[^1]: body` definition → reference renders as superscript link, body appears in a footnotes section at the bottom
- [ ] Click the `[^1]` superscript → scrolls to the footnotes section and highlights the target
- [ ] Click the ↩ back-link in the footnotes → scrolls back to the reference
- [ ] Multiple references in a document → numbered in document order of first reference
- [ ] Same reference used twice → both links jump to the same footnote, only one body appears
- [ ] Orphan definition (`[^foo]: …` with no `[^foo]` anywhere) → definition line disappears, no footnotes section
- [ ] Reference without a definition → `[^missing]` stays as literal text
- [ ] Definition body with `**bold**` and `[a link](url)` → renders with the formatting
- [ ] Footnote literal inside a fenced code block → not transformed
- [ ] Works in PR diff view (all modes) and PR description
- [ ] Dark mode renders correctly