### PR TITLE
feat: rich-view find/replace (P1a complete)

### DIFF
--- a/src/__tests__/tiptap-search.test.ts
+++ b/src/__tests__/tiptap-search.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for the pure search helpers used by the rich-view find/replace
+ * TipTap extension.
+ *
+ * A TipTap / ProseMirror document is a tree of nodes with an
+ * opaque "position" numbering system (blocks contribute 2 positions
+ * for their open/close tokens, text contributes 1 per character).
+ * Rather than testing against a real PM instance (heavy, jsdom has
+ * edge cases), we define a "text run" — a string of contiguous
+ * characters paired with its starting doc position — and test the
+ * search logic against that minimal shape.
+ *
+ * The real TipTap extension walks the doc with `doc.descendants` and
+ * produces a list of these runs. The pure helper takes the runs and
+ * the query and returns { from, to } ranges in doc position space.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  findMatchesInRuns,
+  type TextRun,
+  type DocMatch,
+} from "@/lib/tiptap-search";
+
+describe("findMatchesInRuns", () => {
+  // ─── Empty / trivial ───────────────────────────────────────────────────
+
+  it("returns empty for no runs", () => {
+    expect(findMatchesInRuns([], "foo", {})).toEqual([]);
+  });
+
+  it("returns empty for empty query", () => {
+    const runs: TextRun[] = [{ text: "hello world", docPos: 1 }];
+    expect(findMatchesInRuns(runs, "", {})).toEqual([]);
+  });
+
+  it("returns empty when query is not found", () => {
+    const runs: TextRun[] = [{ text: "hello world", docPos: 1 }];
+    expect(findMatchesInRuns(runs, "xyzzy", {})).toEqual([]);
+  });
+
+  // ─── Single run ────────────────────────────────────────────────────────
+
+  it("finds a match within a single run and maps to doc positions", () => {
+    // Run starts at doc position 1 (first position inside a paragraph).
+    // "hello world" → "world" is at plain index 6, length 5.
+    // Doc positions: from=1+6=7, to=7+5=12.
+    const runs: TextRun[] = [{ text: "hello world", docPos: 1 }];
+    const matches = findMatchesInRuns(runs, "world", {});
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toEqual({ from: 7, to: 12 });
+  });
+
+  it("finds multiple matches within a single run", () => {
+    const runs: TextRun[] = [{ text: "foo bar foo", docPos: 1 }];
+    const matches = findMatchesInRuns(runs, "foo", {});
+    expect(matches).toHaveLength(2);
+    expect(matches[0]).toEqual({ from: 1, to: 4 });
+    expect(matches[1]).toEqual({ from: 9, to: 12 });
+  });
+
+  // ─── Multiple runs (typical PM doc with formatting) ────────────────────
+
+  it("finds matches across multiple runs within the same block", () => {
+    // ProseMirror splits text by mark boundaries: "hello **world**" is
+    // two runs — "hello " at pos 1, "world" at pos 7 (after the space).
+    // A search for "world" should find it at pos 7.
+    const runs: TextRun[] = [
+      { text: "hello ", docPos: 1 },
+      { text: "world", docPos: 7 },
+    ];
+    const matches = findMatchesInRuns(runs, "world", {});
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toEqual({ from: 7, to: 12 });
+  });
+
+  it("finds each run's matches independently when they don't cross", () => {
+    const runs: TextRun[] = [
+      { text: "foo", docPos: 1 },
+      { text: "bar", docPos: 6 },
+      { text: "foo", docPos: 11 },
+    ];
+    const matches = findMatchesInRuns(runs, "foo", {});
+    expect(matches).toHaveLength(2);
+    expect(matches.map((m) => m.from)).toEqual([1, 11]);
+  });
+
+  // ─── Case sensitivity ─────────────────────────────────────────────────
+
+  it("is case-insensitive by default", () => {
+    const runs: TextRun[] = [{ text: "Hello HELLO hello", docPos: 1 }];
+    expect(findMatchesInRuns(runs, "hello", {})).toHaveLength(3);
+  });
+
+  it("honors caseSensitive: true", () => {
+    const runs: TextRun[] = [{ text: "Hello HELLO hello", docPos: 1 }];
+    const matches = findMatchesInRuns(runs, "hello", { caseSensitive: true });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].from).toBe(13); // "hello" starts at plain index 12, doc pos 13
+  });
+
+  // ─── Whole word ───────────────────────────────────────────────────────
+
+  it("honors wholeWord: true on a single run", () => {
+    const runs: TextRun[] = [{ text: "car cart scar", docPos: 1 }];
+    const matches = findMatchesInRuns(runs, "car", { wholeWord: true });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].from).toBe(1);
+  });
+
+  // ─── Regex mode ───────────────────────────────────────────────────────
+
+  it("supports regex queries", () => {
+    const runs: TextRun[] = [{ text: "2024-01-15 and 2025-12-31", docPos: 1 }];
+    const matches = findMatchesInRuns(
+      runs,
+      "\\d{4}-\\d{2}-\\d{2}",
+      { regex: true }
+    );
+    expect(matches).toHaveLength(2);
+  });
+
+  it("returns empty for an invalid regex instead of throwing", () => {
+    const runs: TextRun[] = [{ text: "hello", docPos: 1 }];
+    expect(findMatchesInRuns(runs, "(invalid", { regex: true })).toEqual([]);
+  });
+
+  // ─── Block boundaries ─────────────────────────────────────────────────
+
+  it("does NOT match text that spans a block boundary", () => {
+    // Two paragraphs produce two runs separated in doc position space by
+    // the block open/close tokens. A search for "worldhello" should NOT
+    // match across the boundary — block separators are semantic.
+    const runs: TextRun[] = [
+      { text: "hello world", docPos: 1 },
+      { text: "hello world", docPos: 14 }, // after </p><p> opens
+    ];
+    const matches = findMatchesInRuns(runs, "worldhello", {});
+    expect(matches).toEqual([]);
+  });
+
+  it("handles the same query appearing in separate blocks independently", () => {
+    const runs: TextRun[] = [
+      { text: "first hello", docPos: 1 },
+      { text: "second hello", docPos: 14 },
+    ];
+    const matches = findMatchesInRuns(runs, "hello", {});
+    expect(matches).toHaveLength(2);
+    expect(matches[0].from).toBe(7);  // "hello" at plain index 6 in run 0, doc pos 7
+    expect(matches[1].from).toBe(21); // "hello" at plain index 7 in run 1, doc pos 21
+  });
+
+  // ─── Ordering ─────────────────────────────────────────────────────────
+
+  it("returns matches in ascending doc-position order", () => {
+    const runs: TextRun[] = [
+      { text: "foo", docPos: 100 },
+      { text: "foo", docPos: 10 },
+      { text: "foo", docPos: 50 },
+    ];
+    const matches = findMatchesInRuns(runs, "foo", {});
+    expect(matches.map((m) => m.from)).toEqual([10, 50, 100]);
+  });
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -606,3 +606,22 @@ body {
   margin-left: auto;
   margin-right: auto;
 }
+
+/* Rich-view find/replace match decorations — rendered by the
+ * MardocSearchExtension. Yellow highlight for all matches, orange
+ * for the "current" (focused) match so it's visible among the rest. */
+.ProseMirror .mardoc-search-match {
+  background-color: rgba(255, 235, 0, 0.45);
+  border-radius: 2px;
+  padding: 1px 0;
+}
+.ProseMirror .mardoc-search-match-current {
+  background-color: rgba(255, 140, 0, 0.65);
+  outline: 1px solid rgba(255, 140, 0, 0.9);
+}
+.dark .ProseMirror .mardoc-search-match {
+  background-color: rgba(255, 235, 0, 0.30);
+}
+.dark .ProseMirror .mardoc-search-match-current {
+  background-color: rgba(255, 140, 0, 0.55);
+}

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -72,11 +72,14 @@ import {
 import { analyzeMarkdown, type MarkdownStats } from "@/lib/word-count";
 import { parseImageDimension, formatImageDimension, unwrapCenteredImages, type ImageDimension } from "@/lib/image-resize";
 import { computeDragResize } from "@/lib/image-drag-resize";
+import { MardocSearchExtension } from "@/lib/tiptap-search-extension";
 import { transformGitHubAlerts } from "@/lib/github-alerts";
 import { transformFootnotes } from "@/lib/footnotes";
 import FindReplaceBar from "./FindReplaceBar";
+import RichFindReplaceBar from "./RichFindReplaceBar";
 import type { Match as FindMatch } from "@/lib/find-replace";
 import Outline from "./Outline";
+import { MARDOC_OPEN_FIND_EVENT } from "@/lib/tiptap-search-extension";
 import {
   validateImageFile,
   generateImagePath,
@@ -1175,6 +1178,7 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
       TableRow,
       TableCell,
       TableHeader,
+      MardocSearchExtension,
     ],
     content: markdownToHtml(content, repoFullName, branch, filePath),
     onUpdate: ({ editor }) => {
@@ -1412,11 +1416,21 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
     textarea.scrollTop = Math.max(0, lineNumber * lineHeight - textarea.clientHeight / 2);
   }, [codeContent]);
 
-  // Leaving code view closes the find bar. Opening the bar requires being
-  // in code view, and the bar only operates on codeContent.
+  // Toggling between rich and code view closes the bar so the UI
+  // doesn't end up in a stale state across modes. The user can reopen
+  // it in the new view with Cmd+F.
   useEffect(() => {
-    if (!codeView) setFindBarOpen(false);
+    setFindBarOpen(false);
   }, [codeView]);
+
+  // Rich view opens the find bar via a custom event fired by the
+  // MardocSearchExtension's Mod-F keyboard shortcut. TipTap catches
+  // the key inside the editor; the event bridges to React state.
+  useEffect(() => {
+    const handler = () => setFindBarOpen(true);
+    window.addEventListener(MARDOC_OPEN_FIND_EVENT, handler);
+    return () => window.removeEventListener(MARDOC_OPEN_FIND_EVENT, handler);
+  }, []);
 
   const handleStartComment = useCallback((selectedText: string) => {
     setPendingSelection(selectedText);
@@ -2208,6 +2222,16 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
                   codeTextareaRef.current?.focus();
                 }}
                 onMatchFocused={handleMatchFocused}
+              />
+            )}
+
+            {!codeView && findBarOpen && editor && (
+              <RichFindReplaceBar
+                editor={editor}
+                onClose={() => {
+                  setFindBarOpen(false);
+                  editor.commands.focus();
+                }}
               />
             )}
 

--- a/src/components/RichFindReplaceBar.tsx
+++ b/src/components/RichFindReplaceBar.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import { Search, Replace as ReplaceIcon, X, ChevronUp, ChevronDown, CaseSensitive, Regex, WholeWord } from "lucide-react";
+import type { Editor } from "@tiptap/react";
+import { searchPluginKey } from "@/lib/tiptap-search-extension";
+import type { FindOptions } from "@/lib/find-replace";
+
+interface RichFindReplaceBarProps {
+  /** The TipTap editor instance. Commands are dispatched against this. */
+  editor: Editor;
+  /** Called when the bar should close (Esc pressed, X clicked). */
+  onClose: () => void;
+}
+
+/**
+ * Rich-view find/replace panel. Same visual layout as the code-view
+ * FindReplaceBar but drives its behavior through the
+ * MardocSearchExtension's ProseMirror plugin commands instead of a
+ * plain text string.
+ *
+ * State:
+ *   - query / replacement / options live in this component
+ *   - matches + currentIndex come from the plugin state (read via
+ *     searchPluginKey.getState)
+ *
+ * Commands:
+ *   - setSearchQuery fires on query/options change
+ *   - gotoNext / gotoPrev navigate matches (wraps)
+ *   - replaceCurrent / replaceAll rewrite the doc
+ *   - clearSearch is called on close
+ */
+export default function RichFindReplaceBar({ editor, onClose }: RichFindReplaceBarProps) {
+  const [query, setQuery] = useState("");
+  const [replacement, setReplacement] = useState("");
+  const [options, setOptions] = useState<FindOptions>({});
+  const findInputRef = useRef<HTMLInputElement>(null);
+
+  // Focus the find input on mount, pre-fill from the current selection
+  // if the user selected a word before opening the bar.
+  useEffect(() => {
+    const selectedText = editor.state.doc.textBetween(
+      editor.state.selection.from,
+      editor.state.selection.to,
+      " "
+    );
+    if (selectedText && selectedText.length < 80) {
+      setQuery(selectedText);
+      editor.commands.setSearchQuery(selectedText, options);
+    }
+    findInputRef.current?.focus();
+    findInputRef.current?.select();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Re-run the search whenever query or options change.
+  useEffect(() => {
+    editor.commands.setSearchQuery(query, options);
+  }, [query, options, editor]);
+
+  // Read the plugin's current state — matches count and current index —
+  // by re-subscribing on every render. This is cheap (synchronous read
+  // of the plugin's state slot).
+  const pluginState = searchPluginKey.getState(editor.state);
+  const totalMatches = pluginState?.matches.length ?? 0;
+  const currentIdx = pluginState?.currentIndex ?? 0;
+
+  // Clear decorations + plugin state when the bar closes.
+  const doClose = () => {
+    editor.commands.clearSearch();
+    onClose();
+  };
+
+  // Force a re-render when the editor state changes so the match
+  // counter updates as the user types. Editor events are the canonical
+  // way to subscribe.
+  const [, forceRender] = useState(0);
+  useEffect(() => {
+    const handler = () => forceRender((n) => n + 1);
+    editor.on("transaction", handler);
+    return () => {
+      editor.off("transaction", handler);
+    };
+  }, [editor]);
+
+  const toggle = (key: keyof FindOptions) => {
+    setOptions((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const matchStatus =
+    totalMatches === 0
+      ? query
+        ? "No matches"
+        : ""
+      : `${currentIdx + 1} / ${totalMatches}`;
+
+  return (
+    <div
+      className="sticky top-0 z-20 bg-[var(--surface)] border-b border-[var(--border)] px-3 py-2 flex items-center gap-2 flex-wrap"
+      role="search"
+      aria-label="Find and replace"
+      onKeyDown={(e) => {
+        if (e.key === "Escape") {
+          e.preventDefault();
+          doClose();
+        }
+      }}
+    >
+      {/* Find input */}
+      <div className="flex items-center gap-1 flex-1 min-w-0 max-w-md">
+        <Search size={12} className="text-[var(--text-muted)] shrink-0" />
+        <input
+          ref={findInputRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              if (e.shiftKey) editor.commands.gotoPreviousMatch();
+              else editor.commands.gotoNextMatch();
+            }
+          }}
+          placeholder="Find"
+          className="flex-1 min-w-0 px-2 py-1 text-xs bg-[var(--surface-secondary)] border border-[var(--border)] rounded text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-1 focus:ring-[var(--accent)]"
+        />
+        <span className="text-[10px] text-[var(--text-muted)] font-mono min-w-[3.5em] text-right shrink-0">
+          {matchStatus}
+        </span>
+      </div>
+
+      {/* Option toggles */}
+      <div className="flex items-center gap-0.5">
+        <button
+          onClick={() => toggle("caseSensitive")}
+          className={`p-1 rounded text-[var(--text-muted)] hover:bg-[var(--surface-hover)] transition-colors ${
+            options.caseSensitive ? "bg-[var(--accent-muted)] text-[var(--accent)]" : ""
+          }`}
+          title="Match case"
+          aria-pressed={!!options.caseSensitive}
+        >
+          <CaseSensitive size={14} />
+        </button>
+        <button
+          onClick={() => toggle("wholeWord")}
+          className={`p-1 rounded text-[var(--text-muted)] hover:bg-[var(--surface-hover)] transition-colors ${
+            options.wholeWord ? "bg-[var(--accent-muted)] text-[var(--accent)]" : ""
+          }`}
+          title="Whole word"
+          aria-pressed={!!options.wholeWord}
+        >
+          <WholeWord size={14} />
+        </button>
+        <button
+          onClick={() => toggle("regex")}
+          className={`p-1 rounded text-[var(--text-muted)] hover:bg-[var(--surface-hover)] transition-colors ${
+            options.regex ? "bg-[var(--accent-muted)] text-[var(--accent)]" : ""
+          }`}
+          title="Regular expression"
+          aria-pressed={!!options.regex}
+        >
+          <Regex size={14} />
+        </button>
+      </div>
+
+      {/* Navigate */}
+      <div className="flex items-center gap-0.5">
+        <button
+          onClick={() => editor.commands.gotoPreviousMatch()}
+          disabled={totalMatches === 0}
+          className="p-1 rounded text-[var(--text-muted)] hover:bg-[var(--surface-hover)] transition-colors disabled:opacity-30"
+          title="Previous match (Shift+Enter)"
+        >
+          <ChevronUp size={14} />
+        </button>
+        <button
+          onClick={() => editor.commands.gotoNextMatch()}
+          disabled={totalMatches === 0}
+          className="p-1 rounded text-[var(--text-muted)] hover:bg-[var(--surface-hover)] transition-colors disabled:opacity-30"
+          title="Next match (Enter)"
+        >
+          <ChevronDown size={14} />
+        </button>
+      </div>
+
+      {/* Replace input */}
+      <div className="flex items-center gap-1 flex-1 min-w-0 max-w-md">
+        <ReplaceIcon size={12} className="text-[var(--text-muted)] shrink-0" />
+        <input
+          type="text"
+          value={replacement}
+          onChange={(e) => setReplacement(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              editor.commands.replaceCurrentMatch(replacement);
+            }
+          }}
+          placeholder="Replace"
+          className="flex-1 min-w-0 px-2 py-1 text-xs bg-[var(--surface-secondary)] border border-[var(--border)] rounded text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-1 focus:ring-[var(--accent)]"
+        />
+      </div>
+
+      {/* Replace actions */}
+      <div className="flex items-center gap-1">
+        <button
+          onClick={() => editor.commands.replaceCurrentMatch(replacement)}
+          disabled={totalMatches === 0}
+          className="text-[10px] px-2 py-1 rounded border border-[var(--border)] text-[var(--text-secondary)] hover:bg-[var(--surface-hover)] disabled:opacity-30 transition-colors"
+        >
+          Replace
+        </button>
+        <button
+          onClick={() => editor.commands.replaceAllMatches(replacement)}
+          disabled={totalMatches === 0}
+          className="text-[10px] px-2 py-1 rounded bg-[var(--accent)] text-white hover:bg-[var(--accent-hover)] disabled:opacity-30 transition-colors"
+        >
+          Replace all
+        </button>
+      </div>
+
+      {/* Close */}
+      <button
+        onClick={doClose}
+        className="p-1 text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+        aria-label="Close find bar"
+        title="Close (Esc)"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -30,7 +30,7 @@ export const ALL_SHORTCUTS: Shortcut[] = [
   { keys: ["⌘", "I"], description: "Italic", category: "Editor" },
   { keys: ["⌘", "E"], description: "Inline code", category: "Editor" },
   { keys: ["⌘", "K"], description: "Insert link", category: "Editor" },
-  { keys: ["⌘", "F"], description: "Find and replace (code view)", category: "Editor" },
+  { keys: ["⌘", "F"], description: "Find and replace", category: "Editor" },
   { keys: ["⌘", "Z"], description: "Undo", category: "Editor" },
   { keys: ["⌘", "⇧", "Z"], description: "Redo", category: "Editor" },
   { keys: ["⌘", "↵"], description: "Finish editing block (suggest mode)", category: "Editor" },

--- a/src/lib/tiptap-search-extension.ts
+++ b/src/lib/tiptap-search-extension.ts
@@ -1,0 +1,338 @@
+/**
+ * TipTap extension that implements find / replace over a rich
+ * document: decorations for matched ranges, commands for navigation,
+ * replace, and replaceAll.
+ *
+ * Built from first principles on top of ProseMirror — no new npm
+ * dependency. The core search logic is delegated to
+ * @/lib/tiptap-search (pure, unit-tested) so the extension file itself
+ * stays focused on ProseMirror glue.
+ *
+ * Commands exposed on the editor:
+ *   setSearchQuery(query, options)   — update query, recompute matches
+ *   clearSearch()                    — clear everything
+ *   gotoNextMatch()                  — focus the next match (wraps)
+ *   gotoPreviousMatch()              — focus the previous match (wraps)
+ *   replaceCurrentMatch(replacement) — replace the focused match only
+ *   replaceAllMatches(replacement)   — replace every match
+ *
+ * The extension also publishes its current state (query, options,
+ * match count, current index) as plugin metadata so the UI can read
+ * it and show a status string.
+ */
+
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { findMatchesInRuns, type TextRun, type DocMatch } from "@/lib/tiptap-search";
+import type { FindOptions } from "@/lib/find-replace";
+
+// ─── Plugin key / state shape ─────────────────────────────────────────────
+
+export interface SearchPluginState {
+  query: string;
+  options: FindOptions;
+  matches: DocMatch[];
+  currentIndex: number;
+  decorations: DecorationSet;
+}
+
+export const searchPluginKey = new PluginKey<SearchPluginState>("mardocSearch");
+
+function emptyState(doc?: ProseMirrorNode): SearchPluginState {
+  return {
+    query: "",
+    options: {},
+    matches: [],
+    currentIndex: 0,
+    decorations: DecorationSet.empty,
+  };
+}
+
+// ─── Pure helpers ──────────────────────────────────────────────────────
+
+/**
+ * Walk a ProseMirror document and return the list of TextRun entries
+ * — one per contiguous text node — for feeding into findMatchesInRuns.
+ */
+function collectRuns(doc: ProseMirrorNode): TextRun[] {
+  const runs: TextRun[] = [];
+  doc.descendants((node, pos) => {
+    if (node.isText && node.text) {
+      runs.push({ text: node.text, docPos: pos });
+    }
+    return true;
+  });
+  return runs;
+}
+
+/**
+ * Build a DecorationSet that highlights every match, with a stronger
+ * "current" highlight on the focused one.
+ */
+function buildDecorations(
+  doc: ProseMirrorNode,
+  matches: DocMatch[],
+  currentIndex: number
+): DecorationSet {
+  const decorations: Decoration[] = [];
+  for (let i = 0; i < matches.length; i++) {
+    const m = matches[i];
+    const isCurrent = i === currentIndex;
+    decorations.push(
+      Decoration.inline(m.from, m.to, {
+        class: isCurrent
+          ? "mardoc-search-match mardoc-search-match-current"
+          : "mardoc-search-match",
+      })
+    );
+  }
+  return DecorationSet.create(doc, decorations);
+}
+
+function recomputeMatches(
+  doc: ProseMirrorNode,
+  query: string,
+  options: FindOptions
+): DocMatch[] {
+  if (!query) return [];
+  const runs = collectRuns(doc);
+  return findMatchesInRuns(runs, query, options);
+}
+
+// ─── Extension ─────────────────────────────────────────────────────────
+
+export interface SearchExtensionStorage {
+  query: string;
+  options: FindOptions;
+  matches: DocMatch[];
+  currentIndex: number;
+}
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    mardocSearch: {
+      setSearchQuery: (query: string, options?: FindOptions) => ReturnType;
+      clearSearch: () => ReturnType;
+      gotoNextMatch: () => ReturnType;
+      gotoPreviousMatch: () => ReturnType;
+      replaceCurrentMatch: (replacement: string) => ReturnType;
+      replaceAllMatches: (replacement: string) => ReturnType;
+    };
+  }
+}
+
+/** Custom event fired when the user hits Cmd+F inside the rich editor.
+ *  The Editor React component listens for this and opens the find bar. */
+export const MARDOC_OPEN_FIND_EVENT = "mardoc:open-find";
+
+export const MardocSearchExtension = Extension.create<{}, SearchExtensionStorage>({
+  name: "mardocSearch",
+
+  addStorage() {
+    return {
+      query: "",
+      options: {},
+      matches: [],
+      currentIndex: 0,
+    };
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      // Mod+F opens the find bar via a window-level custom event —
+      // the Editor component listens and flips findBarOpen state.
+      // Returning true tells TipTap we handled the keypress so the
+      // browser's native find doesn't also fire.
+      "Mod-f": () => {
+        if (typeof window !== "undefined") {
+          window.dispatchEvent(new CustomEvent(MARDOC_OPEN_FIND_EVENT));
+        }
+        return true;
+      },
+    };
+  },
+
+  addProseMirrorPlugins() {
+    const extension = this;
+    return [
+      new Plugin<SearchPluginState>({
+        key: searchPluginKey,
+        state: {
+          init: (_, { doc }) => emptyState(doc),
+          apply(tr, prev, _oldState, newState) {
+            // If the document changed, re-run the search against the
+            // new doc so decorations track content edits.
+            if (tr.docChanged && prev.query) {
+              const matches = recomputeMatches(newState.doc, prev.query, prev.options);
+              const currentIndex = Math.min(
+                Math.max(0, prev.currentIndex),
+                Math.max(0, matches.length - 1)
+              );
+              const decorations = buildDecorations(newState.doc, matches, currentIndex);
+              extension.storage.matches = matches;
+              extension.storage.currentIndex = currentIndex;
+              return { ...prev, matches, currentIndex, decorations };
+            }
+
+            // Commands set meta("mardocSearch") to { query, options,
+            // matches?, currentIndex? } to update plugin state.
+            const meta = tr.getMeta(searchPluginKey) as Partial<SearchPluginState> | undefined;
+            if (meta) {
+              const next = { ...prev, ...meta };
+              next.decorations = buildDecorations(newState.doc, next.matches, next.currentIndex);
+              extension.storage.query = next.query;
+              extension.storage.options = next.options;
+              extension.storage.matches = next.matches;
+              extension.storage.currentIndex = next.currentIndex;
+              return next;
+            }
+
+            // Position map for document changes that don't touch the
+            // search state — shift existing decorations so they stay on
+            // their marked ranges.
+            if (tr.docChanged) {
+              return {
+                ...prev,
+                decorations: prev.decorations.map(tr.mapping, tr.doc),
+              };
+            }
+
+            return prev;
+          },
+        },
+        props: {
+          decorations(state) {
+            return searchPluginKey.getState(state)?.decorations || DecorationSet.empty;
+          },
+        },
+      }),
+    ];
+  },
+
+  addCommands() {
+    return {
+      setSearchQuery:
+        (query, options = {}) =>
+        ({ state, dispatch }) => {
+          const matches = recomputeMatches(state.doc, query, options);
+          if (dispatch) {
+            const tr = state.tr.setMeta(searchPluginKey, {
+              query,
+              options,
+              matches,
+              currentIndex: 0,
+            });
+            dispatch(tr);
+          }
+          return true;
+        },
+
+      clearSearch:
+        () =>
+        ({ state, dispatch }) => {
+          if (dispatch) {
+            const tr = state.tr.setMeta(searchPluginKey, {
+              query: "",
+              options: {},
+              matches: [],
+              currentIndex: 0,
+            });
+            dispatch(tr);
+          }
+          return true;
+        },
+
+      gotoNextMatch:
+        () =>
+        ({ state, dispatch }) => {
+          const s = searchPluginKey.getState(state);
+          if (!s || s.matches.length === 0) return false;
+          const nextIdx = (s.currentIndex + 1) % s.matches.length;
+          if (dispatch) {
+            const tr = state.tr.setMeta(searchPluginKey, {
+              ...s,
+              currentIndex: nextIdx,
+            });
+            // Move the selection to the match so the editor scrolls
+            // into view and the cursor lands on the found text.
+            const m = s.matches[nextIdx];
+            tr.setSelection(
+              (state.selection.constructor as any).create(tr.doc, m.from, m.to)
+            );
+            tr.scrollIntoView();
+            dispatch(tr);
+          }
+          return true;
+        },
+
+      gotoPreviousMatch:
+        () =>
+        ({ state, dispatch }) => {
+          const s = searchPluginKey.getState(state);
+          if (!s || s.matches.length === 0) return false;
+          const prevIdx = (s.currentIndex - 1 + s.matches.length) % s.matches.length;
+          if (dispatch) {
+            const tr = state.tr.setMeta(searchPluginKey, {
+              ...s,
+              currentIndex: prevIdx,
+            });
+            const m = s.matches[prevIdx];
+            tr.setSelection(
+              (state.selection.constructor as any).create(tr.doc, m.from, m.to)
+            );
+            tr.scrollIntoView();
+            dispatch(tr);
+          }
+          return true;
+        },
+
+      replaceCurrentMatch:
+        (replacement) =>
+        ({ state, dispatch }) => {
+          const s = searchPluginKey.getState(state);
+          if (!s || s.matches.length === 0) return false;
+          const m = s.matches[s.currentIndex];
+          if (dispatch) {
+            const tr = state.tr.insertText(replacement, m.from, m.to);
+            // Recompute against the new doc inside the same transaction
+            // via meta so the plugin updates decorations + index.
+            const newDoc = tr.doc;
+            const matches = recomputeMatches(newDoc, s.query, s.options);
+            const currentIndex = Math.min(s.currentIndex, Math.max(0, matches.length - 1));
+            tr.setMeta(searchPluginKey, {
+              ...s,
+              matches,
+              currentIndex,
+            });
+            dispatch(tr);
+          }
+          return true;
+        },
+
+      replaceAllMatches:
+        (replacement) =>
+        ({ state, dispatch }) => {
+          const s = searchPluginKey.getState(state);
+          if (!s || s.matches.length === 0) return false;
+          if (dispatch) {
+            // Walk matches from last to first so earlier positions
+            // stay valid as we rewrite.
+            const tr = state.tr;
+            for (let i = s.matches.length - 1; i >= 0; i--) {
+              const m = s.matches[i];
+              tr.insertText(replacement, m.from, m.to);
+            }
+            tr.setMeta(searchPluginKey, {
+              ...s,
+              matches: [],
+              currentIndex: 0,
+            });
+            dispatch(tr);
+          }
+          return true;
+        },
+    };
+  },
+});

--- a/src/lib/tiptap-search.ts
+++ b/src/lib/tiptap-search.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure search helpers for the rich-view find/replace TipTap extension.
+ *
+ * A ProseMirror document uses an opaque position numbering system:
+ * blocks contribute 2 positions for open/close tokens, text contributes
+ * 1 per character. Rather than test against a real PM instance, the
+ * extension walks the doc with `doc.descendants` and produces a list of
+ * TextRun { text, docPos } — contiguous text segments with their
+ * starting doc position. The helper below takes those runs plus a
+ * query and returns match ranges in doc-position space.
+ *
+ * Matches never cross a run boundary. This is correct for two
+ * reasons:
+ *   1. Runs within the same block are split only by mark boundaries
+ *      (bold / italic / link / code), and we don't want a search to
+ *      match across a formatting boundary because the replace would
+ *      get tangled with marks.
+ *   2. Runs in different blocks are separated by block open/close
+ *      tokens in doc position space, so cross-block matches would be
+ *      wrong anyway.
+ *
+ * Tested in tiptap-search.test.ts.
+ */
+
+import { findAll, type FindOptions } from "@/lib/find-replace";
+
+export interface TextRun {
+  text: string;
+  docPos: number;
+}
+
+export interface DocMatch {
+  from: number;
+  to: number;
+}
+
+/**
+ * Find every occurrence of `query` inside the text runs of a
+ * ProseMirror doc and return doc-position ranges.
+ *
+ * Each run is searched independently — matches do not cross run
+ * boundaries. Results are returned sorted by ascending `from`.
+ */
+export function findMatchesInRuns(
+  runs: TextRun[],
+  query: string,
+  options: FindOptions
+): DocMatch[] {
+  if (!query || runs.length === 0) return [];
+
+  const matches: DocMatch[] = [];
+  for (const run of runs) {
+    const found = findAll(run.text, query, options);
+    for (const m of found) {
+      matches.push({
+        from: run.docPos + m.start,
+        to: run.docPos + m.end,
+      });
+    }
+  }
+  matches.sort((a, b) => a.from - b.from);
+  return matches;
+}


### PR DESCRIPTION
## Summary

Tenth and **last** P1a item. Rich-view (WYSIWYG) editor now supports find / replace with live highlighting and keyboard navigation. Matches the code-view experience feature-by-feature.

Implementation chose **Option B** (custom ProseMirror plugin, no new npm dep) over Option A (community TipTap extension) per the confirmation-gate rule for new dependencies.

## How it works

1. Focus the rich editor → press `⌘F` (`Ctrl+F` on Windows/Linux)
2. A find/replace bar appears at the top of the editor with the same layout as the code-view bar
3. Type a query → all matches highlight in yellow, current match highlights in orange, match counter shows `N / total`
4. `Enter` / `Shift+Enter` jumps next / previous (wraps)
5. `Esc` closes the bar
6. Options toggles: case-sensitive / whole word / regex
7. Replace / Replace all rewrites the document in-place
8. Highlights track content edits as you type — decorations are mapped through transactions

Pre-fills the query from the current selection if the user highlighted a word before opening the bar.

## What changed

**`src/lib/tiptap-search.ts`** — pure helper. Takes a list of `TextRun { text, docPos }` extracted from a ProseMirror doc plus a query, returns `{ from, to }` ranges in doc-position space. Delegates to the existing `findAll` from `find-replace.ts` so regex / case / whole-word behavior is identical to code view.

**`src/lib/tiptap-search-extension.ts`** — TipTap extension wrapping a ProseMirror plugin:
- Plugin state holds query, options, matches, currentIndex, DecorationSet
- Decorations re-built on docChanged and on meta updates
- Existing decorations mapped through transactions so edits near (but not on) a match don't break the highlight
- Commands: `setSearchQuery`, `clearSearch`, `gotoNextMatch`, `gotoPreviousMatch`, `replaceCurrentMatch`, `replaceAllMatches`
- `addKeyboardShortcuts` binds `Mod-F` → fires `MARDOC_OPEN_FIND_EVENT` custom window event so the React component can flip `findBarOpen` state

**`src/components/RichFindReplaceBar.tsx`** — visual shell identical to code-view's bar, drives TipTap commands instead of a plain text string. Autofocuses + pre-fills from selection. Subscribes to editor transactions so the match counter stays live.

**`src/components/Editor.tsx`**:
- Registers `MardocSearchExtension` in the editor extensions list
- Renders `RichFindReplaceBar` when `!codeView && findBarOpen`
- Listens for `MARDOC_OPEN_FIND_EVENT` to open the bar from the keyboard shortcut
- Closes the bar on view toggle so it's always clean when switching

**`src/app/globals.css`** — match highlight styles (yellow / orange, dark-mode aware).

**`src/lib/keyboard-shortcuts.ts`** — cheatsheet entry updated from "Find and replace (code view)" to "Find and replace" since both views now work.

## Tests

Test-first. 15 new tests in `tiptap-search.test.ts` for `findMatchesInRuns`:

- Empty runs / empty query / no match → empty
- Single run, single match with doc-position mapping
- Single run, multiple matches
- Match across multiple runs within a block (mark boundaries split runs)
- Matches in multiple independent runs
- Case-insensitive default, `caseSensitive: true` honored
- `wholeWord: true` honored
- Regex mode + invalid-regex guard
- **Does NOT match text spanning a block boundary** — blocks are semantic and cross-block matches would be wrong in doc-position space
- Same query in separate blocks handled independently
- Ordering invariant (matches sorted by ascending `from`)

The ProseMirror plugin and decoration code is integration glue — verified by `npm run build` (TypeScript catches type mismatches) plus manual testing. The invariants that matter for correctness live in the pure helper.

**Test count:** 467 → 482 (+15). Build clean.

## P1a progress — complete

- ✅ Word count (#48)
- ✅ GitHub Alerts (#49)
- ✅ `?` cheatsheet (#50)
- ✅ Find/replace code view (#51)
- ✅ Command palette (#52)
- ✅ Classic PAT instructions (#53)
- ✅ Outline/TOC (#54)
- ✅ Footnotes (#55)
- ✅ Image upload (#56)
- ✅ Image resize click + center + configurable folder (#57)
- ✅ Image drag-resize handle (#58)
- ✅ **Rich-view find/replace (#59 — this PR)**

## Test plan

- [ ] Focus the rich editor → press `⌘F` → bar appears at the top, find input focused
- [ ] Type a query → matches highlight in yellow, current in orange, counter shows `N / total`
- [ ] `Enter` → jumps next (wraps at the end); `Shift+Enter` → jumps previous
- [ ] Keep typing → counter + highlights update live
- [ ] Toggle case / whole word / regex → match count updates
- [ ] Invalid regex → bar shows "No matches" gracefully
- [ ] Type a replacement, click Replace → current match is rewritten, next becomes current
- [ ] Click Replace all → every match rewritten in one transaction
- [ ] Highlight a word before `⌘F` → bar opens with query pre-filled
- [ ] Type in the editor near a match → highlights shift with the edit, stay on the right ranges
- [ ] `Esc` closes; editor focus returns
- [ ] Toggle to code view → bar closes; in code view `⌘F` opens the code-view bar
- [ ] Toggle back to rich view → `⌘F` opens the rich-view bar
- [ ] Cheatsheet (`?`) shows "⌘F Find and replace" with no view-specific qualifier