### PR TITLE
feat: drag-to-resize handles on selected images

### DIFF
--- a/src/__tests__/image-drag-resize.test.ts
+++ b/src/__tests__/image-drag-resize.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Tests for the pure drag-resize math. The helper takes the image's
+ * starting dimensions, the total pointer delta since the drag began,
+ * and a few constraints, and returns the new dimensions.
+ *
+ * Constraints:
+ *   - lockAspectRatio: preserve width/height ratio, drive from the
+ *     dimension with the larger relative change
+ *   - minWidth / minHeight: floor, default 20
+ *   - maxWidth / maxHeight: ceiling, optional
+ */
+import { describe, it, expect } from "vitest";
+import { computeDragResize } from "@/lib/image-drag-resize";
+
+describe("computeDragResize — aspect ratio unlocked", () => {
+  it("zero delta returns unchanged dimensions", () => {
+    const r = computeDragResize({
+      startWidth: 400,
+      startHeight: 300,
+      dx: 0,
+      dy: 0,
+      lockAspectRatio: false,
+    });
+    expect(r.width).toBe(400);
+    expect(r.height).toBe(300);
+  });
+
+  it("positive dx expands width only", () => {
+    const r = computeDragResize({
+      startWidth: 400,
+      startHeight: 300,
+      dx: 50,
+      dy: 0,
+      lockAspectRatio: false,
+    });
+    expect(r.width).toBe(450);
+    expect(r.height).toBe(300);
+  });
+
+  it("positive dy expands height only", () => {
+    const r = computeDragResize({
+      startWidth: 400,
+      startHeight: 300,
+      dx: 0,
+      dy: 100,
+      lockAspectRatio: false,
+    });
+    expect(r.width).toBe(400);
+    expect(r.height).toBe(400);
+  });
+
+  it("negative dx shrinks width", () => {
+    const r = computeDragResize({
+      startWidth: 400,
+      startHeight: 300,
+      dx: -100,
+      dy: 0,
+      lockAspectRatio: false,
+    });
+    expect(r.width).toBe(300);
+    expect(r.height).toBe(300);
+  });
+
+  it("combined dx and dy change both dimensions", () => {
+    const r = computeDragResize({
+      startWidth: 400,
+      startHeight: 300,
+      dx: 60,
+      dy: 40,
+      lockAspectRatio: false,
+    });
+    expect(r.width).toBe(460);
+    expect(r.height).toBe(340);
+  });
+});
+
+describe("computeDragResize — aspect ratio locked", () => {
+  it("zero delta with lock returns unchanged dimensions", () => {
+    const r = computeDragResize({
+      startWidth: 400,
+      startHeight: 300,
+      dx: 0,
+      dy: 0,
+      lockAspectRatio: true,
+    });
+    expect(r.width).toBe(400);
+    expect(r.height).toBe(300);
+  });
+
+  it("positive dx drives the resize and height follows the ratio", () => {
+    // startRatio = 400/300 = 4/3. dx=80 → newWidth=480 → newHeight=360.
+    const r = computeDragResize({
+      startWidth: 400,
+      startHeight: 300,
+      dx: 80,
+      dy: 0,
+      lockAspectRatio: true,
+    });
+    expect(r.width).toBe(480);
+    expect(r.height).toBe(360);
+  });
+
+  it("negative dx shrinks proportionally", () => {
+    // 400/300 ratio, dx=-100 → newWidth=300 → newHeight=225.
+    const r = computeDragResize({
+      startWidth: 400,
+      startHeight: 300,
+      dx: -100,
+      dy: 0,
+      lockAspectRatio: true,
+    });
+    expect(r.width).toBe(300);
+    expect(r.height).toBe(225);
+  });
+
+  it("the larger relative delta wins (dy dominant)", () => {
+    // startRatio = 400/300 = 1.333.
+    // dx=10 → relative change 10/400 = 2.5%
+    // dy=60 → relative change 60/300 = 20%  ← dominant
+    // height = 360 → width = 360 * 400/300 = 480
+    const r = computeDragResize({
+      startWidth: 400,
+      startHeight: 300,
+      dx: 10,
+      dy: 60,
+      lockAspectRatio: true,
+    });
+    expect(r.height).toBe(360);
+    expect(r.width).toBe(480);
+  });
+
+  it("the larger relative delta wins (dx dominant)", () => {
+    // dx=80 → 20% vs dy=10 → 3.3% → dx wins.
+    const r = computeDragResize({
+      startWidth: 400,
+      startHeight: 300,
+      dx: 80,
+      dy: 10,
+      lockAspectRatio: true,
+    });
+    expect(r.width).toBe(480);
+    expect(r.height).toBe(360);
+  });
+
+  it("a square image maintains squareness under lock", () => {
+    const r = computeDragResize({
+      startWidth: 200,
+      startHeight: 200,
+      dx: 50,
+      dy: 50,
+      lockAspectRatio: true,
+    });
+    expect(r.width).toBe(r.height);
+  });
+
+  it("a wide landscape image maintains aspect ratio", () => {
+    // 16:9 → 1600:900. dx=320 → newWidth=1920 → newHeight=1080.
+    const r = computeDragResize({
+      startWidth: 1600,
+      startHeight: 900,
+      dx: 320,
+      dy: 0,
+      lockAspectRatio: true,
+    });
+    expect(r.width).toBe(1920);
+    expect(r.height).toBe(1080);
+  });
+});
+
+describe("computeDragResize — minimum size clamping", () => {
+  it("clamps width to minWidth when shrinking too far", () => {
+    const r = computeDragResize({
+      startWidth: 100,
+      startHeight: 100,
+      dx: -200,
+      dy: 0,
+      lockAspectRatio: false,
+      minWidth: 20,
+    });
+    expect(r.width).toBe(20);
+  });
+
+  it("default minimum is 20 pixels", () => {
+    const r = computeDragResize({
+      startWidth: 100,
+      startHeight: 100,
+      dx: -200,
+      dy: 0,
+      lockAspectRatio: false,
+    });
+    expect(r.width).toBe(20);
+  });
+
+  it("clamps height to minimum when shrinking", () => {
+    const r = computeDragResize({
+      startWidth: 400,
+      startHeight: 100,
+      dx: 0,
+      dy: -200,
+      lockAspectRatio: false,
+      minWidth: 20,
+    });
+    expect(r.height).toBe(20);
+  });
+
+  it("when locked, clamping width also clamps height proportionally", () => {
+    // startRatio = 400/200 = 2. If width clamps to 40, height should
+    // become 20 to maintain the ratio.
+    const r = computeDragResize({
+      startWidth: 400,
+      startHeight: 200,
+      dx: -1000,
+      dy: 0,
+      lockAspectRatio: true,
+      minWidth: 40,
+    });
+    expect(r.width).toBe(40);
+    expect(r.height).toBe(20);
+  });
+});
+
+describe("computeDragResize — maximum size clamping", () => {
+  it("clamps width to maxWidth when expanding too far", () => {
+    const r = computeDragResize({
+      startWidth: 400,
+      startHeight: 300,
+      dx: 10000,
+      dy: 0,
+      lockAspectRatio: false,
+      maxWidth: 1200,
+    });
+    expect(r.width).toBe(1200);
+  });
+
+  it("no maxWidth = unbounded", () => {
+    const r = computeDragResize({
+      startWidth: 400,
+      startHeight: 300,
+      dx: 5000,
+      dy: 0,
+      lockAspectRatio: false,
+    });
+    expect(r.width).toBe(5400);
+  });
+
+  it("when locked, clamping to max width keeps the aspect ratio", () => {
+    // startRatio = 4/3. maxWidth=600 → newHeight should be 450.
+    const r = computeDragResize({
+      startWidth: 400,
+      startHeight: 300,
+      dx: 10000,
+      dy: 0,
+      lockAspectRatio: true,
+      maxWidth: 600,
+    });
+    expect(r.width).toBe(600);
+    expect(r.height).toBe(450);
+  });
+});
+
+describe("computeDragResize — edge cases", () => {
+  it("returns integer dimensions (HTML width/height wants integers)", () => {
+    const r = computeDragResize({
+      startWidth: 333,
+      startHeight: 111,
+      dx: 17,
+      dy: 0,
+      lockAspectRatio: true,
+    });
+    expect(Number.isInteger(r.width)).toBe(true);
+    expect(Number.isInteger(r.height)).toBe(true);
+  });
+
+  it("handles a zero-height input (degenerate) without NaN", () => {
+    const r = computeDragResize({
+      startWidth: 100,
+      startHeight: 0,
+      dx: 50,
+      dy: 0,
+      lockAspectRatio: true,
+    });
+    expect(Number.isFinite(r.width)).toBe(true);
+    expect(Number.isFinite(r.height)).toBe(true);
+  });
+
+  it("handles a zero-width input without NaN", () => {
+    const r = computeDragResize({
+      startWidth: 0,
+      startHeight: 100,
+      dx: 50,
+      dy: 0,
+      lockAspectRatio: true,
+    });
+    expect(Number.isFinite(r.width)).toBe(true);
+    expect(Number.isFinite(r.height)).toBe(true);
+  });
+});

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -71,6 +71,7 @@ import {
 } from "@/lib/draft-store";
 import { analyzeMarkdown, type MarkdownStats } from "@/lib/word-count";
 import { parseImageDimension, formatImageDimension, unwrapCenteredImages, type ImageDimension } from "@/lib/image-resize";
+import { computeDragResize } from "@/lib/image-drag-resize";
 import { transformGitHubAlerts } from "@/lib/github-alerts";
 import { transformFootnotes } from "@/lib/footnotes";
 import FindReplaceBar from "./FindReplaceBar";
@@ -327,6 +328,14 @@ function LinkImageBubble({
   const [editHeight, setEditHeight] = useState("");
   const [editCenter, setEditCenter] = useState(false);
   const [lockAspect, setLockAspect] = useState(true);
+  // Drag-to-resize state. Captured on mousedown on the handle, read on
+  // mousemove. dragStart is non-null while a drag is active.
+  const dragStart = useRef<{
+    startWidth: number;
+    startHeight: number;
+    startX: number;
+    startY: number;
+  } | null>(null);
   // Natural image aspect ratio (intrinsic width / height) captured from
   // the rendered <img>. Used to auto-fill the other dimension when the
   // aspect lock is on.
@@ -488,7 +497,81 @@ function LinkImageBubble({
     setEditing(false);
   };
 
+  // Drag-to-resize handlers. On mousedown we snapshot the image's
+  // current rendered dimensions and the pointer position, then
+  // listen for mousemove / mouseup at the window level so the drag
+  // keeps working even if the pointer leaves the handle element.
+  const onDragStart = (e: React.MouseEvent) => {
+    if (target.type !== "image") return;
+    if (!(target.element instanceof HTMLImageElement)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const img = target.element;
+    // Use rendered bounding-box dimensions as the starting point so
+    // drag math matches what the user sees. Fall back to natural size.
+    const rect = img.getBoundingClientRect();
+    dragStart.current = {
+      startWidth: Math.round(rect.width) || img.naturalWidth || 0,
+      startHeight: Math.round(rect.height) || img.naturalHeight || 0,
+      startX: e.clientX,
+      startY: e.clientY,
+    };
+    const onMove = (ev: MouseEvent) => {
+      const start = dragStart.current;
+      if (!start) return;
+      const next = computeDragResize({
+        startWidth: start.startWidth,
+        startHeight: start.startHeight,
+        dx: ev.clientX - start.startX,
+        dy: ev.clientY - start.startY,
+        lockAspectRatio: lockAspect,
+      });
+      // Push new dimensions into the image node's attributes. The
+      // node is whatever is currently selected — we assume the click
+      // that opened the bubble also selected the image.
+      editor
+        .chain()
+        .updateAttributes("image", {
+          width: String(next.width),
+          height: String(next.height),
+        })
+        .run();
+    };
+    const onUp = () => {
+      dragStart.current = null;
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  };
+
+  // Drag handle position — only for image targets. Rendered absolute
+  // in the same coordinate space as the bubble, positioned on the
+  // image's bottom-right corner so the user can drag it to resize.
+  const showHandle = target.type === "image";
+  const handleSize = 12;
+  const handleTop =
+    rect.bottom - containerRect.top - handleSize / 2;
+  const handleLeft =
+    rect.right - containerRect.left - handleSize / 2;
+
   return (
+    <>
+      {showHandle && (
+        <div
+          className="absolute z-50 bg-[var(--accent)] border-2 border-white dark:border-[var(--surface)] rounded-sm shadow-md cursor-nwse-resize hover:scale-125 transition-transform"
+          style={{
+            top: handleTop,
+            left: handleLeft,
+            width: handleSize,
+            height: handleSize,
+          }}
+          onMouseDown={onDragStart}
+          title="Drag to resize"
+          aria-label="Resize image"
+        />
+      )}
     <div
       ref={bubbleRef}
       className="absolute z-50"
@@ -648,6 +731,7 @@ function LinkImageBubble({
         )}
       </div>
     </div>
+    </>
   );
 }
 

--- a/src/lib/image-drag-resize.ts
+++ b/src/lib/image-drag-resize.ts
@@ -1,0 +1,92 @@
+/**
+ * Pure math for drag-to-resize handles on images.
+ *
+ * Takes the starting dimensions + total pointer delta since the drag
+ * began + constraints, returns the new dimensions. The caller is
+ * responsible for DOM events, event listeners, and committing the new
+ * dimensions to the TipTap node via updateAttributes.
+ *
+ * Tested in image-drag-resize.test.ts.
+ */
+
+export interface DragResizeInput {
+  /** Image width at the moment the drag started, in pixels. */
+  startWidth: number;
+  /** Image height at the moment the drag started, in pixels. */
+  startHeight: number;
+  /** Total horizontal pointer delta since drag start. */
+  dx: number;
+  /** Total vertical pointer delta since drag start. */
+  dy: number;
+  /** When true, preserve the start width/height ratio. */
+  lockAspectRatio: boolean;
+  /** Minimum allowed pixel size for either dimension. Defaults to 20. */
+  minWidth?: number;
+  /** Maximum allowed pixel width. Unbounded when omitted. */
+  maxWidth?: number;
+}
+
+export interface DragResizeOutput {
+  width: number;
+  height: number;
+}
+
+/**
+ * Compute the new image dimensions for a drag handle in the bottom-
+ * right corner. Both dimensions are clamped to `minWidth` and
+ * (optionally) `maxWidth`. With `lockAspectRatio` on, the axis with
+ * the larger RELATIVE change drives the resize, and the other axis
+ * is computed from the original ratio so clamping stays proportional.
+ */
+export function computeDragResize(input: DragResizeInput): DragResizeOutput {
+  const { startWidth, startHeight, dx, dy, lockAspectRatio } = input;
+  const minWidth = input.minWidth ?? 20;
+  const maxWidth = input.maxWidth;
+
+  // Defensive guards: a zero-sized source has no ratio to preserve and
+  // no meaningful drag response — return the deltas directly so the
+  // caller gets finite numbers instead of NaN.
+  if (startWidth <= 0 || startHeight <= 0) {
+    return {
+      width: Math.max(minWidth, Math.round(Math.max(1, startWidth) + dx)),
+      height: Math.max(minWidth, Math.round(Math.max(1, startHeight) + dy)),
+    };
+  }
+
+  let newWidth = startWidth + dx;
+  let newHeight = startHeight + dy;
+
+  if (lockAspectRatio) {
+    const ratio = startWidth / startHeight;
+    // Pick whichever axis moved more proportionally and drive from it.
+    // This is the standard Figma / Photoshop corner-handle behavior:
+    // the user's dominant motion wins, the other axis follows the ratio.
+    const widthScale = Math.abs(newWidth - startWidth) / startWidth;
+    const heightScale = Math.abs(newHeight - startHeight) / startHeight;
+    if (widthScale >= heightScale) {
+      newHeight = newWidth / ratio;
+    } else {
+      newWidth = newHeight * ratio;
+    }
+
+    // Clamp on the width axis only — height derives from width, so
+    // a second independent clamp would either be redundant or would
+    // break the ratio. The minWidth floor applies to width; height
+    // is whatever the ratio gives.
+    if (newWidth < minWidth) newWidth = minWidth;
+    if (maxWidth !== undefined && newWidth > maxWidth) newWidth = maxWidth;
+    newHeight = newWidth / ratio;
+  } else {
+    // Axes are independent — clamp each separately. The same minimum
+    // floor applies to both (a 5-pixel-tall image is never what the
+    // user wanted).
+    if (newWidth < minWidth) newWidth = minWidth;
+    if (maxWidth !== undefined && newWidth > maxWidth) newWidth = maxWidth;
+    if (newHeight < minWidth) newHeight = minWidth;
+  }
+
+  return {
+    width: Math.round(newWidth),
+    height: Math.round(newHeight),
+  };
+}


### PR DESCRIPTION
## Summary

Follow-up to PR #57's click-popover image resize. Adds a small drag handle at the bottom-right corner of a selected image. Click + drag resizes the image live and commits the new dimensions to the node's attributes.

## UX

1. Click an image → the existing Link/Image bubble opens AND a small accent-colored square appears at the image's bottom-right corner
2. Click and drag the handle → image resizes live in the editor
3. Release → final dimensions are committed to the image's `width` / `height` attributes
4. Aspect ratio lock toggle in the bubble controls drag behavior: locked keeps proportions, unlocked lets width and height drift independently
5. Open the bubble → the width/height inputs reflect the current dimensions (already true from #57)

## What changed

**`src/lib/image-drag-resize.ts`** — pure `computeDragResize(input)` that takes the starting dimensions, the total pointer delta, and lock/min/max constraints and returns the new dimensions. Dominant-axis selection (the axis with the larger relative change wins) under aspect lock, single-pass clamping that preserves the ratio.

**`Editor.tsx` LinkImageBubble**:
- New `dragStart` ref holds the snapshot captured on mousedown
- `onDragStart` attaches `mousemove` / `mouseup` listeners to `window` so the drag keeps working if the pointer leaves the handle
- Each `mousemove` calls `computeDragResize` and pipes the result into `editor.chain().updateAttributes("image", { width, height }).run()`
- Handle renders only for image targets, positioned at `rect.right / rect.bottom` (same container coordinate system as the bubble)

## Tests

Test-first. 22 new tests in `image-drag-resize.test.ts`:

- **Unlocked**: zero delta, positive/negative dx, positive/negative dy, combined
- **Locked**: zero delta, dominant-axis selection (dx wins, dy wins), square images, 16:9 landscape ratio preservation, negative drag proportionally shrinks
- **Min clamping**: width floor, default minimum, height floor (unlocked), locked clamping holds the ratio
- **Max clamping**: width ceiling, unbounded default, locked ceiling keeps ratio
- **Edge cases**: integer output (HTML attrs want ints), zero-width / zero-height inputs don't produce NaN

**Test count:** 445 → 467 (+22). Build clean.

## Test plan

- [ ] Paste/drop an image into a real file → click the image → drag handle appears at the bottom-right
- [ ] Drag the handle right → image grows wider (height follows proportionally with lock on)
- [ ] Drag the handle up-left → image shrinks proportionally
- [ ] Turn off the aspect lock in the bubble → drag → width and height change independently
- [ ] Drag until the handle hits the min floor (20 px) → image stops shrinking
- [ ] Release → the final dimensions are reflected in the bubble's Width/Height inputs
- [ ] Save the file → the committed markdown has the correct `<img width="..." height="...">`
- [ ] Reload → the image's size is preserved from the saved file
- [ ] Dragging on a non-image element (shouldn't happen — handle is image-only) → no crash