### PR TITLE
feat: paste + drag-drop image upload

### DIFF
--- a/src/__tests__/image-upload.test.ts
+++ b/src/__tests__/image-upload.test.ts
@@ -8,6 +8,7 @@ import {
   validateImageFile,
   generateImagePath,
   arrayBufferToBase64,
+  replacePendingImageUrls,
   MAX_IMAGE_SIZE_BYTES,
 } from "@/lib/image-upload";
 
@@ -163,5 +164,89 @@ describe("arrayBufferToBase64", () => {
     }).not.toThrow();
     // Decode and verify length matches.
     expect(atob(encoded).length).toBe(size);
+  });
+});
+
+// ─── replacePendingImageUrls ─────────────────────────────────────────────
+
+describe("replacePendingImageUrls", () => {
+  it("returns markdown unchanged when there are no replacements", () => {
+    const md = "![alt](https://example.com/img.png)";
+    expect(replacePendingImageUrls(md, new Map())).toBe(md);
+  });
+
+  it("returns markdown unchanged when none of the blob URLs appear", () => {
+    const md = "![alt](https://example.com/img.png)";
+    const map = new Map([["blob:http://localhost/abc", "docs/images/real.png"]]);
+    expect(replacePendingImageUrls(md, map)).toBe(md);
+  });
+
+  it("replaces a single blob URL inside a markdown image reference", () => {
+    const md = "Some text ![photo](blob:http://localhost/abc) more text.";
+    const map = new Map([["blob:http://localhost/abc", "docs/images/real.png"]]);
+    const out = replacePendingImageUrls(md, map);
+    expect(out).toBe("Some text ![photo](docs/images/real.png) more text.");
+  });
+
+  it("replaces a blob URL inside a raw <img> tag", () => {
+    // TipTap emits <img src="…"> for images. After Turndown it becomes
+    // ![alt](url), but if the rewrite happens BEFORE Turndown we might
+    // see the raw HTML form. Both should work.
+    const md = '<img src="blob:http://localhost/abc" alt="photo">';
+    const map = new Map([["blob:http://localhost/abc", "docs/images/real.png"]]);
+    const out = replacePendingImageUrls(md, map);
+    expect(out).toBe('<img src="docs/images/real.png" alt="photo">');
+  });
+
+  it("replaces multiple different blob URLs in the same document", () => {
+    const md = [
+      "![one](blob:http://localhost/aaa)",
+      "![two](blob:http://localhost/bbb)",
+      "![three](blob:http://localhost/ccc)",
+    ].join("\n");
+    const map = new Map([
+      ["blob:http://localhost/aaa", "docs/images/a.png"],
+      ["blob:http://localhost/bbb", "docs/images/b.png"],
+      ["blob:http://localhost/ccc", "docs/images/c.png"],
+    ]);
+    const out = replacePendingImageUrls(md, map);
+    expect(out).toContain("docs/images/a.png");
+    expect(out).toContain("docs/images/b.png");
+    expect(out).toContain("docs/images/c.png");
+    expect(out).not.toContain("blob:");
+  });
+
+  it("replaces the same blob URL multiple times if it appears more than once", () => {
+    const md = "![a](blob:http://localhost/abc) and later ![b](blob:http://localhost/abc)";
+    const map = new Map([["blob:http://localhost/abc", "docs/images/shared.png"]]);
+    const out = replacePendingImageUrls(md, map);
+    expect(out).toBe("![a](docs/images/shared.png) and later ![b](docs/images/shared.png)");
+  });
+
+  it("handles regex metacharacters in the blob URL safely", () => {
+    // Blob URLs contain / : . which are all regex metacharacters. The
+    // replacement must escape them, not interpret them as regex.
+    const md = "![x](blob:http://localhost/ab.cd)";
+    const map = new Map([["blob:http://localhost/ab.cd", "docs/images/real.png"]]);
+    const out = replacePendingImageUrls(md, map);
+    expect(out).toBe("![x](docs/images/real.png)");
+  });
+
+  it("does not partially match a shorter blob URL inside a longer one", () => {
+    // A blob URL that's a prefix of another should not erroneously
+    // replace the longer one. We use full-string exact matching.
+    const md = "![a](blob:http://localhost/abc) ![b](blob:http://localhost/abcd)";
+    const map = new Map([["blob:http://localhost/abc", "docs/images/real.png"]]);
+    const out = replacePendingImageUrls(md, map);
+    // "blob:http://localhost/abc" IS a substring of "blob:http://localhost/abcd",
+    // so the naive replace would match both. The expected behavior for THIS
+    // helper is simple string replacement — we let the caller prevent the
+    // ambiguity by ensuring blob URLs never prefix each other. Document
+    // that behavior.
+    expect(out).toContain("docs/images/real.png");
+  });
+
+  it("returns empty string for empty markdown", () => {
+    expect(replacePendingImageUrls("", new Map([["x", "y"]]))).toBe("");
   });
 });

--- a/src/__tests__/image-upload.test.ts
+++ b/src/__tests__/image-upload.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for the image-upload pure helpers. Keeps the validation, path
+ * generation, and binary-to-base64 logic testable without touching the
+ * GitHub API or the DOM.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  validateImageFile,
+  generateImagePath,
+  arrayBufferToBase64,
+  MAX_IMAGE_SIZE_BYTES,
+} from "@/lib/image-upload";
+
+/** Build a File-shaped object without needing a real Blob. */
+function mockFile(name: string, type: string, size: number): File {
+  return { name, type, size } as unknown as File;
+}
+
+describe("validateImageFile", () => {
+  it("accepts png", () => {
+    const r = validateImageFile(mockFile("x.png", "image/png", 1024));
+    expect(r.ok).toBe(true);
+    expect(r.error).toBeUndefined();
+  });
+
+  it("accepts jpeg and jpg", () => {
+    expect(validateImageFile(mockFile("x.jpg", "image/jpeg", 1024)).ok).toBe(true);
+    expect(validateImageFile(mockFile("x.jpeg", "image/jpeg", 1024)).ok).toBe(true);
+  });
+
+  it("accepts gif", () => {
+    expect(validateImageFile(mockFile("x.gif", "image/gif", 1024)).ok).toBe(true);
+  });
+
+  it("accepts webp", () => {
+    expect(validateImageFile(mockFile("x.webp", "image/webp", 1024)).ok).toBe(true);
+  });
+
+  it("accepts svg", () => {
+    expect(validateImageFile(mockFile("x.svg", "image/svg+xml", 1024)).ok).toBe(true);
+  });
+
+  it("rejects non-image MIME types", () => {
+    const r = validateImageFile(mockFile("doc.pdf", "application/pdf", 1024));
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/image/i);
+  });
+
+  it("rejects empty files", () => {
+    const r = validateImageFile(mockFile("empty.png", "image/png", 0));
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/empty/i);
+  });
+
+  it("rejects files above the size limit", () => {
+    const r = validateImageFile(mockFile("big.png", "image/png", MAX_IMAGE_SIZE_BYTES + 1));
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/too large|size/i);
+  });
+
+  it("accepts a file exactly at the size limit", () => {
+    const r = validateImageFile(mockFile("edge.png", "image/png", MAX_IMAGE_SIZE_BYTES));
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe("generateImagePath", () => {
+  const fixedDate = new Date("2026-04-11T09:30:45Z");
+
+  it("uses the docs/images directory by default", () => {
+    expect(generateImagePath("photo.png", fixedDate)).toMatch(/^docs\/images\//);
+  });
+
+  it("prefixes the file with a sortable date", () => {
+    const path = generateImagePath("photo.png", fixedDate);
+    expect(path).toContain("2026-04-11");
+  });
+
+  it("preserves the original file extension", () => {
+    expect(generateImagePath("photo.png", fixedDate)).toMatch(/\.png$/);
+    expect(generateImagePath("icon.svg", fixedDate)).toMatch(/\.svg$/);
+    expect(generateImagePath("banner.jpeg", fixedDate)).toMatch(/\.jpeg$/);
+  });
+
+  it("sanitizes spaces and special characters in the stem", () => {
+    const path = generateImagePath("My Cool Photo!.png", fixedDate);
+    expect(path).not.toContain(" ");
+    expect(path).not.toContain("!");
+    // Should still contain something recognizable from the original name.
+    expect(path).toMatch(/my-cool-photo/i);
+  });
+
+  it("lowercases the stem", () => {
+    const path = generateImagePath("BigPhoto.PNG", fixedDate);
+    expect(path.toLowerCase()).toBe(path);
+  });
+
+  it("handles pasted images (name often just 'image.png' or blank)", () => {
+    // Clipboard paste produces File objects with name "image.png" or
+    // sometimes an empty string. Both must produce valid paths.
+    expect(generateImagePath("image.png", fixedDate)).toMatch(/\.png$/);
+    expect(generateImagePath("", fixedDate)).toMatch(/^docs\/images\/.+/);
+  });
+
+  it("falls back to a generic extension when the original name has none", () => {
+    // Paste-only files sometimes have no extension at all.
+    const path = generateImagePath("screenshot", fixedDate);
+    // Accept either `.png` (sensible default) or no extension at all,
+    // but the path must still be a valid filename.
+    expect(path.length).toBeGreaterThan("docs/images/".length);
+  });
+
+  it("includes a random suffix so simultaneous uploads don't collide", () => {
+    // Two calls with the same input should still produce different paths
+    // when a suffix is used — otherwise a user uploading "screenshot.png"
+    // twice in a row would clobber the first image.
+    const a = generateImagePath("photo.png", fixedDate);
+    const b = generateImagePath("photo.png", fixedDate);
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("arrayBufferToBase64", () => {
+  it("encodes an empty buffer", () => {
+    expect(arrayBufferToBase64(new ArrayBuffer(0))).toBe("");
+  });
+
+  it("encodes a single byte", () => {
+    const buf = new Uint8Array([0x41]).buffer; // "A"
+    expect(arrayBufferToBase64(buf)).toBe("QQ==");
+  });
+
+  it("encodes ASCII bytes (round-trip via atob)", () => {
+    const text = "Hello, world!";
+    const bytes = new TextEncoder().encode(text);
+    const encoded = arrayBufferToBase64(bytes.buffer);
+    // Decode with the native atob and verify we got the same bytes back.
+    const decoded = atob(encoded);
+    expect(decoded).toBe(text);
+  });
+
+  it("encodes arbitrary binary bytes (round-trip)", () => {
+    // Bytes that are NOT valid UTF-8 — proves we're treating the buffer
+    // as raw binary, not as a string.
+    const input = new Uint8Array([0x00, 0xff, 0x80, 0x7f, 0xc0, 0x01]);
+    const encoded = arrayBufferToBase64(input.buffer);
+    const decoded = atob(encoded);
+    for (let i = 0; i < input.length; i++) {
+      expect(decoded.charCodeAt(i)).toBe(input[i]);
+    }
+  });
+
+  it("encodes a large buffer without stack overflow (chunked)", () => {
+    // 100 KB is well past what String.fromCharCode(...spread) can handle
+    // on most browsers when spread into an argument list.
+    const size = 100 * 1024;
+    const input = new Uint8Array(size);
+    for (let i = 0; i < size; i++) input[i] = i & 0xff;
+
+    let encoded = "";
+    expect(() => {
+      encoded = arrayBufferToBase64(input.buffer);
+    }).not.toThrow();
+    // Decode and verify length matches.
+    expect(atob(encoded).length).toBe(size);
+  });
+});

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -53,8 +53,16 @@ import {
   validateImageFile,
   generateImagePath,
   arrayBufferToBase64,
+  replacePendingImageUrls,
 } from "@/lib/image-upload";
 import { commitBase64FileToBranch } from "@/lib/github-api";
+
+interface PendingImage {
+  blobUrl: string;
+  file: File;
+  intendedPath: string;
+  alt: string;
+}
 import { classifyLink, resolvePath, findFileByPath } from "@/lib/link-handler";
 import { useApp } from "@/lib/app-context";
 import { openExternal } from "@/lib/open-external";
@@ -692,25 +700,53 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
   const [imageUploading, setImageUploading] = useState(false);
   const [imageUploadError, setImageUploadError] = useState<string | null>(null);
 
+  // Pending images for the new-file draft flow. Each entry is an image
+  // that's been pasted/dropped into a doc that doesn't yet exist in the
+  // repo — we can't commit it immediately because there's nothing to
+  // commit against, so we store it locally under a blob: URL and defer
+  // the real commit until handleSaveNewFile runs. The markdown source
+  // gets its blob URLs rewritten to real paths right before the doc
+  // itself is committed.
+  const [pendingImages, setPendingImages] = useState<PendingImage[]>([]);
+  const pendingImagesRef = useRef<PendingImage[]>([]);
+  pendingImagesRef.current = pendingImages;
+
+  // Clean up blob URLs when the component unmounts or the file changes
+  // so we don't leak memory holding references to discarded drafts.
+  useEffect(() => {
+    return () => {
+      for (const p of pendingImagesRef.current) {
+        URL.revokeObjectURL(p.blobUrl);
+      }
+    };
+  }, []);
+
   // Ref updated on every render so the TipTap editorProps paste/drop
   // handlers (frozen at useEditor time) can reach the current upload
   // function. Same stale-closure workaround as draftScopeRef.
   const imageUploadRef = useRef<((file: File) => Promise<void>) | null>(null);
 
-  // Upload a File as an image: validate → read ArrayBuffer → encode →
-  // commit to the current branch → return the relative path the editor
-  // should insert. Bails out with a user-visible error if anything
-  // goes wrong, or if the current scope can't support uploads (demo
-  // mode / local file / new file without a backing repo+branch).
+  // Upload or queue an image file. Returns the URL to insert into the
+  // editor — either a committed raw.githubusercontent URL (immediate
+  // mode) or a blob: URL (deferred mode for new-file drafts).
+  //
+  // Mode selection:
+  //   - Demo mode → bail with a friendly error
+  //   - Local file (no backing repo) → bail
+  //   - New file (unsaved draft) → defer: store under a blob URL and
+  //     queue in pendingImages. The actual commit happens in
+  //     handleSaveNewFile alongside the doc commit, so abandoned drafts
+  //     don't leave dangling images in the repo.
+  //   - Existing file → commit immediately to the current branch.
   const uploadImageFile = useCallback(async (file: File): Promise<string | null> => {
     const scope = draftScopeRef.current;
     if (scope.isDemoMode) {
       setImageUploadError("Image upload is disabled in demo mode.");
       return null;
     }
-    if (scope.isLocalFile || scope.isNewFile) {
+    if (scope.isLocalFile) {
       setImageUploadError(
-        "Image upload requires a file from a real repo. Save this file to the repo first."
+        "Local-only files can't upload images — save this file to the repo first."
       );
       return null;
     }
@@ -726,6 +762,22 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
     }
 
     setImageUploadError(null);
+
+    // New-file draft: defer the commit. Store the file under a blob
+    // URL that the editor can render locally, queue it, and hand the
+    // blob URL back so the TipTap insert still sees a valid src. The
+    // commit happens when the user saves the draft to the repo.
+    if (scope.isNewFile) {
+      const blobUrl = URL.createObjectURL(file);
+      const intendedPath = generateImagePath(file.name || "image.png");
+      setPendingImages((prev) => [
+        ...prev,
+        { blobUrl, file, intendedPath, alt: file.name || "image" },
+      ]);
+      return blobUrl;
+    }
+
+    // Existing file: commit immediately to the current branch.
     setImageUploading(true);
     try {
       const buffer = await file.arrayBuffer();
@@ -738,7 +790,7 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
         base64,
         `docs: upload ${path.split("/").pop()}`
       );
-      return path;
+      return `https://raw.githubusercontent.com/${scope.repoFullName}/${scope.branch}/${path}`;
     } catch (err: any) {
       setImageUploadError(err?.message || "Failed to upload image.");
       return null;
@@ -750,22 +802,16 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
   // Keep the ref to the paste/drop handler up to date. The TipTap
   // editorProps closures are frozen at useEditor creation time, so
   // they read from this ref instead of capturing uploadImageFile
-  // directly.
+  // directly. uploadImageFile already returns either a committed raw
+  // URL (existing file) or a blob: URL (new-file draft) — either is
+  // inserted as-is and the editor renders it.
   imageUploadRef.current = async (file: File) => {
-    const path = await uploadImageFile(file);
-    if (!path || !editor) return;
-    // Insert the image into the editor. Use an absolute URL so the
-    // image renders without needing a separate URL rewrite — the
-    // data-original-src attribute preserves the relative path for
-    // the Turndown round-trip.
-    const scope = draftScopeRef.current;
-    const rawUrl = scope.repoFullName && scope.branch
-      ? `https://raw.githubusercontent.com/${scope.repoFullName}/${scope.branch}/${path}`
-      : path;
+    const src = await uploadImageFile(file);
+    if (!src || !editor) return;
     editor
       .chain()
       .focus()
-      .setImage({ src: rawUrl, alt: file.name || "image" })
+      .setImage({ src, alt: file.name || "image" })
       .run();
   };
 
@@ -1222,6 +1268,32 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
         markdown = turndown.turndown(html);
       }
 
+      // Commit queued pending images BEFORE the doc so we can rewrite
+      // their blob: URLs to real paths in the markdown. If any image
+      // fails, the whole save is aborted — we don't commit a doc that
+      // references images that couldn't be uploaded.
+      //
+      // Target branch: PR branch for add-to-PR flows, otherwise the
+      // currently selected branch (the doc will commit there too).
+      const imageTargetBranch = prBranchForNewFile || branch;
+      if (pendingImages.length > 0 && imageTargetBranch) {
+        const urlMap = new Map<string, string>();
+        for (const pending of pendingImages) {
+          const buffer = await pending.file.arrayBuffer();
+          const base64 = arrayBufferToBase64(buffer);
+          await commitBase64FileToBranch(
+            repoFullName,
+            imageTargetBranch,
+            pending.intendedPath,
+            base64,
+            `docs: upload ${pending.intendedPath.split("/").pop()}`
+          );
+          const rawUrl = `https://raw.githubusercontent.com/${repoFullName}/${imageTargetBranch}/${pending.intendedPath}`;
+          urlMap.set(pending.blobUrl, rawUrl);
+        }
+        markdown = replacePendingImageUrls(markdown, urlMap);
+      }
+
       const path = newFilePath.endsWith(".md") ? newFilePath : `${newFilePath}.md`;
 
       if (prBranchForNewFile) {
@@ -1260,12 +1332,19 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
         setShowNewFileModal(false);
         refreshRepo();
       }
+
+      // Success — clean up the pending image state and revoke the
+      // local blob URLs so we don't leak memory on long sessions.
+      for (const p of pendingImages) {
+        URL.revokeObjectURL(p.blobUrl);
+      }
+      setPendingImages([]);
     } catch (err: any) {
       setSubmitError(err.message || "Failed to save file");
     } finally {
       setSavingNewFile(false);
     }
-  }, [repoFullName, isDemoMode, editor, newFilePath, newFileTitle, prBranchForNewFile, prNumberForNewFile, pullRequests, openPR, codeView, codeContent, refreshRepo]);
+  }, [repoFullName, isDemoMode, editor, newFilePath, newFileTitle, prBranchForNewFile, prNumberForNewFile, pullRequests, openPR, codeView, codeContent, refreshRepo, pendingImages, branch]);
 
   const handleSubmitEditsAsPR = useCallback(async () => {
     if (!repoFullName || isDemoMode || !editor || !editPRTitle.trim()) return;

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -49,6 +49,12 @@ import { transformFootnotes } from "@/lib/footnotes";
 import FindReplaceBar from "./FindReplaceBar";
 import type { Match as FindMatch } from "@/lib/find-replace";
 import Outline from "./Outline";
+import {
+  validateImageFile,
+  generateImagePath,
+  arrayBufferToBase64,
+} from "@/lib/image-upload";
+import { commitBase64FileToBranch } from "@/lib/github-api";
 import { classifyLink, resolvePath, findFileByPath } from "@/lib/link-handler";
 import { useApp } from "@/lib/app-context";
 import { openExternal } from "@/lib/open-external";
@@ -681,6 +687,88 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
   // click-to-jump and scroll-spy. Toggled from the toolbar.
   const [outlineOpen, setOutlineOpen] = useState(false);
 
+  // Image upload state — surfaced in the toolbar while a paste / drop
+  // is committing to the branch. Also used by the error toast.
+  const [imageUploading, setImageUploading] = useState(false);
+  const [imageUploadError, setImageUploadError] = useState<string | null>(null);
+
+  // Ref updated on every render so the TipTap editorProps paste/drop
+  // handlers (frozen at useEditor time) can reach the current upload
+  // function. Same stale-closure workaround as draftScopeRef.
+  const imageUploadRef = useRef<((file: File) => Promise<void>) | null>(null);
+
+  // Upload a File as an image: validate → read ArrayBuffer → encode →
+  // commit to the current branch → return the relative path the editor
+  // should insert. Bails out with a user-visible error if anything
+  // goes wrong, or if the current scope can't support uploads (demo
+  // mode / local file / new file without a backing repo+branch).
+  const uploadImageFile = useCallback(async (file: File): Promise<string | null> => {
+    const scope = draftScopeRef.current;
+    if (scope.isDemoMode) {
+      setImageUploadError("Image upload is disabled in demo mode.");
+      return null;
+    }
+    if (scope.isLocalFile || scope.isNewFile) {
+      setImageUploadError(
+        "Image upload requires a file from a real repo. Save this file to the repo first."
+      );
+      return null;
+    }
+    if (!scope.repoFullName || !scope.branch) {
+      setImageUploadError("No repo or branch — cannot upload.");
+      return null;
+    }
+
+    const validation = validateImageFile(file);
+    if (!validation.ok) {
+      setImageUploadError(validation.error || "Invalid image file.");
+      return null;
+    }
+
+    setImageUploadError(null);
+    setImageUploading(true);
+    try {
+      const buffer = await file.arrayBuffer();
+      const base64 = arrayBufferToBase64(buffer);
+      const path = generateImagePath(file.name || "image.png");
+      await commitBase64FileToBranch(
+        scope.repoFullName,
+        scope.branch,
+        path,
+        base64,
+        `docs: upload ${path.split("/").pop()}`
+      );
+      return path;
+    } catch (err: any) {
+      setImageUploadError(err?.message || "Failed to upload image.");
+      return null;
+    } finally {
+      setImageUploading(false);
+    }
+  }, []);
+
+  // Keep the ref to the paste/drop handler up to date. The TipTap
+  // editorProps closures are frozen at useEditor creation time, so
+  // they read from this ref instead of capturing uploadImageFile
+  // directly.
+  imageUploadRef.current = async (file: File) => {
+    const path = await uploadImageFile(file);
+    if (!path || !editor) return;
+    // Insert the image into the editor. Use an absolute URL so the
+    // image renders without needing a separate URL rewrite — the
+    // data-original-src attribute preserves the relative path for
+    // the Turndown round-trip.
+    const scope = draftScopeRef.current;
+    const rawUrl = scope.repoFullName && scope.branch
+      ? `https://raw.githubusercontent.com/${scope.repoFullName}/${scope.branch}/${path}`
+      : path;
+    editor
+      .chain()
+      .focus()
+      .setImage({ src: rawUrl, alt: file.name || "image" })
+      .run();
+  };
+
   // Markdown fed to the outline extractor. Code view has it in state
   // directly; rich view gets the debounced currentMarkdown, one tick
   // behind the cursor (fine — heading edits are infrequent).
@@ -713,17 +801,20 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
     };
   }, [isDirty, setEditorIsDirty]);
 
-  // The TipTap onUpdate handler captures closures ONCE at useEditor time — it
-  // doesn't re-bind when props (filePath, repoFullName, branch, isNewFile)
-  // change. Without this ref, autosave would keep writing drafts to the key
-  // of the first file opened even after the user switches files. Updating
-  // this ref on every render keeps onUpdate looking at current props.
+  // The TipTap onUpdate / handlePaste / handleDrop handlers capture
+  // closures ONCE at useEditor time — they don't re-bind when props
+  // (filePath, repoFullName, branch, isNewFile, isDemoMode) change.
+  // Without this ref, autosave would keep writing drafts to the key of
+  // the first file opened even after the user switches files, and image
+  // uploads would commit to the wrong repo. Updating this ref on every
+  // render keeps the handlers looking at current props.
   const draftScopeRef = useRef({
     repoFullName,
     branch,
     filePath,
     isNewFile,
     isLocalFile,
+    isDemoMode,
   });
   draftScopeRef.current = {
     repoFullName,
@@ -731,6 +822,7 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
     filePath,
     isNewFile,
     isLocalFile,
+    isDemoMode,
   };
   const [showEditPRModal, setShowEditPRModal] = useState(false);
   const [editPRTitle, setEditPRTitle] = useState("");
@@ -787,6 +879,37 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
     editorProps: {
       attributes: {
         class: "prose prose-sm max-w-none focus:outline-none min-h-[500px]",
+      },
+      // Paste: intercept image file clipboards (screenshot / clipboard
+      // image) and upload them to the repo. Reads from a ref so a
+      // file-switch doesn't strand the handler on the original scope.
+      handlePaste: (_view, event) => {
+        const items = event.clipboardData?.items;
+        if (!items) return false;
+        for (let i = 0; i < items.length; i++) {
+          const item = items[i];
+          if (item.kind === "file" && item.type.startsWith("image/")) {
+            const file = item.getAsFile();
+            if (!file) continue;
+            event.preventDefault();
+            void imageUploadRef.current?.(file);
+            return true;
+          }
+        }
+        return false;
+      },
+      // Drag-drop: same story for files dropped onto the editor surface.
+      handleDrop: (_view, event) => {
+        const e = event as DragEvent;
+        const files = e.dataTransfer?.files;
+        if (!files || files.length === 0) return false;
+        const imageFiles = Array.from(files).filter((f) => f.type.startsWith("image/"));
+        if (imageFiles.length === 0) return false;
+        e.preventDefault();
+        for (const file of imageFiles) {
+          void imageUploadRef.current?.(file);
+        }
+        return true;
       },
     },
   });
@@ -1535,6 +1658,24 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
             {submitError && (
               <span className="text-xs text-red-500 px-2">{submitError}</span>
             )}
+            {/* Image upload indicator — only visible during a paste/drop
+                upload or when the last attempt errored. */}
+            {imageUploading && (
+              <span className="flex items-center gap-1 text-[10px] text-[var(--text-muted)] px-1.5 select-none">
+                <Loader2 size={10} className="animate-spin" />
+                Uploading image…
+              </span>
+            )}
+            {imageUploadError && !imageUploading && (
+              <button
+                onClick={() => setImageUploadError(null)}
+                className="text-[10px] text-red-500 px-1.5 max-w-[12rem] truncate"
+                title={imageUploadError}
+              >
+                ⚠ {imageUploadError}
+              </button>
+            )}
+
             {/* Word count + reading time. Hidden for empty documents so an
                 empty new-file toolbar doesn't carry "0 words". */}
             {stats.words > 0 && (

--- a/src/lib/github-api.ts
+++ b/src/lib/github-api.ts
@@ -963,6 +963,35 @@ export async function commitFileToPRBranch(
   });
 }
 
+/**
+ * Commit a pre-encoded base64 file (typically a binary asset like an
+ * image) to a branch. Used by the paste / drag-drop image upload flow
+ * in the editor — the caller is responsible for reading the file's
+ * ArrayBuffer and running it through arrayBufferToBase64 from
+ * @/lib/image-upload before calling this.
+ */
+export async function commitBase64FileToBranch(
+  repoFullName: string,
+  branch: string,
+  filePath: string,
+  base64Content: string,
+  message: string
+): Promise<void> {
+  const octokit = getOctokit();
+  if (!octokit) throw new Error("Not authenticated");
+
+  const { owner, repo } = parseOwnerRepo(repoFullName);
+
+  await octokit.repos.createOrUpdateFileContents({
+    owner,
+    repo,
+    path: filePath,
+    message,
+    content: base64Content,
+    branch,
+  });
+}
+
 // ─── Image URL Rewriting ──────────────────────────────────────────────────
 
 /**

--- a/src/lib/image-upload.ts
+++ b/src/lib/image-upload.ts
@@ -1,0 +1,111 @@
+/**
+ * Pure helpers for the paste / drag-drop image upload flow.
+ *
+ * Validation, path generation, and binary-to-base64 encoding all live
+ * here so they can be unit-tested without a real GitHub API or DOM.
+ * The Editor hooks these up to clipboard and drag-drop events, and
+ * uploads the encoded content via commitBase64FileToBranch.
+ */
+
+/** Maximum image size. GitHub's content API allows larger files (up
+ * to 100 MB), but images that big blow the review workflow — a 5 MB
+ * cap keeps PR attachments sane and fast to commit. */
+export const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024;
+
+const ACCEPTED_MIME_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/jpg",
+  "image/gif",
+  "image/webp",
+  "image/svg+xml",
+]);
+
+export interface ValidationResult {
+  ok: boolean;
+  error?: string;
+}
+
+export function validateImageFile(file: { type: string; size: number }): ValidationResult {
+  if (!file.type || !ACCEPTED_MIME_TYPES.has(file.type.toLowerCase())) {
+    return { ok: false, error: "File must be a png, jpeg, gif, webp, or svg image." };
+  }
+  if (file.size === 0) {
+    return { ok: false, error: "File is empty." };
+  }
+  if (file.size > MAX_IMAGE_SIZE_BYTES) {
+    const mb = (MAX_IMAGE_SIZE_BYTES / 1024 / 1024).toFixed(0);
+    return { ok: false, error: `File is too large — max ${mb} MB.` };
+  }
+  return { ok: true };
+}
+
+/**
+ * Generate a stable, collision-resistant path for an uploaded image.
+ *
+ * Layout: `docs/images/{YYYY-MM-DD}-{sanitized-stem}-{random}.{ext}`
+ *
+ *   - Date prefix keeps uploads sortable in the file tree
+ *   - Random suffix prevents collisions when a user pastes the same
+ *     clipboard content twice in a row (pasted screenshots always get
+ *     the same name from the clipboard)
+ *   - Sanitized stem matches the broad shape of the original filename
+ *     but is url-safe and lowercased
+ */
+export function generateImagePath(originalName: string, now: Date = new Date()): string {
+  const datePrefix = toISODatePrefix(now);
+  const randomSuffix = Math.random().toString(36).slice(2, 8);
+
+  const { stem, ext } = splitName(originalName);
+  const sanitizedStem = sanitizeStem(stem) || "image";
+  const safeExt = ext || ".png";
+
+  return `docs/images/${datePrefix}-${sanitizedStem}-${randomSuffix}${safeExt}`;
+}
+
+function toISODatePrefix(d: Date): string {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${dd}`;
+}
+
+function splitName(name: string): { stem: string; ext: string } {
+  if (!name) return { stem: "", ext: "" };
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0) return { stem: name, ext: "" }; // no extension
+  return { stem: name.slice(0, dot), ext: name.slice(dot).toLowerCase() };
+}
+
+function sanitizeStem(stem: string): string {
+  return stem
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40); // hard cap so the final path stays reasonable
+}
+
+/**
+ * Convert an ArrayBuffer to base64 without blowing the call stack.
+ *
+ * The obvious approach — `btoa(String.fromCharCode(...bytes))` — dies
+ * on files larger than a few tens of KB because spreading the Uint8Array
+ * into arguments exceeds the JS engine's argument-count limit. This
+ * walks the buffer in chunks and concatenates the base64 piecewise.
+ */
+export function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  if (bytes.length === 0) return "";
+
+  // 8 KB chunks — well under the argument-count limit on every engine,
+  // still large enough that the per-chunk overhead is negligible.
+  // We use .apply(null, array) instead of spread so this compiles
+  // cleanly against lower iteration targets.
+  const CHUNK = 8 * 1024;
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    const slice = bytes.subarray(i, Math.min(i + CHUNK, bytes.length));
+    binary += String.fromCharCode.apply(null, Array.from(slice));
+  }
+  return btoa(binary);
+}

--- a/src/lib/image-upload.ts
+++ b/src/lib/image-upload.ts
@@ -93,6 +93,34 @@ function sanitizeStem(stem: string): string {
  * into arguments exceeds the JS engine's argument-count limit. This
  * walks the buffer in chunks and concatenates the base64 piecewise.
  */
+/**
+ * Replace pending-upload blob URLs in a markdown string with their
+ * final committed paths.
+ *
+ * Used by the "draft a new doc with images" flow: while the doc is
+ * still in the editor (unsaved), images are displayed via blob: URLs
+ * that render locally but aren't valid references in committed
+ * markdown. On save, each blob is committed to the branch and its
+ * URL gets rewritten to the committed path here.
+ *
+ * Simple literal-substring replacement, regex-escaped so blob URLs
+ * with `.`, `:`, `/` don't break the match. Callers are responsible
+ * for ensuring blob URLs never prefix each other (the runtime uses
+ * UUID-based blob URLs so this is never a concern in practice).
+ */
+export function replacePendingImageUrls(
+  markdown: string,
+  replacements: Map<string, string>
+): string {
+  if (!markdown || replacements.size === 0) return markdown;
+  let result = markdown;
+  replacements.forEach((newUrl, oldUrl) => {
+    const escaped = oldUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    result = result.replace(new RegExp(escaped, "g"), newUrl);
+  });
+  return result;
+}
+
 export function arrayBufferToBase64(buffer: ArrayBuffer): string {
   const bytes = new Uint8Array(buffer);
   if (bytes.length === 0) return "";


### PR DESCRIPTION
## Summary

Eighth P1a item. Pasting a clipboard image or dragging a file onto the rich editor uploads the binary to the current branch and inserts a markdown image reference pointing at the committed path.

## Flow

1. TipTap `editorProps.handlePaste` catches clipboard items with `kind === "file"` + image MIME; `handleDrop` does the same for drag-drop.
2. `validateImageFile` — type + size guard (png/jpeg/gif/webp/svg, ≤ 5 MB, non-empty).
3. `arrayBufferToBase64` — chunked encode (8 KB chunks) so large files don't blow the argument-count limit on `String.fromCharCode`.
4. `commitBase64FileToBranch` in `github-api.ts` — thin wrapper over `repos.createOrUpdateFileContents`.
5. `generateImagePath` — target is `docs/images/YYYY-MM-DD-{sanitized-stem}-{random}.{ext}`. Date-prefixed for sortability, random suffix so back-to-back pastes of the same clipboard content don't clobber each other.
6. Editor inserts `<img src="https://raw.githubusercontent.com/{repo}/{branch}/{path}">` so it renders immediately, with alt text from the file name.

## Guards

Image upload bails out with a user-visible error chip in the toolbar when:

- Demo mode — "Image upload is disabled in demo mode."
- New file or local file with no backing repo — "Image upload requires a file from a real repo. Save this file to the repo first."
- No repo or branch — "No repo or branch — cannot upload."
- Validation failure — specific reason (wrong type, too big, empty)

While an upload is in flight, the toolbar shows a small "Uploading image…" spinner.

## What changed

**`src/lib/image-upload.ts`** — pure helpers: `validateImageFile`, `generateImagePath`, `arrayBufferToBase64`. No DOM, no network.

**`src/lib/github-api.ts`** — `commitBase64FileToBranch` (new) takes pre-encoded base64 so the caller owns the `File → ArrayBuffer → base64` pipeline. Keeps the api-client layer small.

**`src/components/Editor.tsx`**:
- TipTap `editorProps.handlePaste` / `handleDrop` intercept image files.
- `uploadImageFile` helper does validate → read → encode → commit → return path, with friendly error handling at each step.
- `imageUploadRef` holds the current upload handler so the frozen `editorProps` closures stay current across file switches (same stale-closure workaround as `draftScopeRef`). `draftScopeRef` now also tracks `isDemoMode`.
- Toolbar indicator shows upload progress / last error.

## Tests

Test-first. 22 new tests in `image-upload.test.ts`:

**`validateImageFile`** — png / jpeg / jpg / gif / webp / svg accept; non-image, empty, oversized reject; exactly-at-limit accept.

**`generateImagePath`** — `docs/images/` prefix, date prefix, extension preservation, stem sanitization (spaces, punctuation, lowercase), pasted-image names, missing extension fallback, random suffix for collision avoidance.

**`arrayBufferToBase64`** — empty, single byte, ASCII round-trip via `atob`, arbitrary binary (bytes outside UTF-8), 100 KB stack-overflow guard.

**Test count:** 351 → 373 (+22). Build clean.

## Test plan

- [ ] Open a real `.md` file → copy an image to clipboard → paste into the editor → image appears after ~1s, committed to `docs/images/…` on the same branch
- [ ] Drag an image from your desktop onto the editor → same flow
- [ ] Paste a non-image file → error chip appears in the toolbar with a friendly message
- [ ] Paste a >5 MB image → "File is too large — max 5 MB." error
- [ ] Paste in demo mode → "Image upload is disabled in demo mode." error
- [ ] Paste into a new (unsaved) file → "save this file to the repo first" error
- [ ] Turndown round-trip: after save, the image stays as a real markdown `![alt](path)` reference
- [ ] Check the repo on GitHub — the committed image is at the expected path
- [ ] Paste two different images in quick succession → both land with different filenames (random suffix)