### PR TITLE
feat: image resize — click to set width/height + aspect lock

### DIFF
--- a/src/__tests__/image-path-config.test.ts
+++ b/src/__tests__/image-path-config.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for the per-repo image upload path configuration.
+ *
+ * The user can set a different target folder per repo (e.g. some
+ * projects use docs/images, some docs/assets, some src/assets). The
+ * setting is persisted in localStorage keyed by repo full name, with
+ * a sensible default.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  getImageUploadFolder,
+  setImageUploadFolder,
+  sanitizeImageFolder,
+  DEFAULT_IMAGE_FOLDER,
+} from "@/lib/image-path-config";
+
+describe("DEFAULT_IMAGE_FOLDER", () => {
+  it("is a reasonable default", () => {
+    expect(DEFAULT_IMAGE_FOLDER).toBe("docs/images");
+  });
+});
+
+describe("sanitizeImageFolder", () => {
+  it("returns the trimmed folder unchanged for a well-formed input", () => {
+    expect(sanitizeImageFolder("docs/images")).toBe("docs/images");
+    expect(sanitizeImageFolder("docs/assets/img")).toBe("docs/assets/img");
+  });
+
+  it("strips leading and trailing slashes", () => {
+    expect(sanitizeImageFolder("/docs/images")).toBe("docs/images");
+    expect(sanitizeImageFolder("docs/images/")).toBe("docs/images");
+    expect(sanitizeImageFolder("/docs/images/")).toBe("docs/images");
+  });
+
+  it("collapses consecutive slashes", () => {
+    expect(sanitizeImageFolder("docs//images")).toBe("docs/images");
+    expect(sanitizeImageFolder("docs///images")).toBe("docs/images");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(sanitizeImageFolder("  docs/images  ")).toBe("docs/images");
+  });
+
+  it("rejects path traversal and returns the default", () => {
+    expect(sanitizeImageFolder("../docs/images")).toBe(DEFAULT_IMAGE_FOLDER);
+    expect(sanitizeImageFolder("docs/../escape")).toBe(DEFAULT_IMAGE_FOLDER);
+    expect(sanitizeImageFolder("docs/images/..")).toBe(DEFAULT_IMAGE_FOLDER);
+  });
+
+  it("rejects empty or whitespace-only input", () => {
+    expect(sanitizeImageFolder("")).toBe(DEFAULT_IMAGE_FOLDER);
+    expect(sanitizeImageFolder("   ")).toBe(DEFAULT_IMAGE_FOLDER);
+    expect(sanitizeImageFolder("//")).toBe(DEFAULT_IMAGE_FOLDER);
+  });
+
+  it("rejects absolute-looking paths with protocols", () => {
+    expect(sanitizeImageFolder("http://example.com/docs")).toBe(DEFAULT_IMAGE_FOLDER);
+    expect(sanitizeImageFolder("file:///docs")).toBe(DEFAULT_IMAGE_FOLDER);
+  });
+
+  it("accepts a single-level folder", () => {
+    expect(sanitizeImageFolder("assets")).toBe("assets");
+  });
+
+  it("accepts folder names with hyphens, underscores, and numbers", () => {
+    expect(sanitizeImageFolder("docs/images-2024")).toBe("docs/images-2024");
+    expect(sanitizeImageFolder("my_assets")).toBe("my_assets");
+  });
+});
+
+describe("getImageUploadFolder / setImageUploadFolder", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns the default when no value is stored", () => {
+    expect(getImageUploadFolder("owner/repo")).toBe(DEFAULT_IMAGE_FOLDER);
+  });
+
+  it("returns the default when the repo is undefined", () => {
+    expect(getImageUploadFolder(undefined)).toBe(DEFAULT_IMAGE_FOLDER);
+  });
+
+  it("returns a stored value per repo", () => {
+    setImageUploadFolder("owner/repo", "docs/assets");
+    expect(getImageUploadFolder("owner/repo")).toBe("docs/assets");
+  });
+
+  it("keeps different repos independent", () => {
+    setImageUploadFolder("owner/a", "docs/images");
+    setImageUploadFolder("owner/b", "assets");
+    expect(getImageUploadFolder("owner/a")).toBe("docs/images");
+    expect(getImageUploadFolder("owner/b")).toBe("assets");
+  });
+
+  it("sanitizes on the way in", () => {
+    setImageUploadFolder("owner/repo", "  /docs//assets/  ");
+    expect(getImageUploadFolder("owner/repo")).toBe("docs/assets");
+  });
+
+  it("falls back to default if the stored value was tampered with", () => {
+    // Someone edits localStorage directly — the read path still
+    // sanitizes so we don't trust raw storage values.
+    localStorage.setItem("mardoc:image-folder:owner/repo", "../../../etc");
+    expect(getImageUploadFolder("owner/repo")).toBe(DEFAULT_IMAGE_FOLDER);
+  });
+
+  it("setting an empty string clears the stored value", () => {
+    setImageUploadFolder("owner/repo", "docs/images");
+    setImageUploadFolder("owner/repo", "");
+    // After clearing, we're back to the default.
+    expect(getImageUploadFolder("owner/repo")).toBe(DEFAULT_IMAGE_FOLDER);
+  });
+});

--- a/src/__tests__/image-resize.test.ts
+++ b/src/__tests__/image-resize.test.ts
@@ -15,6 +15,7 @@ import {
   parseImageDimension,
   formatImageDimension,
   buildSizedImageHTML,
+  unwrapCenteredImages,
   type ImageDimension,
 } from "@/lib/image-resize";
 
@@ -229,5 +230,115 @@ describe("buildSizedImageHTML", () => {
     const formatted = formatImageDimension(first);
     const second = parseImageDimension(formatted);
     expect(second).toEqual(first);
+  });
+
+  // ─── center=true in the build output ───────────────────────────────────
+
+  it("wraps the <img> in <div align='center'> when center is true", () => {
+    const out = buildSizedImageHTML({
+      src: "x.png",
+      alt: "centered",
+      width: { value: 300, unit: "px" },
+      height: null,
+      center: true,
+    });
+    expect(out).toContain('<div align="center">');
+    expect(out).toContain("</div>");
+    // The <img> tag itself should still be inside, with its width.
+    expect(out).toContain('width="300"');
+    expect(out).toContain('src="x.png"');
+  });
+
+  it("does not wrap when center is false or omitted", () => {
+    const out = buildSizedImageHTML({
+      src: "x.png",
+      alt: "",
+      width: null,
+      height: null,
+    });
+    expect(out).not.toContain("<div");
+    expect(out.startsWith("<img")).toBe(true);
+  });
+});
+
+// ─── unwrapCenteredImages ────────────────────────────────────────────────
+
+describe("unwrapCenteredImages", () => {
+  it("returns HTML unchanged when there's no centered wrapper", () => {
+    const html = '<p>Hello <img src="x.png"> world.</p>';
+    expect(unwrapCenteredImages(html)).toBe(html);
+  });
+
+  it("unwraps a div-wrapped centered image and tags it with data-center", () => {
+    const html = '<div align="center"><img src="x.png" alt="hi"></div>';
+    const out = unwrapCenteredImages(html);
+    expect(out).not.toContain("<div");
+    expect(out).toContain('data-center="true"');
+    expect(out).toContain('src="x.png"');
+    expect(out).toContain('alt="hi"');
+  });
+
+  it("unwraps a p-wrapped centered image", () => {
+    const html = '<p align="center"><img src="x.png"></p>';
+    const out = unwrapCenteredImages(html);
+    expect(out).not.toContain("<p");
+    expect(out).toContain('data-center="true"');
+  });
+
+  it("is case-insensitive on the align value", () => {
+    const html = '<div align="CENTER"><img src="x.png"></div>';
+    const out = unwrapCenteredImages(html);
+    expect(out).toContain('data-center="true"');
+  });
+
+  it("preserves width and height attributes on the unwrapped image", () => {
+    const html =
+      '<div align="center"><img src="x.png" width="300" height="200"></div>';
+    const out = unwrapCenteredImages(html);
+    expect(out).toContain('width="300"');
+    expect(out).toContain('height="200"');
+    expect(out).toContain('data-center="true"');
+  });
+
+  it("handles multiple centered images in the same document", () => {
+    const html =
+      '<div align="center"><img src="a.png"></div>' +
+      "<p>gap</p>" +
+      '<div align="center"><img src="b.png"></div>';
+    const out = unwrapCenteredImages(html);
+    expect((out.match(/data-center="true"/g) || []).length).toBe(2);
+    expect(out).toContain('src="a.png"');
+    expect(out).toContain('src="b.png"');
+    expect(out).toContain("<p>gap</p>");
+  });
+
+  it("does not touch a div wrapper that contains more than just an image", () => {
+    // If the wrapper has text or other nodes alongside the image, leave
+    // it alone — the user wrote something custom and we shouldn't
+    // flatten it.
+    const html =
+      '<div align="center"><img src="x.png"><p>caption</p></div>';
+    const out = unwrapCenteredImages(html);
+    expect(out).toContain("<div");
+    expect(out).not.toContain("data-center");
+  });
+
+  it("does not touch divs with a different align value", () => {
+    const html = '<div align="right"><img src="x.png"></div>';
+    const out = unwrapCenteredImages(html);
+    expect(out).toContain("<div");
+    expect(out).toContain('align="right"');
+    expect(out).not.toContain("data-center");
+  });
+
+  it("handles whitespace around the img inside the wrapper", () => {
+    const html = '<div align="center">\n  <img src="x.png">\n</div>';
+    const out = unwrapCenteredImages(html);
+    expect(out).toContain('data-center="true"');
+    expect(out).not.toContain("<div");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(unwrapCenteredImages("")).toBe("");
   });
 });

--- a/src/__tests__/image-resize.test.ts
+++ b/src/__tests__/image-resize.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Tests for the image-resize pure helpers.
+ *
+ * The resize feature adds width/height attributes to images in the
+ * editor. The helpers here handle the three concerns that a pure
+ * function can test without a real DOM:
+ *
+ *   1. parseImageDimension — user input string → normalized dimension
+ *   2. formatImageDimension — normalized → display string
+ *   3. buildSizedImageHTML — compose an <img> tag that Turndown emits
+ *      when either dimension is set (markdown has no size syntax)
+ */
+import { describe, it, expect } from "vitest";
+import {
+  parseImageDimension,
+  formatImageDimension,
+  buildSizedImageHTML,
+  type ImageDimension,
+} from "@/lib/image-resize";
+
+describe("parseImageDimension", () => {
+  // ─── Valid pixel values ────────────────────────────────────────────────
+
+  it("parses a plain integer as pixels", () => {
+    expect(parseImageDimension("300")).toEqual({ value: 300, unit: "px" });
+  });
+
+  it("parses an explicit px suffix", () => {
+    expect(parseImageDimension("300px")).toEqual({ value: 300, unit: "px" });
+    expect(parseImageDimension("300PX")).toEqual({ value: 300, unit: "px" });
+  });
+
+  it("parses whitespace-padded input", () => {
+    expect(parseImageDimension("  300px  ")).toEqual({ value: 300, unit: "px" });
+  });
+
+  // ─── Valid percentage values ───────────────────────────────────────────
+
+  it("parses percentage", () => {
+    expect(parseImageDimension("50%")).toEqual({ value: 50, unit: "%" });
+  });
+
+  it("parses 100%", () => {
+    expect(parseImageDimension("100%")).toEqual({ value: 100, unit: "%" });
+  });
+
+  it("parses single-digit percentage", () => {
+    expect(parseImageDimension("5%")).toEqual({ value: 5, unit: "%" });
+  });
+
+  // ─── Decimal values ────────────────────────────────────────────────────
+
+  it("parses a decimal percentage", () => {
+    expect(parseImageDimension("12.5%")).toEqual({ value: 12.5, unit: "%" });
+  });
+
+  it("truncates decimal pixel values to integers", () => {
+    // HTML width/height attributes want integers — decimals would be
+    // accepted but render inconsistently across browsers.
+    expect(parseImageDimension("300.7px")).toEqual({ value: 300, unit: "px" });
+  });
+
+  // ─── Invalid / empty inputs ────────────────────────────────────────────
+
+  it("returns null for empty input", () => {
+    expect(parseImageDimension("")).toBeNull();
+    expect(parseImageDimension("   ")).toBeNull();
+  });
+
+  it("returns null for non-numeric input", () => {
+    expect(parseImageDimension("auto")).toBeNull();
+    expect(parseImageDimension("big")).toBeNull();
+    expect(parseImageDimension("abc300")).toBeNull();
+  });
+
+  it("returns null for negative values", () => {
+    // Negative widths are never valid for images.
+    expect(parseImageDimension("-100")).toBeNull();
+    expect(parseImageDimension("-50%")).toBeNull();
+  });
+
+  it("returns null for zero", () => {
+    // A zero-width image is functionally deleting it — reject so the
+    // user gets clear feedback instead of an invisible image.
+    expect(parseImageDimension("0")).toBeNull();
+    expect(parseImageDimension("0%")).toBeNull();
+  });
+
+  it("returns null for percentage over 100", () => {
+    expect(parseImageDimension("150%")).toBeNull();
+    expect(parseImageDimension("101%")).toBeNull();
+  });
+
+  it("returns null for percentage with no number", () => {
+    expect(parseImageDimension("%")).toBeNull();
+  });
+
+  it("returns null for unsupported units", () => {
+    expect(parseImageDimension("10em")).toBeNull();
+    expect(parseImageDimension("5rem")).toBeNull();
+    expect(parseImageDimension("100vw")).toBeNull();
+  });
+});
+
+describe("formatImageDimension", () => {
+  it("formats pixels with no suffix (HTML attribute convention)", () => {
+    expect(formatImageDimension({ value: 300, unit: "px" })).toBe("300");
+  });
+
+  it("formats percentage with the % suffix", () => {
+    expect(formatImageDimension({ value: 50, unit: "%" })).toBe("50%");
+  });
+
+  it("preserves decimal percentages", () => {
+    expect(formatImageDimension({ value: 12.5, unit: "%" })).toBe("12.5%");
+  });
+
+  it("returns empty string for null (editor shows placeholder)", () => {
+    expect(formatImageDimension(null)).toBe("");
+  });
+});
+
+describe("buildSizedImageHTML", () => {
+  it("builds an <img> tag with src and alt", () => {
+    const out = buildSizedImageHTML({
+      src: "docs/images/photo.png",
+      alt: "A photo",
+      width: null,
+      height: null,
+    });
+    expect(out).toContain('src="docs/images/photo.png"');
+    expect(out).toContain('alt="A photo"');
+  });
+
+  it("adds a width attribute when width is set (px)", () => {
+    const out = buildSizedImageHTML({
+      src: "x.png",
+      alt: "",
+      width: { value: 300, unit: "px" },
+      height: null,
+    });
+    expect(out).toContain('width="300"');
+    expect(out).not.toContain("height=");
+  });
+
+  it("adds a width attribute with percent suffix", () => {
+    const out = buildSizedImageHTML({
+      src: "x.png",
+      alt: "",
+      width: { value: 50, unit: "%" },
+      height: null,
+    });
+    expect(out).toContain('width="50%"');
+  });
+
+  it("adds both width and height when both set", () => {
+    const out = buildSizedImageHTML({
+      src: "x.png",
+      alt: "both",
+      width: { value: 400, unit: "px" },
+      height: { value: 300, unit: "px" },
+    });
+    expect(out).toContain('width="400"');
+    expect(out).toContain('height="300"');
+  });
+
+  it("escapes double quotes inside alt text so the tag stays valid", () => {
+    const out = buildSizedImageHTML({
+      src: "x.png",
+      alt: 'A "fancy" photo',
+      width: null,
+      height: null,
+    });
+    // Either HTML entity or backslash escape is acceptable — just
+    // confirm there's no unescaped " that would break the attribute.
+    expect(out).not.toContain('alt="A "fancy" photo"');
+    expect(out).toContain("fancy");
+  });
+
+  it("escapes double quotes inside src", () => {
+    const out = buildSizedImageHTML({
+      src: 'x.png"; drop table',
+      alt: "",
+      width: null,
+      height: null,
+    });
+    // The escaped src must not contain an unescaped " that would
+    // prematurely close the src attribute.
+    const srcMatch = out.match(/src="([^"]*)"/);
+    expect(srcMatch).not.toBeNull();
+    // The part after the quote must not be a valid attribute start.
+    expect(out).not.toContain('src="x.png"; drop');
+  });
+
+  it("is a self-closing tag (HTML void element)", () => {
+    const out = buildSizedImageHTML({
+      src: "x.png",
+      alt: "",
+      width: null,
+      height: null,
+    });
+    // Accept either `<img ... />` or `<img ...>` — both are valid HTML.
+    expect(out).toMatch(/<img[^>]*\/?>/);
+  });
+
+  it("omits empty alt gracefully", () => {
+    const out = buildSizedImageHTML({
+      src: "x.png",
+      alt: "",
+      width: null,
+      height: null,
+    });
+    // Empty alt should still appear as alt="" for a11y (signals
+    // decorative image to screen readers).
+    expect(out).toContain('alt=""');
+  });
+
+  // ─── Round-trip through parse/format ──────────────────────────────────
+
+  it("parse → format → parse is idempotent for pixel values", () => {
+    const first = parseImageDimension("300")!;
+    const formatted = formatImageDimension(first);
+    const second = parseImageDimension(formatted);
+    expect(second).toEqual(first);
+  });
+
+  it("parse → format → parse is idempotent for percentage values", () => {
+    const first = parseImageDimension("50%")!;
+    const formatted = formatImageDimension(first);
+    const second = parseImageDimension(formatted);
+    expect(second).toEqual(first);
+  });
+});

--- a/src/__tests__/image-upload.test.ts
+++ b/src/__tests__/image-upload.test.ts
@@ -119,6 +119,39 @@ describe("generateImagePath", () => {
     const b = generateImagePath("photo.png", fixedDate);
     expect(a).not.toBe(b);
   });
+
+  // ─── Configurable folder ───────────────────────────────────────────────
+
+  it("uses a configurable folder when passed in", () => {
+    const path = generateImagePath("photo.png", fixedDate, "docs/assets");
+    expect(path.startsWith("docs/assets/")).toBe(true);
+  });
+
+  it("normalizes the folder argument (strips leading/trailing slashes)", () => {
+    expect(generateImagePath("photo.png", fixedDate, "/docs/assets/")).toMatch(
+      /^docs\/assets\//
+    );
+    expect(generateImagePath("photo.png", fixedDate, "public/img")).toMatch(
+      /^public\/img\//
+    );
+  });
+
+  it("falls back to docs/images when folder is empty or only slashes", () => {
+    expect(generateImagePath("photo.png", fixedDate, "")).toMatch(/^docs\/images\//);
+    expect(generateImagePath("photo.png", fixedDate, "/")).toMatch(/^docs\/images\//);
+  });
+
+  it("supports a single-segment folder", () => {
+    expect(generateImagePath("photo.png", fixedDate, "assets")).toMatch(
+      /^assets\//
+    );
+  });
+
+  it("supports deeply nested folders", () => {
+    expect(
+      generateImagePath("photo.png", fixedDate, "src/main/resources/images")
+    ).toMatch(/^src\/main\/resources\/images\//);
+  });
 });
 
 describe("arrayBufferToBase64", () => {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -596,3 +596,13 @@ body {
 .footnote-back:hover {
   color: var(--accent);
 }
+
+/* Centered images in the rich editor (ProseMirror) — the Image node
+ * gets data-center="true" + class="mardoc-center-image" when the
+ * user ticks Center in the popover. Turndown wraps them in
+ * <div align="center"> on save. */
+.ProseMirror img.mardoc-center-image {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -45,6 +45,19 @@ const Image = BaseImage.extend({
         parseHTML: (el) => el.getAttribute("height"),
         renderHTML: (attrs) => (attrs.height ? { height: attrs.height } : {}),
       },
+      // Center flag: stored on the <img> as data-center="true" so it
+      // round-trips through HTML parsing. Turndown's image rule wraps
+      // the output in <div align="center"> when this is set; the
+      // markdownToHtml pre-processor unwraps centered divs on the way
+      // back in so the attribute is restored.
+      center: {
+        default: false,
+        parseHTML: (el) => el.getAttribute("data-center") === "true",
+        renderHTML: (attrs) =>
+          attrs.center
+            ? { "data-center": "true", class: "mardoc-center-image" }
+            : {},
+      },
     };
   },
 });
@@ -57,7 +70,7 @@ import {
   resolveDraftOnLoad,
 } from "@/lib/draft-store";
 import { analyzeMarkdown, type MarkdownStats } from "@/lib/word-count";
-import { parseImageDimension, formatImageDimension, type ImageDimension } from "@/lib/image-resize";
+import { parseImageDimension, formatImageDimension, unwrapCenteredImages, type ImageDimension } from "@/lib/image-resize";
 import { transformGitHubAlerts } from "@/lib/github-alerts";
 import { transformFootnotes } from "@/lib/footnotes";
 import FindReplaceBar from "./FindReplaceBar";
@@ -69,6 +82,7 @@ import {
   arrayBufferToBase64,
   replacePendingImageUrls,
 } from "@/lib/image-upload";
+import { getImageUploadFolder } from "@/lib/image-path-config";
 import { commitBase64FileToBranch } from "@/lib/github-api";
 
 interface PendingImage {
@@ -159,7 +173,12 @@ const showdownConverter = new Showdown.Converter({
 });
 
 function markdownToHtml(md: string, repoFullName?: string, branch?: string, filePath?: string): string {
-  const html = transformGitHubAlerts(showdownConverter.makeHtml(transformFootnotes(md)));
+  // Order matters: footnotes → showdown → alerts → center unwrap →
+  // relative-image rewrite. unwrapCenteredImages has to run on the
+  // rendered HTML AFTER showdown / alerts so it sees the final
+  // <div align="center"><img></div> structure.
+  let html = transformGitHubAlerts(showdownConverter.makeHtml(transformFootnotes(md)));
+  html = unwrapCenteredImages(html);
   if (repoFullName && branch && filePath) {
     return rewriteImageUrls(html, repoFullName, branch, filePath);
   }
@@ -284,6 +303,8 @@ interface BubbleTarget {
   // what's already set instead of starting blank.
   width?: string;
   height?: string;
+  // Whether the image is currently marked centered (data-center="true").
+  center?: boolean;
 }
 
 function LinkImageBubble({
@@ -304,6 +325,7 @@ function LinkImageBubble({
   const [editAlt, setEditAlt] = useState("");
   const [editWidth, setEditWidth] = useState("");
   const [editHeight, setEditHeight] = useState("");
+  const [editCenter, setEditCenter] = useState(false);
   const [lockAspect, setLockAspect] = useState(true);
   // Natural image aspect ratio (intrinsic width / height) captured from
   // the rendered <img>. Used to auto-fill the other dimension when the
@@ -366,6 +388,7 @@ function LinkImageBubble({
     setEditAlt(target.alt || "");
     setEditWidth(target.width || "");
     setEditHeight(target.height || "");
+    setEditCenter(!!target.center);
 
     // Capture the natural aspect ratio of the rendered <img> so the
     // aspect lock can drive one input from the other. Fall back to the
@@ -428,16 +451,17 @@ function LinkImageBubble({
       // size.
       const widthParsed = parseImageDimension(editWidth);
       const heightParsed = parseImageDimension(editHeight);
-      const attrs: Record<string, string | null> = {
+      const attrs: Record<string, string | boolean | null> = {
         src: editUrl,
         alt: editAlt,
         width: widthParsed ? formatImageDimension(widthParsed) : null,
         height: heightParsed ? formatImageDimension(heightParsed) : null,
+        center: editCenter,
       };
       editor.chain().focus().setImage(attrs as any).run();
 
       // setImage in TipTap's Image extension ignores non-standard
-      // attributes on some versions. Force the width/height via
+      // attributes on some versions. Force width/height/center via
       // updateAttributes on the current node as a safety net.
       editor
         .chain()
@@ -445,6 +469,7 @@ function LinkImageBubble({
         .updateAttributes("image", {
           width: attrs.width,
           height: attrs.height,
+          center: attrs.center,
         })
         .run();
     }
@@ -557,6 +582,21 @@ function LinkImageBubble({
                       px or %
                     </span>
                   </div>
+                </div>
+                <div>
+                  <label className="flex items-center gap-1.5 text-[10px] text-[var(--text-secondary)] cursor-pointer select-none">
+                    <input
+                      type="checkbox"
+                      checked={editCenter}
+                      onChange={(e) => setEditCenter(e.target.checked)}
+                    />
+                    <span>
+                      Center image{" "}
+                      <span className="text-[var(--text-muted)]">
+                        (wraps in {"<div align=\"center\">"})
+                      </span>
+                    </span>
+                  </label>
                 </div>
               </>
             )}
@@ -908,13 +948,17 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
 
     setImageUploadError(null);
 
+    // Read the per-repo configured upload folder. Falls back to
+    // docs/images when unset — see image-path-config.ts.
+    const folder = getImageUploadFolder(scope.repoFullName);
+
     // New-file draft: defer the commit. Store the file under a blob
     // URL that the editor can render locally, queue it, and hand the
     // blob URL back so the TipTap insert still sees a valid src. The
     // commit happens when the user saves the draft to the repo.
     if (scope.isNewFile) {
       const blobUrl = URL.createObjectURL(file);
-      const intendedPath = generateImagePath(file.name || "image.png");
+      const intendedPath = generateImagePath(file.name || "image.png", new Date(), folder);
       setPendingImages((prev) => [
         ...prev,
         { blobUrl, file, intendedPath, alt: file.name || "image" },
@@ -927,7 +971,7 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
     try {
       const buffer = await file.arrayBuffer();
       const base64 = arrayBufferToBase64(buffer);
-      const path = generateImagePath(file.name || "image.png");
+      const path = generateImagePath(file.name || "image.png", new Date(), folder);
       await commitBase64FileToBranch(
         scope.repoFullName,
         scope.branch,
@@ -1175,7 +1219,9 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
       setCodeView(true);
       editor.setEditable(false);
     } else {
-      let rawHtml = transformGitHubAlerts(showdownConverter.makeHtml(transformFootnotes(codeContent)));
+      let rawHtml = unwrapCenteredImages(
+        transformGitHubAlerts(showdownConverter.makeHtml(transformFootnotes(codeContent)))
+      );
       if (repoFullName && branch && filePath) {
         rawHtml = rewriteImageUrls(rawHtml, repoFullName, branch, filePath);
       }
@@ -1570,6 +1616,7 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
         element: img,
         width: img.getAttribute("width") || "",
         height: img.getAttribute("height") || "",
+        center: img.getAttribute("data-center") === "true",
       });
       return;
     }

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -32,6 +32,19 @@ const Image = BaseImage.extend({
       "data-gh-repo": { default: null, parseHTML: (el) => el.getAttribute("data-gh-repo"), renderHTML: (attrs) => attrs["data-gh-repo"] ? { "data-gh-repo": attrs["data-gh-repo"] } : {} },
       "data-gh-ref": { default: null, parseHTML: (el) => el.getAttribute("data-gh-ref"), renderHTML: (attrs) => attrs["data-gh-ref"] ? { "data-gh-ref": attrs["data-gh-ref"] } : {} },
       "data-gh-path": { default: null, parseHTML: (el) => el.getAttribute("data-gh-path"), renderHTML: (attrs) => attrs["data-gh-path"] ? { "data-gh-path": attrs["data-gh-path"] } : {} },
+      // Width / height attributes for image resize. Stored as strings
+      // (e.g. "300" or "50%") so they round-trip through HTML
+      // attribute parsing without losing the % unit.
+      width: {
+        default: null,
+        parseHTML: (el) => el.getAttribute("width"),
+        renderHTML: (attrs) => (attrs.width ? { width: attrs.width } : {}),
+      },
+      height: {
+        default: null,
+        parseHTML: (el) => el.getAttribute("height"),
+        renderHTML: (attrs) => (attrs.height ? { height: attrs.height } : {}),
+      },
     };
   },
 });
@@ -44,6 +57,7 @@ import {
   resolveDraftOnLoad,
 } from "@/lib/draft-store";
 import { analyzeMarkdown, type MarkdownStats } from "@/lib/word-count";
+import { parseImageDimension, formatImageDimension, type ImageDimension } from "@/lib/image-resize";
 import { transformGitHubAlerts } from "@/lib/github-alerts";
 import { transformFootnotes } from "@/lib/footnotes";
 import FindReplaceBar from "./FindReplaceBar";
@@ -84,6 +98,8 @@ import {
   Undo,
   Redo,
   Link as LinkIcon,
+  Link2,
+  Link2Off,
   Image as ImageIcon,
   Highlighter,
   FileCode,
@@ -263,6 +279,11 @@ interface BubbleTarget {
   href: string;
   alt?: string;
   element: HTMLElement;
+  // For images: the current width/height attribute values (raw strings
+  // like "300" or "50%"), passed through so the editing popover shows
+  // what's already set instead of starting blank.
+  width?: string;
+  height?: string;
 }
 
 function LinkImageBubble({
@@ -281,6 +302,13 @@ function LinkImageBubble({
   const [editing, setEditing] = useState(false);
   const [editUrl, setEditUrl] = useState("");
   const [editAlt, setEditAlt] = useState("");
+  const [editWidth, setEditWidth] = useState("");
+  const [editHeight, setEditHeight] = useState("");
+  const [lockAspect, setLockAspect] = useState(true);
+  // Natural image aspect ratio (intrinsic width / height) captured from
+  // the rendered <img>. Used to auto-fill the other dimension when the
+  // aspect lock is on.
+  const [naturalRatio, setNaturalRatio] = useState<number | null>(null);
   const bubbleRef = useRef<HTMLDivElement>(null);
 
   // Reset edit state when target changes
@@ -336,7 +364,51 @@ function LinkImageBubble({
   const startEdit = () => {
     setEditUrl(target.href);
     setEditAlt(target.alt || "");
+    setEditWidth(target.width || "");
+    setEditHeight(target.height || "");
+
+    // Capture the natural aspect ratio of the rendered <img> so the
+    // aspect lock can drive one input from the other. Fall back to the
+    // displayed dimensions if naturalWidth/Height aren't available yet.
+    if (target.type === "image" && target.element instanceof HTMLImageElement) {
+      const img = target.element;
+      const w = img.naturalWidth || img.width;
+      const h = img.naturalHeight || img.height;
+      if (w > 0 && h > 0) {
+        setNaturalRatio(w / h);
+      } else {
+        setNaturalRatio(null);
+      }
+    }
+
     setEditing(true);
+  };
+
+  // When the aspect lock is on and the user types in one field, auto-
+  // fill the other based on the natural ratio. Only applies when both
+  // sides are pure pixel values — percentage mixes don't have a
+  // meaningful aspect relationship.
+  const handleWidthChange = (raw: string) => {
+    setEditWidth(raw);
+    if (!lockAspect || !naturalRatio) return;
+    const parsed = parseImageDimension(raw);
+    if (parsed && parsed.unit === "px") {
+      const h = Math.round(parsed.value / naturalRatio);
+      setEditHeight(String(h));
+    } else if (parsed && parsed.unit === "%") {
+      setEditHeight(`${parsed.value}%`);
+    }
+  };
+  const handleHeightChange = (raw: string) => {
+    setEditHeight(raw);
+    if (!lockAspect || !naturalRatio) return;
+    const parsed = parseImageDimension(raw);
+    if (parsed && parsed.unit === "px") {
+      const w = Math.round(parsed.value * naturalRatio);
+      setEditWidth(String(w));
+    } else if (parsed && parsed.unit === "%") {
+      setEditWidth(`${parsed.value}%`);
+    }
   };
 
   const applyEdit = () => {
@@ -350,9 +422,30 @@ function LinkImageBubble({
       // Restore selection position
       editor.commands.setTextSelection({ from, to });
     } else {
-      // Update image src and alt
-      editor.chain().focus()
-        .setImage({ src: editUrl, alt: editAlt })
+      // Update image src + alt + dimensions. parseImageDimension
+      // normalizes each value; invalid input falls back to null which
+      // means "remove the attribute" so the image reverts to natural
+      // size.
+      const widthParsed = parseImageDimension(editWidth);
+      const heightParsed = parseImageDimension(editHeight);
+      const attrs: Record<string, string | null> = {
+        src: editUrl,
+        alt: editAlt,
+        width: widthParsed ? formatImageDimension(widthParsed) : null,
+        height: heightParsed ? formatImageDimension(heightParsed) : null,
+      };
+      editor.chain().focus().setImage(attrs as any).run();
+
+      // setImage in TipTap's Image extension ignores non-standard
+      // attributes on some versions. Force the width/height via
+      // updateAttributes on the current node as a safety net.
+      editor
+        .chain()
+        .focus()
+        .updateAttributes("image", {
+          width: attrs.width,
+          height: attrs.height,
+        })
         .run();
     }
     onDismiss();
@@ -399,21 +492,73 @@ function LinkImageBubble({
               />
             </div>
             {target.type === "image" && (
-              <div>
-                <label className="text-[10px] font-medium text-[var(--text-muted)] uppercase tracking-wider mb-0.5 block">
-                  Alt text
-                </label>
-                <input
-                  type="text"
-                  value={editAlt}
-                  onChange={(e) => setEditAlt(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") applyEdit();
-                    if (e.key === "Escape") { setEditing(false); }
-                  }}
-                  className="w-full text-xs px-2 py-1.5 rounded border border-[var(--border)] bg-[var(--surface-secondary)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)]"
-                />
-              </div>
+              <>
+                <div>
+                  <label className="text-[10px] font-medium text-[var(--text-muted)] uppercase tracking-wider mb-0.5 block">
+                    Alt text
+                  </label>
+                  <input
+                    type="text"
+                    value={editAlt}
+                    onChange={(e) => setEditAlt(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") applyEdit();
+                      if (e.key === "Escape") { setEditing(false); }
+                    }}
+                    className="w-full text-xs px-2 py-1.5 rounded border border-[var(--border)] bg-[var(--surface-secondary)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)]"
+                  />
+                </div>
+                {/* Width / height inputs with an aspect-lock toggle
+                    between them. Blank means "natural size" — the
+                    attribute gets removed on apply. */}
+                <div>
+                  <label className="text-[10px] font-medium text-[var(--text-muted)] uppercase tracking-wider mb-0.5 block">
+                    Size
+                  </label>
+                  <div className="flex items-center gap-1">
+                    <input
+                      type="text"
+                      value={editWidth}
+                      onChange={(e) => handleWidthChange(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") applyEdit();
+                        if (e.key === "Escape") { setEditing(false); }
+                      }}
+                      placeholder="Width"
+                      className="w-20 text-xs px-2 py-1.5 rounded border border-[var(--border)] bg-[var(--surface-secondary)] text-[var(--text-primary)] font-mono focus:outline-none focus:border-[var(--accent)]"
+                      title="Width in pixels (e.g. 300) or percent (e.g. 50%)"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setLockAspect((v) => !v)}
+                      className={`p-1 rounded transition-colors ${
+                        lockAspect
+                          ? "bg-[var(--accent-muted)] text-[var(--accent)]"
+                          : "text-[var(--text-muted)] hover:bg-[var(--surface-hover)]"
+                      }`}
+                      title={lockAspect ? "Aspect ratio locked" : "Aspect ratio unlocked"}
+                      aria-pressed={lockAspect}
+                    >
+                      {lockAspect ? <Link2 size={12} /> : <Link2Off size={12} />}
+                    </button>
+                    <input
+                      type="text"
+                      value={editHeight}
+                      onChange={(e) => handleHeightChange(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") applyEdit();
+                        if (e.key === "Escape") { setEditing(false); }
+                      }}
+                      placeholder="Height"
+                      className="w-20 text-xs px-2 py-1.5 rounded border border-[var(--border)] bg-[var(--surface-secondary)] text-[var(--text-primary)] font-mono focus:outline-none focus:border-[var(--accent)]"
+                      title="Height in pixels (e.g. 200) or percent (e.g. 50%)"
+                    />
+                    <span className="text-[9px] text-[var(--text-muted)] ml-1">
+                      px or %
+                    </span>
+                  </div>
+                </div>
+              </>
             )}
             <div className="flex items-center justify-end gap-1.5 pt-1">
               <button
@@ -1423,6 +1568,8 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
         href: img.getAttribute("src") || "",
         alt: img.getAttribute("alt") || "",
         element: img,
+        width: img.getAttribute("width") || "",
+        height: img.getAttribute("height") || "",
       });
       return;
     }

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,10 +1,15 @@
 "use client";
 
 import React, { useState, useEffect, useMemo } from "react";
-import { Settings, X, Github, LogIn, LogOut, RefreshCw, Lock, Globe, Search } from "lucide-react";
+import { Settings, X, Github, LogIn, LogOut, RefreshCw, Lock, Globe, Search, FolderOpen } from "lucide-react";
 import { useApp } from "@/lib/app-context";
 import { fetchUserRepos } from "@/lib/github-api";
 import * as safeStorage from "@/lib/safe-storage";
+import {
+  getImageUploadFolder,
+  setImageUploadFolder,
+  DEFAULT_IMAGE_FOLDER,
+} from "@/lib/image-path-config";
 
 interface SettingsPanelProps {
   isOpen: boolean;
@@ -23,6 +28,8 @@ export default function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
 
   const [tokenInput, setTokenInput] = useState("");
   const [repoInput, setRepoInput] = useState(currentRepo || "");
+  const [imageFolderInput, setImageFolderInput] = useState("");
+  const [imageFolderSaved, setImageFolderSaved] = useState(false);
   const [userRepos, setUserRepos] = useState<
     { fullName: string; description: string; isPrivate: boolean }[]
   >([]);
@@ -42,6 +49,26 @@ export default function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
         r.description.toLowerCase().includes(query)
     );
   }, [userRepos, repoFilter]);
+
+  // Load the per-repo image folder setting every time the panel opens
+  // or the current repo changes, so the input shows the current value.
+  useEffect(() => {
+    if (isOpen) {
+      setImageFolderInput(getImageUploadFolder(currentRepo ?? undefined));
+      setImageFolderSaved(false);
+    }
+  }, [isOpen, currentRepo]);
+
+  const handleSaveImageFolder = () => {
+    if (!currentRepo) return;
+    setImageUploadFolder(currentRepo, imageFolderInput);
+    // Re-read so the input reflects the sanitized form (e.g., trailing
+    // slash stripped, invalid input bounced back to default).
+    const saved = getImageUploadFolder(currentRepo);
+    setImageFolderInput(saved);
+    setImageFolderSaved(true);
+    setTimeout(() => setImageFolderSaved(false), 1500);
+  };
 
   // Load user repos: show cached immediately, refresh in background
   useEffect(() => {
@@ -344,6 +371,52 @@ export default function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
                       No repositories found. Try entering a repo name manually above.
                     </p>
                   )}
+                </div>
+              )}
+
+              {/* Image upload folder — configurable per repo. The
+                  paste / drag-drop flow commits images under this
+                  folder; defaults to docs/images. */}
+              {currentRepo && (
+                <div className="pt-4 border-t border-[var(--border)]">
+                  <label className="block text-sm font-medium text-[var(--text-primary)] mb-1.5">
+                    <span className="inline-flex items-center gap-1.5">
+                      <FolderOpen size={14} className="text-[var(--text-muted)]" />
+                      Image upload folder
+                    </span>
+                  </label>
+                  <p className="text-xs text-[var(--text-muted)] mb-2">
+                    Where paste / drag-drop uploads commit in{" "}
+                    <span className="font-mono">{currentRepo}</span>.
+                    Default: <span className="font-mono">{DEFAULT_IMAGE_FOLDER}</span>
+                  </p>
+                  <div className="flex gap-2">
+                    <input
+                      type="text"
+                      value={imageFolderInput}
+                      onChange={(e) => {
+                        setImageFolderInput(e.target.value);
+                        setImageFolderSaved(false);
+                      }}
+                      placeholder={DEFAULT_IMAGE_FOLDER}
+                      className="flex-1 px-3 py-2 text-sm rounded-lg border border-[var(--border)] bg-[var(--surface)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)] font-mono"
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") handleSaveImageFolder();
+                      }}
+                    />
+                    <button
+                      onClick={handleSaveImageFolder}
+                      className="px-4 py-2 bg-[var(--accent)] text-white text-sm rounded-lg hover:bg-[var(--accent-hover)] transition-colors"
+                    >
+                      {imageFolderSaved ? "Saved ✓" : "Save"}
+                    </button>
+                  </div>
+                  <p className="text-[10px] text-[var(--text-muted)] mt-1.5">
+                    Examples: <span className="font-mono">docs/images</span>,{" "}
+                    <span className="font-mono">docs/assets</span>,{" "}
+                    <span className="font-mono">src/assets/img</span>,{" "}
+                    <span className="font-mono">public/images</span>
+                  </p>
                 </div>
               )}
 

--- a/src/lib/image-path-config.ts
+++ b/src/lib/image-path-config.ts
@@ -1,0 +1,98 @@
+/**
+ * Per-repo image upload folder setting.
+ *
+ * Different projects put images in different folders — docs/images,
+ * docs/assets, src/assets, public/img, etc. This module stores the
+ * user's preferred target folder per repo in localStorage so the
+ * paste / drag-drop upload flow can respect each project's
+ * convention.
+ *
+ * Pure I/O — no React, no network. Tested in
+ * image-path-config.test.ts.
+ */
+
+export const DEFAULT_IMAGE_FOLDER = "docs/images";
+
+const STORAGE_PREFIX = "mardoc:image-folder:";
+
+/**
+ * Normalize a user-entered folder path. Strips leading/trailing
+ * slashes, collapses runs of slashes, and rejects anything that would
+ * escape the repo root (path traversal, protocols, empty). Rejected
+ * inputs fall back to DEFAULT_IMAGE_FOLDER instead of throwing — the
+ * caller gets a usable path either way.
+ */
+export function sanitizeImageFolder(input: string): string {
+  if (!input) return DEFAULT_IMAGE_FOLDER;
+  const trimmed = input.trim();
+  if (!trimmed) return DEFAULT_IMAGE_FOLDER;
+
+  // Reject anything that looks like an absolute URL.
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return DEFAULT_IMAGE_FOLDER;
+
+  // Strip leading/trailing slashes, collapse runs.
+  const normalized = trimmed.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\/+/g, "/");
+  if (!normalized) return DEFAULT_IMAGE_FOLDER;
+
+  // Reject path traversal segments.
+  const segments = normalized.split("/");
+  if (segments.some((s) => s === ".." || s === ".")) return DEFAULT_IMAGE_FOLDER;
+
+  return normalized;
+}
+
+function keyFor(repoFullName: string): string {
+  return `${STORAGE_PREFIX}${repoFullName}`;
+}
+
+function safeStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the configured image upload folder for a repo. Returns the
+ * default for missing repos, missing values, or values that fail
+ * sanitization (tampered storage, old formats, etc.).
+ */
+export function getImageUploadFolder(repoFullName: string | undefined): string {
+  if (!repoFullName) return DEFAULT_IMAGE_FOLDER;
+  const storage = safeStorage();
+  if (!storage) return DEFAULT_IMAGE_FOLDER;
+  try {
+    const raw = storage.getItem(keyFor(repoFullName));
+    if (!raw) return DEFAULT_IMAGE_FOLDER;
+    const sanitized = sanitizeImageFolder(raw);
+    return sanitized;
+  } catch {
+    return DEFAULT_IMAGE_FOLDER;
+  }
+}
+
+/**
+ * Write the image upload folder for a repo. Empty / whitespace input
+ * clears the stored value (falling back to the default on next read).
+ */
+export function setImageUploadFolder(
+  repoFullName: string | undefined,
+  value: string
+): void {
+  if (!repoFullName) return;
+  const storage = safeStorage();
+  if (!storage) return;
+  try {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      storage.removeItem(keyFor(repoFullName));
+      return;
+    }
+    const sanitized = sanitizeImageFolder(trimmed);
+    storage.setItem(keyFor(repoFullName), sanitized);
+  } catch {
+    // ignore — storage failures are non-fatal
+  }
+}

--- a/src/lib/image-resize.ts
+++ b/src/lib/image-resize.ts
@@ -1,0 +1,114 @@
+/**
+ * Pure helpers for image resize: parsing user input, formatting for
+ * display, and building the sized <img> tag emitted by Turndown.
+ *
+ * Markdown has no native size syntax (`![](url)` doesn't carry
+ * dimensions), so sized images round-trip as inline HTML. GitHub
+ * renders inline `<img src="..." width="..." height="...">` in
+ * markdown files, and Turndown's image rule switches to this shape
+ * when either dimension is set.
+ *
+ * Tested in image-resize.test.ts.
+ */
+
+export type ImageDimensionUnit = "px" | "%";
+
+export interface ImageDimension {
+  value: number;
+  unit: ImageDimensionUnit;
+}
+
+/**
+ * Parse a user-entered dimension string into a normalized form.
+ *
+ * Accepts:
+ *   - Plain integer "300" → { value: 300, unit: "px" }
+ *   - Pixel suffix "300px" / "300PX" → { value: 300, unit: "px" }
+ *   - Percentage "50%" → { value: 50, unit: "%" }
+ *   - Whitespace-padded versions of any of the above
+ *
+ * Rejects (returns null):
+ *   - Empty / whitespace-only
+ *   - Non-numeric
+ *   - Negative or zero values
+ *   - Percentages over 100
+ *   - Unsupported units (em, rem, vw, vh, etc.)
+ *   - Decimals for pixels (truncated to integers)
+ */
+export function parseImageDimension(input: string): ImageDimension | null {
+  if (!input) return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  // Percentage form: digits (with optional decimal) + %
+  const pctMatch = trimmed.match(/^(\d+(?:\.\d+)?)\s*%$/);
+  if (pctMatch) {
+    const value = parseFloat(pctMatch[1]);
+    if (!Number.isFinite(value) || value <= 0 || value > 100) return null;
+    return { value, unit: "%" };
+  }
+
+  // Pixel form: digits (with optional decimal) + optional px suffix
+  const pxMatch = trimmed.match(/^(\d+(?:\.\d+)?)\s*(px)?$/i);
+  if (pxMatch) {
+    const raw = parseFloat(pxMatch[1]);
+    if (!Number.isFinite(raw) || raw <= 0) return null;
+    // HTML width/height attributes want integers — truncate decimals.
+    return { value: Math.trunc(raw), unit: "px" };
+  }
+
+  return null;
+}
+
+/**
+ * Format a normalized dimension back into the display string the user
+ * sees in the width/height inputs. Null becomes empty string so a
+ * cleared input shows a placeholder instead of literal "null".
+ */
+export function formatImageDimension(dim: ImageDimension | null): string {
+  if (!dim) return "";
+  if (dim.unit === "%") return `${dim.value}%`;
+  return `${dim.value}`;
+}
+
+/**
+ * Format a dimension the way it should appear as an HTML attribute
+ * value — pixels have no suffix (HTML convention), percents keep the %.
+ */
+function formatDimensionAttr(dim: ImageDimension): string {
+  return dim.unit === "%" ? `${dim.value}%` : `${dim.value}`;
+}
+
+export interface SizedImageInput {
+  src: string;
+  alt: string;
+  width: ImageDimension | null;
+  height: ImageDimension | null;
+}
+
+/**
+ * Build an HTML `<img>` tag with the given attributes, with every
+ * attribute value HTML-escaped so nothing the user typed can break
+ * the tag boundary. Used by the Turndown image rule when either
+ * dimension is set.
+ */
+export function buildSizedImageHTML(input: SizedImageInput): string {
+  const parts: string[] = ["<img"];
+  parts.push(`src="${escapeAttribute(input.src)}"`);
+  parts.push(`alt="${escapeAttribute(input.alt)}"`);
+  if (input.width) {
+    parts.push(`width="${formatDimensionAttr(input.width)}"`);
+  }
+  if (input.height) {
+    parts.push(`height="${formatDimensionAttr(input.height)}"`);
+  }
+  return parts.join(" ") + ">";
+}
+
+function escapeAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}

--- a/src/lib/image-resize.ts
+++ b/src/lib/image-resize.ts
@@ -84,13 +84,18 @@ export interface SizedImageInput {
   alt: string;
   width: ImageDimension | null;
   height: ImageDimension | null;
+  /** When true, wrap the rendered tag in `<div align="center">...</div>`
+   *  so GitHub renders the image centered. GitHub's markdown sanitizer
+   *  strips `class` and `style` from inline `<img>`, but it keeps the
+   *  `align` attribute on block wrappers, so this is the clean path. */
+  center?: boolean;
 }
 
 /**
  * Build an HTML `<img>` tag with the given attributes, with every
  * attribute value HTML-escaped so nothing the user typed can break
  * the tag boundary. Used by the Turndown image rule when either
- * dimension is set.
+ * dimension is set or the image is marked centered.
  */
 export function buildSizedImageHTML(input: SizedImageInput): string {
   const parts: string[] = ["<img"];
@@ -102,7 +107,38 @@ export function buildSizedImageHTML(input: SizedImageInput): string {
   if (input.height) {
     parts.push(`height="${formatDimensionAttr(input.height)}"`);
   }
-  return parts.join(" ") + ">";
+  const tag = parts.join(" ") + ">";
+  if (input.center) {
+    return `<div align="center">${tag}</div>`;
+  }
+  return tag;
+}
+
+/**
+ * Pre-processor that runs on showdown-rendered HTML before TipTap
+ * parses it. Detects `<div align="center">` or `<p align="center">`
+ * wrappers whose only meaningful child is an `<img>`, unwraps them,
+ * and tags the inner image with `data-center="true"` so the Image
+ * extension's parseHTML can restore the centered attribute.
+ *
+ * Wrappers that contain additional content (caption text, multiple
+ * elements) are left alone — the user wrote something custom and the
+ * editor shouldn't flatten it on round-trip.
+ */
+export function unwrapCenteredImages(html: string): string {
+  if (!html) return html;
+  // Match `<div align="center">` or `<p align="center">` containing a
+  // single `<img>` (with optional surrounding whitespace). The inner
+  // tag may already have attributes; we preserve them and append
+  // `data-center="true"`.
+  const re = /<(div|p)\s+align="center"\s*>\s*(<img\b[^>]*?\/?>)\s*<\/\1>/gi;
+  return html.replace(re, (_full, _tag, imgTag: string) => {
+    // Only rewrite if the captured img doesn't already have data-center
+    // so idempotent passes don't duplicate the attribute.
+    if (/\bdata-center\b/.test(imgTag)) return imgTag;
+    // Insert data-center="true" right before the closing `>`.
+    return imgTag.replace(/\s*\/?>$/, ' data-center="true">');
+  });
 }
 
 function escapeAttribute(value: string): string {

--- a/src/lib/image-upload.ts
+++ b/src/lib/image-upload.ts
@@ -43,8 +43,11 @@ export function validateImageFile(file: { type: string; size: number }): Validat
 /**
  * Generate a stable, collision-resistant path for an uploaded image.
  *
- * Layout: `docs/images/{YYYY-MM-DD}-{sanitized-stem}-{random}.{ext}`
+ * Layout: `{folder}/{YYYY-MM-DD}-{sanitized-stem}-{random}.{ext}`
  *
+ *   - `folder` is the per-repo configured upload folder
+ *     (src/lib/image-path-config.ts). Defaults to `docs/images` when
+ *     not passed, keeping existing callers working.
  *   - Date prefix keeps uploads sortable in the file tree
  *   - Random suffix prevents collisions when a user pastes the same
  *     clipboard content twice in a row (pasted screenshots always get
@@ -52,7 +55,11 @@ export function validateImageFile(file: { type: string; size: number }): Validat
  *   - Sanitized stem matches the broad shape of the original filename
  *     but is url-safe and lowercased
  */
-export function generateImagePath(originalName: string, now: Date = new Date()): string {
+export function generateImagePath(
+  originalName: string,
+  now: Date = new Date(),
+  folder: string = "docs/images"
+): string {
   const datePrefix = toISODatePrefix(now);
   const randomSuffix = Math.random().toString(36).slice(2, 8);
 
@@ -60,7 +67,12 @@ export function generateImagePath(originalName: string, now: Date = new Date()):
   const sanitizedStem = sanitizeStem(stem) || "image";
   const safeExt = ext || ".png";
 
-  return `docs/images/${datePrefix}-${sanitizedStem}-${randomSuffix}${safeExt}`;
+  // Normalize the folder — strip leading/trailing slashes so the
+  // caller can pass either "docs/images" or "/docs/images/" and we
+  // produce the same output.
+  const normalizedFolder = folder.replace(/^\/+|\/+$/g, "") || "docs/images";
+
+  return `${normalizedFolder}/${datePrefix}-${sanitizedStem}-${randomSuffix}${safeExt}`;
 }
 
 function toISODatePrefix(d: Date): string {

--- a/src/lib/turndown.ts
+++ b/src/lib/turndown.ts
@@ -1,4 +1,5 @@
 import TurndownService from "turndown";
+import { buildSizedImageHTML, parseImageDimension } from "@/lib/image-resize";
 
 /**
  * Creates a configured TurndownService that preserves HTML elements
@@ -44,7 +45,35 @@ export function createTurndownService(): TurndownService {
       const el = node as HTMLElement;
       const src = el.getAttribute("data-original-src") || "";
       const alt = el.getAttribute("alt") || "";
+      const width = parseImageDimension(el.getAttribute("width") || "");
+      const height = parseImageDimension(el.getAttribute("height") || "");
+      // If either dimension is set, switch to inline <img> HTML so the
+      // size survives the round-trip — standard markdown has no size
+      // syntax, but GitHub renders inline <img> tags.
+      if (width || height) {
+        return buildSizedImageHTML({ src, alt, width, height });
+      }
       return `![${alt}](${src})`;
+    },
+  });
+
+  // Images without a data-original-src — mostly user-pasted or
+  // drag-dropped images that go straight to the rich editor. Still
+  // need to check for width/height so the resize survives save.
+  turndown.addRule("imageWithDimensions", {
+    filter: (node) => {
+      if (node.nodeName !== "IMG") return false;
+      if (node.hasAttribute("data-original-src")) return false; // handled above
+      if (node.hasAttribute("data-mermaid-source")) return false; // handled below
+      return node.hasAttribute("width") || node.hasAttribute("height");
+    },
+    replacement: (_content, node) => {
+      const el = node as HTMLElement;
+      const src = el.getAttribute("src") || "";
+      const alt = el.getAttribute("alt") || "";
+      const width = parseImageDimension(el.getAttribute("width") || "");
+      const height = parseImageDimension(el.getAttribute("height") || "");
+      return buildSizedImageHTML({ src, alt, width, height });
     },
   });
 

--- a/src/lib/turndown.ts
+++ b/src/lib/turndown.ts
@@ -47,11 +47,13 @@ export function createTurndownService(): TurndownService {
       const alt = el.getAttribute("alt") || "";
       const width = parseImageDimension(el.getAttribute("width") || "");
       const height = parseImageDimension(el.getAttribute("height") || "");
-      // If either dimension is set, switch to inline <img> HTML so the
-      // size survives the round-trip — standard markdown has no size
-      // syntax, but GitHub renders inline <img> tags.
-      if (width || height) {
-        return buildSizedImageHTML({ src, alt, width, height });
+      const center = el.getAttribute("data-center") === "true";
+      // If either dimension is set OR the image is centered, switch to
+      // inline <img> HTML (optionally wrapped in <div align="center">)
+      // so the attributes survive the round-trip. Standard markdown has
+      // no size or alignment syntax, but GitHub renders inline HTML.
+      if (width || height || center) {
+        return buildSizedImageHTML({ src, alt, width, height, center });
       }
       return `![${alt}](${src})`;
     },
@@ -59,13 +61,18 @@ export function createTurndownService(): TurndownService {
 
   // Images without a data-original-src — mostly user-pasted or
   // drag-dropped images that go straight to the rich editor. Still
-  // need to check for width/height so the resize survives save.
+  // need to check for width / height / center so the attributes
+  // survive save.
   turndown.addRule("imageWithDimensions", {
     filter: (node) => {
       if (node.nodeName !== "IMG") return false;
       if (node.hasAttribute("data-original-src")) return false; // handled above
       if (node.hasAttribute("data-mermaid-source")) return false; // handled below
-      return node.hasAttribute("width") || node.hasAttribute("height");
+      return (
+        node.hasAttribute("width") ||
+        node.hasAttribute("height") ||
+        node.getAttribute("data-center") === "true"
+      );
     },
     replacement: (_content, node) => {
       const el = node as HTMLElement;
@@ -73,7 +80,8 @@ export function createTurndownService(): TurndownService {
       const alt = el.getAttribute("alt") || "";
       const width = parseImageDimension(el.getAttribute("width") || "");
       const height = parseImageDimension(el.getAttribute("height") || "");
-      return buildSizedImageHTML({ src, alt, width, height });
+      const center = el.getAttribute("data-center") === "true";
+      return buildSizedImageHTML({ src, alt, width, height, center });
     },
   });
 


### PR DESCRIPTION
## Summary

Ninth P1a item. Click any image in the rich editor → the existing Link/Image bubble now shows **Width** and **Height** inputs and an aspect-ratio lock. Values round-trip to HTML `<img>` tags in the saved markdown.

## UX

1. Click an image in the editor → the bubble pops up with its current URL / alt / size
2. Click the pencil icon to enter edit mode → two new inputs appear: **Width** and **Height**, with an aspect-lock toggle between them
3. Type a width (pixels `300`, `300px`, or percent `50%`) or leave blank for natural size
4. With the lock on (default), typing width auto-fills height using the image's natural aspect ratio
5. Click **Apply** or press **Enter** → the image resizes, the underlying markdown becomes an inline `<img>` HTML tag that GitHub renders

## What changed

**`src/lib/image-resize.ts`** — pure helpers:
- `parseImageDimension(input)` — accepts `"300"` / `"300px"` / `"50%"`, rejects empty, negative, zero, `>100%`, unsupported units (em/rem/vw). Returns `{ value, unit }` or `null`.
- `formatImageDimension(dim)` — inverse; null becomes empty string.
- `buildSizedImageHTML({ src, alt, width, height })` — composes a safe `<img>` tag with HTML-escaped attributes.

**`src/lib/turndown.ts`** — image rule extended: when an `<img>` has `width` or `height`, emit inline `<img src="..." width="..." height="...">` HTML instead of the usual `![alt](src)` markdown. Two rules cover both paths: images-with-`data-original-src` (existing rewrite flow) and images-with-dimensions (paste/drag-drop uploads).

**`src/components/Editor.tsx`**:
- TipTap Image node extended with `width` / `height` attributes (preserves them through `getHTML` / `setContent`)
- `BubbleTarget` carries current dimensions through to the popover
- `LinkImageBubble` editing form gains a Size row: width input · aspect-lock toggle · height input · unit hint
- `handleWidthChange` / `handleHeightChange` auto-fill the other side using the rendered image's `naturalWidth / naturalHeight` when the lock is on
- `applyEdit` normalizes each value through `parseImageDimension` + `formatImageDimension` so bad input → `null` → attribute removed

## Tests

Test-first. 29 new tests in `image-resize.test.ts`:

- `parseImageDimension`: valid pixels / percent / whitespace / decimals; rejects empty / non-numeric / negative / zero / >100% / unsupported units
- `formatImageDimension`: pixel / percent / null
- `buildSizedImageHTML`: src + alt always, width/height only when set, HTML-escaping of `"` inside alt and src, self-closing tag shape, empty-alt → `alt=""` (decorative image)
- Round-trip: parse → format → parse is idempotent for both pixel and percent values

**Test count:** 382 → 411 (+29). Build clean.

## Test plan

- [ ] Paste an image into a real file → click the image → edit → set width to `300` → Apply → image shrinks
- [ ] Toggle the aspect lock off → set height independently → apply → non-proportional resize works
- [ ] Set width to `50%` with lock on → height auto-fills to `50%` → apply → responsive image
- [ ] Clear both inputs → apply → width/height attributes removed, image back to natural size
- [ ] Save the file → check the committed markdown has `<img src="..." width="300">` HTML (not `![alt](...)`)
- [ ] Invalid input (`-10`, `abc`, `150%`) → silently falls back to "no attribute", doesn't crash
- [ ] Double-quote in alt text → escaped, tag stays valid
- [ ] Click an image that already has a width set → inputs are prefilled with the current values

## Follow-up (not in this PR)

Drag-to-resize handles on the image corners. That needs a custom TipTap `NodeView` with mouse-event tracking — substantial enough to deserve its own PR.