### PR TITLE
feat: inline comments on HTML files (feature 033)

### DIFF
--- a/docs/features/037-ai-page-translation.md
+++ b/docs/features/037-ai-page-translation.md
@@ -1,0 +1,93 @@
+# 037 — AI Page Translation (Repo-Resident Translations)
+
+## Value
+
+Teams that ship documentation in multiple languages today either (a) maintain parallel language trees by hand, which drifts immediately, or (b) rely on runtime browser translation, which doesn't round-trip back to the repo and can't be reviewed. MarDoc already has the right surface: open a `.md` or `.html` file, hit a "Translate" action, get an AI-generated translation rendered in the editor, review it like any other document, and commit it back to the repo as a sibling file (e.g. `guide.es.md`, `guide.fr.md` or `i18n/es/guide.md`). The translation becomes a real file under version control — reviewable, diffable, PR-able, and permanently attached to the repo as the source of truth.
+
+This turns MarDoc into the documentation i18n workflow for AI-era teams: one source document, N committed translations, all reviewable by the humans on the team who actually speak those languages, no external translation service or CAT tool in the loop.
+
+## Acceptance Criteria
+
+- [ ] "Translate" action available from the editor toolbar and command palette on any markdown or HTML document
+- [ ] User selects a target language (persisted list of recent targets + searchable full list)
+- [ ] AI generates a translation of the full document, preserving structure (headings, lists, tables, code blocks, links, images, mermaid diagrams, GitHub alerts, footnotes)
+- [ ] Code blocks are NOT translated (code stays in its original form — only comments inside code blocks are translated, optionally)
+- [ ] Link URLs are NOT translated; link *text* is
+- [ ] Image alt text and captions are translated
+- [ ] Mermaid diagram labels are translated; diagram structure is preserved
+- [ ] User chooses the save path (default: configurable pattern like `{basename}.{lang}.{ext}` or `i18n/{lang}/{path}`)
+- [ ] Translated document opens in the editor for human review before commit
+- [ ] Commit is a real PR (or direct commit, based on existing editor settings) — same workflow as any other edit
+- [ ] Repo-level configuration for: default target languages, save path pattern, translation provider
+- [ ] Works in both real-repo mode and demo mode (demo mode uses a mocked translation response)
+- [ ] Translation provider is configurable (OpenAI, Anthropic, local model via endpoint) — user supplies their own API key, stored in localStorage alongside the GitHub token
+- [ ] No translation data leaves the user's browser except to the configured provider's API endpoint (preserves the "no backend" trust story)
+- [ ] Per-block "re-translate" action for reviewers who want to fix a specific paragraph
+- [ ] Round-trip test: markdown → translated markdown → rendered → markdown preserves structure byte-for-byte on blocks that weren't translated (code, links, images)
+
+## Dependencies
+
+- **HTML inline comments (033)** and **HTML WYSIWYG (035)** should probably ship first so that HTML translations can be reviewed with the same flow as markdown translations. Not a hard blocker — translation can ship for markdown first and HTML later.
+- **AI provider abstraction** (new) — a thin wrapper around OpenAI/Anthropic SDKs that handles: chunking, rate limiting, API key management, error surfacing. Lives in `src/lib/ai-provider.ts`. Reusable by future AI features (document summarization, comment suggestions, etc.).
+
+## Implementation Notes
+
+### Provider abstraction
+
+- `src/lib/ai-provider.ts` — ports + adapters. Interface `TranslationProvider { translate(text, sourceLang, targetLang, options): Promise<string> }`. Adapters: `OpenAIProvider`, `AnthropicProvider`, `CustomEndpointProvider`.
+- API keys stored in `localStorage` under namespaced keys (`mardoc.ai.openai.key`, etc.), surfaced in Settings panel.
+- Never log or include API keys in error messages.
+
+### Chunking strategy
+
+Large documents blow out single-shot prompts. Split at block boundaries (`parseBlocks` from `diff-blocks.ts` — the same function that powers markdown review pipeline). Translate block-by-block with shared context (previous block + target language) so terminology stays consistent. Re-assemble in source order.
+
+### Structure preservation
+
+The prompt to the LLM must include the rules: "preserve markdown/HTML syntax exactly, translate only visible prose, do not translate code, do not translate URLs, do not reformat tables, keep mermaid node IDs stable, translate only mermaid labels." Add a post-processing validator that re-parses the output with `parseBlocks` and confirms the block count matches the input — if it doesn't, the LLM hallucinated structure and we surface a warning.
+
+### Code block handling
+
+Default: leave code blocks untranslated. Optional: translate comments inside code blocks (would require language-aware comment parsing — defer to a follow-on story).
+
+### Save path conventions
+
+Two patterns users pick between in settings:
+
+1. **Sibling suffix:** `README.md` → `README.es.md`. Simple, works anywhere, but pollutes the root.
+2. **Subdirectory:** `README.md` → `i18n/es/README.md`. Cleaner for large doc trees, matches conventions in many i18n frameworks.
+
+Config per repo, stored in a `.mardoc.json` file the app reads/writes. If `.mardoc.json` doesn't exist, default to sibling suffix and prompt to create it on first translation.
+
+### Review workflow
+
+Translated document opens in the editor with a banner: "AI-translated from README.md — review and edit before committing." The reviewer can accept as-is or edit freely. Committing creates the translated file with an attribution commit message (`chore(i18n): add Spanish translation of README.md via AI`). Subsequent re-translations update the same file via PR, keeping diff history so humans can review what changed.
+
+### "Keep in sync" follow-on (deferred)
+
+After the first translation lands, users want: "whenever README.md changes, flag the Spanish translation as stale." This needs commit-hash tracking (store the source commit SHA in the translated file's front-matter) and a staleness indicator in the sidebar. Defer to a follow-on story (038).
+
+### Tests to add (test-first)
+
+1. `src/__tests__/ai-provider.test.ts` — mock provider contract, chunking correctness, structure-preservation validator
+2. `src/__tests__/translation-save-path.test.ts` — sibling-suffix and subdirectory path computation
+3. `src/__tests__/translation-roundtrip.test.ts` — given a document with known code blocks/links/images, the non-prose elements must be byte-identical in the translated output
+4. `src/__tests__/readme-claims.test.ts` — extend with "translation preserves structure" claim if we add it to the README
+
+### Out of scope for this story
+
+- Translating code comments inside code blocks
+- Keep-in-sync staleness detection (deferred to 038)
+- Translation memory / glossary management
+- Bulk "translate entire repo" action
+
+## Open questions
+
+- Which AI provider is the default? Anthropic Claude has better structured-output discipline for long documents; OpenAI is more universally adopted. Probably ship with both and let users pick.
+- Do we need a content-filtering guard for sensitive documents? Some teams won't want to send internal docs to an external API. Suggest: add a per-repo "AI features enabled" flag in `.mardoc.json` so repos can opt out entirely.
+- How do we handle translation of documents that reference each other by filename? A link to `[Guide](./guide.md)` in a Spanish translation should probably point to `./guide.es.md` if it exists. That's a post-processing pass over the translated output — doable but out of scope for v1.
+
+## Related
+
+- **038 — Translation staleness detection** (follow-on: track source SHA in translated files, flag when source changes)
+- **039 — AI-assisted editing** (reuses the AI provider abstraction for inline rewrites, summarization, comment suggestions)

--- a/docs/features/038-cellphone-mode-viewer.md
+++ b/docs/features/038-cellphone-mode-viewer.md
@@ -1,0 +1,98 @@
+# 038 — Cellphone Mode Viewer
+
+## Value
+
+MarDoc today is a desktop-first tool: sidebars, multi-column diff views, WYSIWYG toolbars, comment panels. Opening it on a phone produces a usable but not comfortable experience — reviewers tapping through a PR on the train to their 9am standup get shrunken desktop chrome instead of a mobile-native read. For the AI-era market we're targeting (PMs, execs, designers, legal reviewers on the go), cellphone mode isn't a nice-to-have — it's where half the reviews will happen.
+
+Cellphone mode turns MarDoc into a read-and-comment experience sized and shaped for a phone: one document at a time, full-width prose, thumb-friendly comment affordances, swipe navigation between files in a PR, and a comment-queue flow that assumes the user will submit the whole review from the phone. Editing is optional — most phone users just read and leave comments, the same pattern as Google Docs mobile.
+
+## Acceptance Criteria
+
+- [ ] App detects viewport width and switches to cellphone layout below a breakpoint (default 640px, configurable)
+- [ ] Sidebar collapses into a hamburger drawer that overlays when opened
+- [ ] Comment panel slides up from the bottom as a sheet instead of a right-side rail
+- [ ] DiffViewer shows one view mode at a time (rendered, by default) with a compact mode-switcher
+- [ ] Selecting text triggers a floating action button ("💬 Comment") near the selection — tap to open the comment input in a bottom sheet
+- [ ] Comment input auto-focuses with a virtual keyboard, submits on return
+- [ ] PR file list appears as a vertical list with swipe-left/swipe-right gestures to move between files
+- [ ] Editor toolbar shrinks to icon-only and can be scrolled horizontally if it overflows
+- [ ] Command palette replaced with a prominent search button that opens a full-screen search sheet
+- [ ] Cheatsheet and settings open as full-screen modals instead of side panels
+- [ ] Typography scale adjusts: slightly smaller headings, same body size, more generous line height
+- [ ] Touch targets are all ≥44pt (Apple HIG) / ≥48dp (Material) minimum
+- [ ] Dark mode works in cellphone layout
+- [ ] Landscape orientation on phone uses desktop layout (enough horizontal room)
+- [ ] iPad / tablet uses desktop layout by default, with a user toggle to force cellphone mode
+- [ ] All existing features work in cellphone mode (read, comment, review, edit, suggest, approve)
+- [ ] A user can complete a full PR review from an iPhone without ever needing a horizontal scroll
+
+## Dependencies
+
+- No new backend dependencies — it's a layout / UX rework of existing client-side code
+- Touch gesture support for swipe navigation (pick a lightweight library or write a small wrapper over pointer events — prefer the latter)
+- Review of all components that currently assume desktop-scale viewport: `Sidebar.tsx`, `DiffViewer.tsx`, `PRDetail.tsx`, `Editor.tsx`, `SettingsPanel.tsx`, `CommandPalette.tsx`
+
+## Implementation Notes
+
+### Breakpoint strategy
+
+Use Tailwind's existing `sm:`, `md:`, `lg:` responsive utilities. Add a `useViewport()` hook that returns `'mobile' | 'tablet' | 'desktop'` based on window width + user agent hints (to distinguish iPad from iPhone-in-landscape). The hook drives conditional rendering where layout differences are structural (e.g. sidebar → drawer), not just stylistic.
+
+Structural changes (where we render a different component):
+- `Sidebar` → `MobileSidebarDrawer` (overlay with backdrop, hamburger trigger in header)
+- `CommentPanel` (right rail) → `CommentSheet` (bottom sheet, drag-to-dismiss)
+- `DiffViewer` view-mode selector → compact mode-switcher
+- `CommandPalette` → full-screen search modal
+- `SettingsPanel` (side panel) → full-screen modal
+
+Stylistic changes (same component, different Tailwind classes):
+- Editor toolbar → icon-only, horizontal scroll
+- Typography → adjusted line height and heading scale
+- Spacing → larger touch targets
+
+### Selection → floating action button
+
+On selection end, the parent gets the selection via the existing selection-tracking hook. In cellphone mode, render a small floating button near the selection's bounding rect. Tap opens the comment input as a bottom sheet. The existing selection-to-line-range logic (`mapSelectionToLines` for markdown, `data-mardoc-line` for HTML) stays the same — only the UI that wraps it changes.
+
+### Swipe navigation
+
+For moving between files in a PR: pointer events on the main content area. Swipe left → next file, swipe right → previous file. Threshold: 80px horizontal with <30px vertical drift. Implement as a small hook (`useSwipe`) so it's testable and reusable. Animate with CSS transform, not a full page transition.
+
+### Bottom sheet component
+
+Write a minimal `BottomSheet` component: backdrop, sheet with drag-to-dismiss, snap points (half-height, full-height). No external dep. Accessible (focus trap, escape-to-close, aria-modal). Reusable for: comment input, comment thread view, settings, command palette.
+
+### Editor in cellphone mode
+
+WYSIWYG editing on a phone is real but secondary. For v1, the Editor in cellphone mode:
+- Collapses the toolbar to a small floating "format" button that opens a bottom sheet with format actions
+- Hides the code-view toggle (editing raw markdown on a phone is painful)
+- Disables the find/replace action (not useful on a phone form factor)
+- Keeps autosave, keyboard shortcuts where the OS supports them, and the save button prominent
+
+### Testing
+
+1. **Visual regression tests** at multiple viewports (375x667 iPhone SE, 390x844 iPhone 14, 768x1024 iPad portrait). Use Playwright or Vitest browser mode if we add it. Deferred if too heavy — start with manual QA.
+2. **Unit tests** for `useViewport` (mock `window.matchMedia`) and `useSwipe` (synthetic pointer events).
+3. **Integration tests** for cellphone-mode flows: open PR → read file → select text → leave comment → submit review. Stub out Octokit and drive the DOM directly.
+4. **Manual QA checklist** in the PR description: walk through the full review flow on a real iPhone, screenshot each step.
+
+### Out of scope for this story
+
+- Offline mode / PWA install (we're not a PWA yet — that's a separate story)
+- Push notifications for PR updates
+- Native app wrappers (Capacitor, React Native) — cellphone mode is a responsive web layer, not a native app
+- Cross-device sync (review started on phone, continued on desktop) — already works, since the review queue lives in GitHub
+
+## Open questions
+
+- What breakpoint do we use? 640px (Tailwind's `sm:` boundary) is the safe default, but some devices are 430px wide. Probably 768px — anything narrower is cellphone mode.
+- Do we ship cellphone mode as a user-toggleable preference or always on below the breakpoint? Probably always on with a "desktop mode" escape hatch in settings for power users.
+- How do we handle the virtual keyboard pushing content around? The bottom sheet needs to resize on `visualViewport` changes.
+- Swipe navigation might conflict with horizontal scroll inside code blocks. Solution: don't start a swipe gesture if the touch starts on a `<pre>` or a scrollable element.
+- Does the comment pin overlay on HTML iframes work with touch? Need to verify in the HTML review flow (feature 033).
+
+## Related
+
+- **033 — Inline comments on HTML** — must work in cellphone mode (taps inside the iframe must surface a floating action button on the parent)
+- **039 — PWA infrastructure** (follow-on: manifest, service worker, install prompt, offline read-only for previously-viewed PRs)

--- a/public/demo.html
+++ b/public/demo.html
@@ -3,783 +3,395 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>OpenTelemetry Architecture &amp; Integration Guide — FinOps Knowledge Article</title>
+<title>The Field Guide to Document Review in the AI Era</title>
 <script type="module">
-import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-mermaid.initialize({
-  startOnLoad: true,
-  theme: 'base',
-  themeVariables: {
-    primaryColor: '#E6F1FB',
-    primaryTextColor: '#0C447C',
-    primaryBorderColor: '#85B7EB',
-    secondaryColor: '#E1F5EE',
-    secondaryTextColor: '#085041',
-    secondaryBorderColor: '#5DCAA5',
-    tertiaryColor: '#FAEEDA',
-    tertiaryTextColor: '#633806',
-    tertiaryBorderColor: '#FAC775',
-    lineColor: '#5F5E5A',
-    textColor: '#2C2C2A',
-    fontSize: '14px',
-    fontFamily: '"Inter", "Segoe UI", system-ui, sans-serif',
-    noteTextColor: '#2C2C2A',
-    noteBkgColor: '#F1EFE8',
-    noteBorderColor: '#B4B2A9',
-    edgeLabelBackground: '#ffffff',
-  },
-  flowchart: { curve: 'basis', padding: 16 },
-  sequence: { actorMargin: 60, messageMargin: 40 }
-});
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'base',
+    themeVariables: {
+      primaryColor: '#eff6ff',
+      primaryTextColor: '#1e3a8a',
+      primaryBorderColor: '#60a5fa',
+      secondaryColor: '#ecfdf5',
+      secondaryTextColor: '#065f46',
+      secondaryBorderColor: '#34d399',
+      tertiaryColor: '#fef3c7',
+      tertiaryTextColor: '#92400e',
+      tertiaryBorderColor: '#fbbf24',
+      lineColor: '#6b7280',
+      fontSize: '13px',
+      fontFamily: '"Inter", -apple-system, "Segoe UI", system-ui, sans-serif'
+    }
+  });
 </script>
 <style>
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
-
   :root {
-    --bg: #FAFAF8;
-    --surface: #FFFFFF;
-    --border: #E2E0D8;
-    --text: #1A1A18;
-    --text-secondary: #5F5E5A;
-    --accent: #185FA5;
-    --accent-light: #E6F1FB;
-    --teal: #0F6E56;
-    --teal-light: #E1F5EE;
-    --coral: #993C1D;
-    --coral-light: #FAECE7;
-    --amber: #854F0B;
-    --amber-light: #FAEEDA;
-    --purple: #534AB7;
-    --purple-light: #EEEDFE;
-    --red: #A32D2D;
-    --red-light: #FCEBEB;
+    --ink: #1a1a1a;
+    --paper: #fafaf7;
+    --accent: #2563eb;
+    --accent-soft: #eff6ff;
+    --accent-dark: #1e3a8a;
+    --muted: #6b7280;
+    --rule: #e5e7eb;
+    --card-bg: #ffffff;
+    --warn: #f59e0b;
+    --warn-soft: #fffbeb;
+    --ok: #10b981;
+    --ok-soft: #ecfdf5;
   }
-
-  * { margin: 0; padding: 0; box-sizing: border-box; }
-
-  body {
-    font-family: 'Inter', system-ui, sans-serif;
-    background: var(--bg);
-    color: var(--text);
-    line-height: 1.7;
-    font-size: 15px;
+  html, body {
+    margin: 0;
+    padding: 0;
+    background: var(--paper);
+    color: var(--ink);
+    font-family: Georgia, "Times New Roman", serif;
+    line-height: 1.65;
   }
-
-  .page-wrapper {
-    max-width: 900px;
+  main {
+    max-width: 760px;
     margin: 0 auto;
-    padding: 40px 24px 80px;
+    padding: 48px 32px 96px;
   }
-
-  /* Header */
-  .doc-header {
-    border-bottom: 2px solid var(--text);
-    padding-bottom: 24px;
+  header {
+    border-bottom: 1px solid var(--rule);
+    padding-bottom: 28px;
     margin-bottom: 40px;
   }
-  .doc-header .meta {
-    font-size: 12px;
+  header .kicker {
     text-transform: uppercase;
-    letter-spacing: 1.5px;
-    color: var(--text-secondary);
-    margin-bottom: 12px;
-    font-weight: 600;
-  }
-  .doc-header h1 {
-    font-size: 32px;
-    font-weight: 700;
-    line-height: 1.2;
-    margin-bottom: 8px;
-  }
-  .doc-header .subtitle {
-    font-size: 17px;
-    color: var(--text-secondary);
-    font-weight: 400;
-  }
-
-  /* Audience badges */
-  .audience {
-    display: flex;
-    gap: 8px;
-    margin-top: 16px;
-    flex-wrap: wrap;
-  }
-  .badge {
+    letter-spacing: 0.14em;
     font-size: 11px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.8px;
-    padding: 4px 10px;
-    border-radius: 4px;
-  }
-  .badge.lt { background: var(--purple-light); color: var(--purple); }
-  .badge.eng { background: var(--teal-light); color: var(--teal); }
-
-  /* Section headers */
-  h2 {
-    font-size: 22px;
-    font-weight: 700;
-    margin: 48px 0 8px;
-    padding-top: 24px;
-    border-top: 1px solid var(--border);
-  }
-  h2:first-of-type { border-top: none; padding-top: 0; }
-  h3 {
-    font-size: 17px;
-    font-weight: 600;
-    margin: 32px 0 8px;
-    color: var(--text);
-  }
-  h4 {
-    font-size: 15px;
-    font-weight: 600;
-    margin: 20px 0 6px;
-  }
-
-  p { margin-bottom: 14px; }
-
-  /* Diagram containers */
-  .diagram-card {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 28px 20px;
-    margin: 24px 0;
-    overflow-x: auto;
-  }
-  .diagram-card .diagram-title {
-    font-size: 13px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    color: var(--text-secondary);
-    margin-bottom: 16px;
-  }
-  .mermaid {
-    display: flex;
-    justify-content: center;
-  }
-
-  /* Callout boxes */
-  .callout {
-    border-left: 3px solid;
-    padding: 16px 20px;
-    margin: 20px 0;
-    border-radius: 0 6px 6px 0;
-    font-size: 14px;
-  }
-  .callout.key { border-color: var(--accent); background: var(--accent-light); }
-  .callout.key strong { color: var(--accent); }
-  .callout.answer { border-color: var(--teal); background: var(--teal-light); }
-  .callout.answer strong { color: var(--teal); }
-  .callout.warning { border-color: var(--coral); background: var(--coral-light); }
-  .callout.warning strong { color: var(--coral); }
-  .callout.finops { border-color: var(--purple); background: var(--purple-light); }
-  .callout.finops strong { color: var(--purple); }
-
-  /* Numbered questions */
-  .question-block {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 20px 24px;
-    margin: 20px 0;
-  }
-  .question-block .q {
-    font-weight: 600;
     color: var(--accent);
-    margin-bottom: 8px;
-    font-size: 15px;
+    font-family: -apple-system, "Segoe UI", sans-serif;
+    margin-bottom: 10px;
+    font-weight: 600;
   }
-  .question-block .a {
-    color: var(--text);
+  h1 {
+    font-size: 38px;
+    line-height: 1.15;
+    margin: 0 0 14px;
+    letter-spacing: -0.01em;
   }
-
-  /* Table */
+  header .byline {
+    color: var(--muted);
+    font-size: 14px;
+    font-family: -apple-system, "Segoe UI", sans-serif;
+  }
+  h2 {
+    font-size: 26px;
+    margin-top: 44px;
+    margin-bottom: 14px;
+    letter-spacing: -0.005em;
+  }
+  h3 {
+    font-size: 19px;
+    margin-top: 30px;
+    margin-bottom: 10px;
+  }
+  p { margin: 0 0 16px; }
+  blockquote {
+    border-left: 4px solid var(--accent);
+    background: var(--accent-soft);
+    margin: 28px 0;
+    padding: 18px 22px;
+    font-style: italic;
+    color: var(--accent-dark);
+    border-radius: 0 6px 6px 0;
+  }
+  ul, ol { padding-left: 24px; }
+  li { margin-bottom: 6px; }
   table {
     width: 100%;
     border-collapse: collapse;
-    margin: 20px 0;
+    margin: 28px 0;
+    font-family: -apple-system, "Segoe UI", sans-serif;
     font-size: 14px;
+    background: var(--card-bg);
+    border-radius: 6px;
+    overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+  }
+  th, td {
+    text-align: left;
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--rule);
   }
   th {
-    text-align: left;
+    background: #f8fafc;
     font-weight: 600;
-    padding: 10px 14px;
-    border-bottom: 2px solid var(--text);
+    color: #374151;
+    letter-spacing: 0.02em;
     font-size: 12px;
     text-transform: uppercase;
-    letter-spacing: 0.8px;
-    color: var(--text-secondary);
-  }
-  td {
-    padding: 10px 14px;
-    border-bottom: 1px solid var(--border);
-    vertical-align: top;
   }
   tr:last-child td { border-bottom: none; }
-
   code {
-    font-family: 'JetBrains Mono', monospace;
+    font-family: "JetBrains Mono", Menlo, Consolas, monospace;
     font-size: 13px;
-    background: #F1EFE8;
-    padding: 2px 6px;
+    background: #f3f4f6;
+    padding: 1px 6px;
     border-radius: 3px;
+    color: #be185d;
   }
-
-  /* TOC */
-  .toc {
-    background: var(--surface);
-    border: 1px solid var(--border);
+  pre {
+    background: #0f172a;
+    color: #e2e8f0;
+    padding: 18px 22px;
     border-radius: 8px;
-    padding: 20px 24px;
-    margin-bottom: 36px;
+    overflow-x: auto;
+    font-size: 13px;
+    line-height: 1.55;
+    box-shadow: 0 2px 6px rgba(15,23,42,0.1);
   }
-  .toc-title {
-    font-size: 12px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 1.2px;
-    color: var(--text-secondary);
-    margin-bottom: 12px;
+  pre code {
+    background: transparent;
+    color: inherit;
+    padding: 0;
   }
-  .toc ol { padding-left: 20px; }
-  .toc li { margin-bottom: 6px; font-size: 14px; }
-  .toc a { color: var(--accent); text-decoration: none; }
-  .toc a:hover { text-decoration: underline; }
-
-  /* Summary strip */
-  .summary-strip {
+  .callout {
+    background: var(--card-bg);
+    border: 1px solid var(--rule);
+    border-left: 4px solid var(--accent);
+    padding: 18px 22px;
+    margin: 28px 0;
+    border-radius: 6px;
+    font-family: -apple-system, "Segoe UI", sans-serif;
+    font-size: 14px;
+    line-height: 1.6;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+  }
+  .callout strong { color: var(--accent); }
+  .callout.warn {
+    border-left-color: var(--warn);
+    background: var(--warn-soft);
+  }
+  .callout.warn strong { color: #b45309; }
+  .callout.ok {
+    border-left-color: var(--ok);
+    background: var(--ok-soft);
+  }
+  .callout.ok strong { color: #047857; }
+  .cards {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    grid-template-columns: repeat(3, 1fr);
     gap: 16px;
-    margin: 24px 0;
+    margin: 28px 0;
   }
-  .summary-card {
-    background: var(--surface);
-    border: 1px solid var(--border);
+  .card {
+    background: var(--card-bg);
+    border: 1px solid var(--rule);
     border-radius: 8px;
-    padding: 16px;
+    padding: 20px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
   }
-  .summary-card .label {
+  .card .label {
+    font-family: -apple-system, "Segoe UI", sans-serif;
     font-size: 11px;
     text-transform: uppercase;
-    letter-spacing: 1px;
-    color: var(--text-secondary);
+    letter-spacing: 0.1em;
+    color: var(--accent);
     font-weight: 600;
-    margin-bottom: 4px;
+    margin-bottom: 8px;
   }
-  .summary-card .value {
-    font-size: 18px;
-    font-weight: 700;
+  .card h4 {
+    margin: 0 0 8px;
+    font-size: 16px;
   }
-
-  .footer {
-    margin-top: 48px;
-    padding-top: 20px;
-    border-top: 1px solid var(--border);
-    font-size: 12px;
-    color: var(--text-secondary);
+  .card p {
+    margin: 0;
+    font-size: 13px;
+    color: #4b5563;
+    line-height: 1.55;
+    font-family: -apple-system, "Segoe UI", sans-serif;
+  }
+  .mermaid {
+    background: var(--card-bg);
+    border: 1px solid var(--rule);
+    border-radius: 8px;
+    padding: 24px;
+    margin: 28px 0;
+    text-align: center;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+  }
+  footer {
+    margin-top: 72px;
+    padding-top: 28px;
+    border-top: 1px solid var(--rule);
+    color: var(--muted);
+    font-size: 13px;
+    font-family: -apple-system, "Segoe UI", sans-serif;
+  }
+  @media (max-width: 640px) {
+    .cards { grid-template-columns: 1fr; }
+    main { padding: 32px 20px 64px; }
+    h1 { font-size: 30px; }
   }
 </style>
 </head>
 <body>
-<div class="page-wrapper">
+<main>
 
-<!-- HEADER -->
-<header class="doc-header">
-  <div class="meta">Knowledge Article &middot; Architecture &middot; Observability</div>
-  <h1>OpenTelemetry: Architecture, Trace Context &amp; Integration Patterns</h1>
-  <p class="subtitle">How OTel works, what the Collector does, how cloud providers implement it, and how we (as a FinOps integrator) can consume trace data.</p>
-  <div class="audience">
-    <span class="badge lt">Leadership</span>
-    <span class="badge eng">Engineering</span>
-  </div>
+<header>
+  <div class="kicker">Sample Document</div>
+  <h1>The Field Guide to Document Review in the AI Era</h1>
+  <div class="byline">A demo document for MarDoc — highlight any passage and leave a comment.</div>
 </header>
 
-<!-- TOC -->
-<nav class="toc">
-  <div class="toc-title">Contents</div>
-  <ol>
-    <li><a href="#tldr">Executive summary</a></li>
-    <li><a href="#what-is-otel">What is OpenTelemetry?</a></li>
-    <li><a href="#trace-context">W3C Trace Context &amp; how correlation works</a></li>
-    <li><a href="#spans-events">Spans, events, and custom attributes</a></li>
-    <li><a href="#collector">The OTel Collector: what it does</a></li>
-    <li><a href="#cloud">Cloud-provider OTel collectors (AWS, GCP, Azure)</a></li>
-    <li><a href="#questions">Answering our five questions</a></li>
-    <li><a href="#finops">FinOps integration patterns: how we plug in</a></li>
-    <li><a href="#decision">Decision matrix</a></li>
-  </ol>
-</nav>
+<p>This is a sample HTML document shipped with MarDoc. Use it to try the review flow the same way you would on any <code>.html</code> file in a real repository: select a sentence, leave a comment, reply, resolve. Every interaction is routed through the same GitHub review API that markdown files use — the only thing that changes is the rendering layer.</p>
 
-<!-- EXECUTIVE SUMMARY -->
-<section id="tldr">
-<h2>1. Executive summary</h2>
+<blockquote>
+  If the reviewer can't read the document, they can't review the document. HTML and markdown are how AI writes; they should be how humans review.
+</blockquote>
 
-<div class="summary-strip">
-  <div class="summary-card">
-    <div class="label">What OTel is</div>
-    <div class="value" style="font-size:14px; font-weight:500; line-height:1.5">A vendor-neutral standard for collecting traces, metrics, and logs from applications.</div>
+<h2>Why document review is the bottleneck</h2>
+
+<p>Most organizations have quietly accumulated three review workflows, each of which makes a different set of people unhappy. Engineers review code in pull requests. Writers review prose in Google Docs or Notion. Everyone else reviews whatever the last meeting's action item ended up in — a spreadsheet, a Slack thread, a draft email nobody ever sends.</p>
+
+<p>When AI-generated content enters the picture, the bottleneck becomes obvious. A language model can produce a four-thousand-word technical brief in ninety seconds. A human can review it in forty-five minutes. The constraint is no longer production; it is attention. And attention, unlike compute, does not scale by adding another GPU.</p>
+
+<h3>The three review styles</h3>
+
+<p>Every review task falls into one of three shapes. Understanding which shape you're dealing with tells you which tool to use.</p>
+
+<div class="cards">
+  <div class="card">
+    <div class="label">Style 1</div>
+    <h4>Correctness</h4>
+    <p>Does this assert something true? Technical docs, legal language, anything with an audit trail.</p>
   </div>
-  <div class="summary-card">
-    <div class="label">Core idea</div>
-    <div class="value" style="font-size:14px; font-weight:500; line-height:1.5">A single <code>traceparent</code> header flows through every service; a Collector aggregates the data.</div>
+  <div class="card">
+    <div class="label">Style 2</div>
+    <h4>Voice</h4>
+    <p>Does this sound like us? Brand copy, marketing, and external communications.</p>
   </div>
-  <div class="summary-card">
-    <div class="label">Our opportunity</div>
-    <div class="value" style="font-size:14px; font-weight:500; line-height:1.5">We can receive OTel data as an additional exporter — we do not need to replace anything.</div>
+  <div class="card">
+    <div class="label">Style 3</div>
+    <h4>Structure</h4>
+    <p>Does this belong here, at this length, in this order? Long-form reports and strategy memos.</p>
   </div>
 </div>
 
-<p>OpenTelemetry (OTel) is a CNCF-graduated open-source standard that gives every participating application a common way to emit telemetry — traces, metrics, and logs. A <strong>W3C Trace Context</strong> header (<code>traceparent</code>) carries a trace ID across service boundaries so that downstream systems can correlate all the spans belonging to a single request. The <strong>OTel Collector</strong> sits between applications and observability backends, receiving, processing, and exporting telemetry. As a FinOps integrator, we can tap into this pipeline without disrupting existing observability setups.</p>
-</section>
+<p>A good review tool makes all three cheap. A bad one makes each of them expensive in a different way. The trick is that most teams have never named which of the three they are doing at any given moment, so the tool choice is accidental and the review gets the shape of whatever application happened to be open.</p>
 
-<!-- WHAT IS OTEL -->
-<section id="what-is-otel">
-<h2>2. What is OpenTelemetry?</h2>
+<h2>Comparing the common tools</h2>
 
-<p>OpenTelemetry is an instrumentation framework — it standardizes <em>how</em> applications generate and transmit telemetry data. It is <strong>not</strong> a storage or visualization backend (like Datadog, Grafana, or AWS X-Ray). Instead, it provides SDKs that applications embed, and a Collector process that routes the data to one or more backends of your choice.</p>
-
-<p>OTel covers three "signal types": <strong>traces</strong> (a request's journey across services), <strong>metrics</strong> (numeric measurements like latency or error rates), and <strong>logs</strong> (structured event records). For our purposes, traces are the primary concern because they carry the correlation ID that ties an entire request lifecycle together.</p>
-
-<div class="diagram-card">
-  <div class="diagram-title">Diagram 1 — The three pillars of OTel</div>
-  <pre class="mermaid">
-flowchart LR
-  subgraph Application["Instrumented application"]
-    direction TB
-    T["Traces<br/><i>request flow</i>"]
-    M["Metrics<br/><i>counters, histograms</i>"]
-    L["Logs<br/><i>structured events</i>"]
-  end
-  Application -->|OTLP| C["OTel Collector"]
-  C -->|export| B1["Backend A<br/><i>e.g. Datadog</i>"]
-  C -->|export| B2["Backend B<br/><i>e.g. X-Ray</i>"]
-  C -->|export| B3["Backend C<br/><i>e.g. Us (FinOps)</i>"]
-  style Application fill:#E6F1FB,stroke:#85B7EB,color:#0C447C
-  style C fill:#FAEEDA,stroke:#FAC775,color:#633806
-  style B1 fill:#E1F5EE,stroke:#5DCAA5,color:#085041
-  style B2 fill:#E1F5EE,stroke:#5DCAA5,color:#085041
-  style B3 fill:#EEEDFE,stroke:#AFA9EC,color:#3C3489
-  </pre>
-</div>
-
-<div class="callout key">
-  <strong>Key insight for leadership:</strong> OTel is the industry standard. AWS, GCP, and Azure all ship their own OTel distributions. Customers who adopt OTel can send their telemetry to <em>multiple</em> backends simultaneously — including us — with a configuration change, not a code change.
-</div>
-</section>
-
-<!-- TRACE CONTEXT -->
-<section id="trace-context">
-<h2>3. W3C Trace Context &amp; how correlation works</h2>
-
-<p>The <a href="https://www.w3.org/TR/trace-context/">W3C Trace Context</a> specification defines an HTTP header called <code>traceparent</code> that propagates tracing identity across service boundaries. Its format is:</p>
-
-<p style="text-align:center; margin:20px 0;">
-  <code style="font-size:15px; padding:8px 16px; background:#F1EFE8; border-radius:6px;">
-    traceparent: 00-&lt;trace-id&gt;-&lt;parent-span-id&gt;-&lt;trace-flags&gt;
-  </code>
-</p>
-
-<p>The <strong>trace ID</strong> (32 hex characters) is the correlation key. It is generated by the first service that handles a request and propagated — unchanged — to every downstream service. Each service creates its own <strong>span</strong> (with a unique 16-character span ID) and attaches that span to the shared trace ID. The Collector (or backend) then reconstructs the full call tree by grouping spans that share the same trace ID.</p>
-
-<div class="diagram-card">
-  <div class="diagram-title">Diagram 2 — Trace context propagation across services</div>
-  <pre class="mermaid">
-sequenceDiagram
-    participant U as User / Browser
-    participant A as Service A<br/>(API Gateway)
-    participant B as Service B<br/>(Order Service)
-    participant C as Service C<br/>(Payment Service)
-    participant Col as OTel Collector
-
-    U->>A: POST /order
-    Note over A: Generates trace ID<br/>abc123...
-    A->>B: traceparent: 00-abc123...-span_a-01
-    Note over B: Creates span_b,<br/>same trace ID
-    B->>C: traceparent: 00-abc123...-span_b-01
-    Note over C: Creates span_c,<br/>same trace ID
-
-    A-->>Col: span_a (trace: abc123)
-    B-->>Col: span_b (trace: abc123)
-    C-->>Col: span_c (trace: abc123)
-
-    Note over Col: Correlates all 3 spans<br/>into one trace tree
-  </pre>
-</div>
-
-<div class="callout key">
-  <strong>Key insight:</strong> The trace ID is the universal correlation key. Any system that receives spans tagged with the same trace ID can reconstruct the request's full journey. This is exactly how we, as an integrator, can correlate cost data with application request paths.
-</div>
-</section>
-
-<!-- SPANS AND EVENTS -->
-<section id="spans-events">
-<h2>4. Spans, events, and custom attributes</h2>
-
-<p>A <strong>span</strong> represents a single unit of work — an HTTP handler, a database query, a message consumer. Every span contains a start time, an end time, a name, and a status. Beyond these basics, there are two mechanisms for attaching custom data to a span:</p>
-
-<h3>Span attributes</h3>
-<p>Key-value pairs set on the span itself. These describe the work being done: <code>http.method = "POST"</code>, <code>db.system = "postgresql"</code>, <code>cloud.region = "us-east-1"</code>. OTel defines "semantic conventions" — standardized attribute names — so that tooling can interpret them consistently. Applications can also add their own custom attributes (e.g. <code>finops.cost_center = "team-alpha"</code>).</p>
-
-<h3>Span events</h3>
-<p>Timestamped log entries attached to a span. Think of them as "something interesting happened during this span." An event has a name, a timestamp, and its own set of attributes. For example, a span representing an HTTP request might have an event named <code>cache.miss</code> with an attribute <code>cache.key = "user:42"</code>.</p>
-
-<div class="diagram-card">
-  <div class="diagram-title">Diagram 3 — Anatomy of a span</div>
-  <pre class="mermaid">
-flowchart TB
-    subgraph Span["Span: POST /api/order"]
-        direction TB
-        H["Span headers<br/><i>trace_id, span_id, parent_span_id,<br/>start_time, end_time, status</i>"]
-        A["Attributes (key-value pairs)<br/><i>http.method=POST, http.route=/api/order,<br/>cloud.region=us-east-1,<br/>finops.cost_center=team-alpha</i>"]
-        E["Events (timestamped entries)<br/><i>event: db.query.start { db.statement=SELECT... }<br/>event: cache.miss { cache.key=user:42 }</i>"]
-    end
-    H --> A --> E
-    style Span fill:#E6F1FB,stroke:#85B7EB,color:#0C447C
-    style H fill:#ffffff,stroke:#85B7EB,color:#0C447C
-    style A fill:#ffffff,stroke:#85B7EB,color:#0C447C
-    style E fill:#ffffff,stroke:#85B7EB,color:#0C447C
-  </pre>
-</div>
-
-<div class="callout answer">
-  <strong>Answer to "Does the application need to emit an OTel event with attributes?":</strong> Yes — if you want to track <em>unique, domain-specific</em> data within each span (like cost center, tenant ID, or billing tier), the application must explicitly set those as span attributes or emit span events with attributes. The trace ID and basic span metadata are handled automatically by the OTel SDK, but custom business data requires instrumentation code.
-</div>
-</section>
-
-<!-- COLLECTOR -->
-<section id="collector">
-<h2>5. The OTel Collector: what it does</h2>
-
-<p>The Collector is a standalone process (a binary, container, or sidecar) that acts as a telemetry pipeline. It has three stages:</p>
-
-<div class="diagram-card">
-  <div class="diagram-title">Diagram 4 — OTel Collector internal pipeline</div>
-  <pre class="mermaid">
-flowchart LR
-    subgraph Receivers["Receivers"]
-        R1["OTLP<br/>(gRPC / HTTP)"]
-        R2["Jaeger"]
-        R3["Prometheus"]
-    end
-    subgraph Processors["Processors"]
-        P1["Batching"]
-        P2["Filtering"]
-        P3["Attribute<br/>enrichment"]
-        P4["Sampling"]
-    end
-    subgraph Exporters["Exporters"]
-        E1["OTLP → Backend A"]
-        E2["OTLP → Backend B"]
-        E3["AWS X-Ray"]
-        E4["OTLP → FinOps"]
-    end
-    R1 --> P1
-    R2 --> P1
-    R3 --> P1
-    P1 --> P2 --> P3 --> P4
-    P4 --> E1
-    P4 --> E2
-    P4 --> E3
-    P4 --> E4
-    style Receivers fill:#E6F1FB,stroke:#85B7EB,color:#0C447C
-    style Processors fill:#FAEEDA,stroke:#FAC775,color:#633806
-    style Exporters fill:#E1F5EE,stroke:#5DCAA5,color:#085041
-  </pre>
-</div>
-
-<p><strong>Receivers</strong> accept data in various formats (OTLP, Jaeger, Prometheus, etc.). <strong>Processors</strong> transform the data — batching for efficiency, filtering out noise, enriching with metadata, sampling to reduce volume. <strong>Exporters</strong> send the processed data to one or more destinations. This fan-out capability is critical: a single Collector can feed data to AWS X-Ray, Datadog, <em>and</em> a FinOps platform simultaneously.</p>
-
-<h3>Deployment patterns</h3>
-
-<div class="diagram-card">
-  <div class="diagram-title">Diagram 5 — Agent vs. Gateway deployment</div>
-  <pre class="mermaid">
-flowchart TB
-    subgraph Pattern_A["Pattern A: Agent (sidecar)"]
-        direction LR
-        App1A["App 1"] --> Col1A["Collector<br/>(sidecar)"]
-        App2A["App 2"] --> Col2A["Collector<br/>(sidecar)"]
-        Col1A --> Backend_A["Backend"]
-        Col2A --> Backend_A
-    end
-
-    subgraph Pattern_B["Pattern B: Gateway (centralized)"]
-        direction LR
-        App1B["App 1"] --> GW["Collector<br/>(gateway)"]
-        App2B["App 2"] --> GW
-        App3B["App 3"] --> GW
-        GW --> Backend_B1["Backend A"]
-        GW --> Backend_B2["Backend B"]
-    end
-
-    subgraph Pattern_C["Pattern C: Agent + Gateway (recommended)"]
-        direction LR
-        App1C["App 1"] --> Col1C["Agent"]
-        App2C["App 2"] --> Col2C["Agent"]
-        Col1C --> GWC["Gateway<br/>Collector"]
-        Col2C --> GWC
-        GWC --> Backend_C1["Backend A"]
-        GWC --> Backend_C2["Backend B"]
-    end
-
-    style Pattern_A fill:#ffffff,stroke:#85B7EB
-    style Pattern_B fill:#ffffff,stroke:#5DCAA5
-    style Pattern_C fill:#ffffff,stroke:#AFA9EC
-  </pre>
-</div>
-
-<p>The recommended production pattern is <strong>Agent + Gateway</strong> (Pattern C): lightweight agent collectors run alongside each application (low-latency ingestion, local buffering), forwarding to a centralized gateway collector that handles cross-cutting concerns like sampling, attribute enrichment, and multi-backend export.</p>
-
-<div class="callout warning">
-  <strong>Common misconception:</strong> "There is only one Collector." In practice, organizations often run <em>many</em> Collector instances — one per pod/host (agents) plus one or more centralized gateways. The architecture is flexible and scalable.
-</div>
-</section>
-
-<!-- CLOUD PROVIDERS -->
-<section id="cloud">
-<h2>6. Cloud-provider OTel collectors</h2>
-
-<p>Each major cloud provider ships its own distribution of the OTel Collector, pre-configured with cloud-specific receivers, processors, and exporters:</p>
+<p>Here is the same review task — "add a paragraph to an existing document and have two stakeholders approve it" — across five tools, ranked by total elapsed time from first draft to final merge.</p>
 
 <table>
   <thead>
     <tr>
-      <th>Cloud</th>
-      <th>Distribution</th>
-      <th>Trace backend</th>
-      <th>Metrics backend</th>
-      <th>Key detail</th>
+      <th>Tool</th>
+      <th>Source of truth</th>
+      <th>Review model</th>
+      <th>Typical turnaround</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td><strong>AWS</strong></td>
-      <td>AWS Distro for OpenTelemetry (ADOT)</td>
-      <td>AWS X-Ray</td>
-      <td>CloudWatch, Managed Prometheus</td>
-      <td>Runs on ECS, EKS, EC2, Lambda. Includes AWS resource detectors and SigV4 auth. Pre-built Docker image on ECR.</td>
+      <td>Google Docs</td>
+      <td>Doc itself</td>
+      <td>Inline comments</td>
+      <td>Hours</td>
     </tr>
     <tr>
-      <td><strong>GCP</strong></td>
-      <td>Google Cloud OpenTelemetry Collector</td>
-      <td>Cloud Trace (native OTLP endpoint)</td>
-      <td>Cloud Monitoring, Managed Prometheus</td>
-      <td>Native OTLP ingestion via <code>telemetry.googleapis.com</code>. GKE resource detection built in. Largest attribute size limits.</td>
+      <td>Notion</td>
+      <td>Notion page</td>
+      <td>Inline comments</td>
+      <td>Hours</td>
     </tr>
     <tr>
-      <td><strong>Azure</strong></td>
-      <td>Azure Monitor OpenTelemetry Distro</td>
-      <td>Application Insights</td>
-      <td>Azure Monitor Metrics</td>
-      <td>Managed OTel agent in Container Apps. Uses Application Insights connection string. Supports Managed Identity auth.</td>
+      <td>GitHub PR (raw)</td>
+      <td>Repository</td>
+      <td>Line-level diff</td>
+      <td>Days — non-engineers bounce</td>
+    </tr>
+    <tr>
+      <td>Word + email</td>
+      <td>Attachment</td>
+      <td>Track changes</td>
+      <td>Days to weeks</td>
+    </tr>
+    <tr>
+      <td>MarDoc</td>
+      <td>Repository</td>
+      <td>Inline comments on rendered doc</td>
+      <td>Hours</td>
     </tr>
   </tbody>
 </table>
 
-<div class="diagram-card">
-  <div class="diagram-title">Diagram 6 — Cloud OTel ecosystem (multi-cloud view)</div>
-  <pre class="mermaid">
-flowchart TB
-    subgraph AWS["AWS"]
-        AApp["Application"] --> ADOT["ADOT Collector"]
-        ADOT --> XRay["X-Ray"]
-        ADOT --> CW["CloudWatch"]
-    end
-    subgraph GCP["GCP"]
-        GApp["Application"] --> GCOL["GCP OTel Collector"]
-        GCOL --> CT["Cloud Trace"]
-        GCOL --> CM["Cloud Monitoring"]
-    end
-    subgraph Azure["Azure"]
-        ZApp["Application"] --> AZCOL["Azure OTel Distro"]
-        AZCOL --> AI["App Insights"]
-        AZCOL --> AM["Azure Monitor"]
-    end
+<p>The pattern is not that one tool is universally better. The pattern is that the tools which keep the document close to its source of truth lose the reviewers, and the tools which keep the reviewers happy lose the document. Any workflow that optimizes for only one of those ends up with the other problem rebuilt somewhere else by hand.</p>
 
-    ADOT -->|OTLP export| US["Our FinOps<br/>Platform"]
-    GCOL -->|OTLP export| US
-    AZCOL -->|OTLP export| US
+<h2>A simple review flow</h2>
 
-    style AWS fill:#FAEEDA,stroke:#FAC775,color:#633806
-    style GCP fill:#E6F1FB,stroke:#85B7EB,color:#0C447C
-    style Azure fill:#E1F5EE,stroke:#5DCAA5,color:#085041
-    style US fill:#EEEDFE,stroke:#AFA9EC,color:#3C3489
-  </pre>
-</div>
+<p>The diagram below shows the review path for a document living in a GitHub repository. Every arrow represents a step that has traditionally required a handoff between people on different tools. The entire flow happens in one tab.</p>
 
-<div class="callout key">
-  <strong>Key insight:</strong> All three cloud providers use the standard OTel Collector architecture with OTLP as the common protocol. This means a customer on any cloud can add our OTLP endpoint as an additional exporter without replacing their existing observability tooling.
-</div>
-</section>
-
-<!-- FIVE QUESTIONS -->
-<section id="questions">
-<h2>7. Answering our five questions</h2>
-
-<div class="question-block">
-  <div class="q">Q1: Is there typically an OTel Collector configured to receive application data from each application?</div>
-  <div class="a"><strong>Yes.</strong> In production, most organizations deploy at least one Collector layer. The most common pattern is an agent-mode Collector running as a sidecar or DaemonSet alongside each application, feeding into a gateway-mode Collector for centralized processing and export. The Collector handles batching, retries, enrichment, and multi-destination export — things you don't want each application doing individually.</div>
-</div>
-
-<div class="question-block">
-  <div class="q">Q2: Is there usually only one OTel Collector?</div>
-  <div class="a"><strong>No — there are usually many.</strong> A typical Kubernetes deployment runs one agent Collector per node (as a DaemonSet) plus one or more gateway Collector instances. In a multi-cloud setup, each cloud environment typically has its own Collector fleet. The "one Collector" mental model only applies to the simplest dev/test setups.</div>
-</div>
-
-<div class="question-block">
-  <div class="q">Q3: What are the standard OTel Collectors in AWS, GCP, Azure?</div>
-  <div class="a">See the table in Section 6. In short: <strong>AWS → ADOT</strong> (feeds X-Ray, CloudWatch), <strong>GCP → Google Cloud OTel Collector</strong> (feeds Cloud Trace, Cloud Monitoring with native OTLP), <strong>Azure → Azure Monitor OpenTelemetry Distro</strong> (feeds Application Insights, Azure Monitor). All are distributions of the upstream open-source OTel Collector with cloud-specific plugins.</div>
-</div>
-
-<div class="question-block">
-  <div class="q">Q4: If we want to inspect OTel data from a trace, can we integrate <em>with</em> the OTel Collector?</div>
-  <div class="a"><strong>Yes — this is the recommended approach.</strong> The customer's existing Collector is configured to add our OTLP endpoint as an additional exporter. Their Collector fans out data to their existing backend (e.g. Datadog) <em>and</em> to us simultaneously. We receive a copy of the telemetry; we don't intercept or modify the existing flow. This is a <strong>configuration change</strong> on the customer's Collector — no code changes in their applications.</div>
-</div>
-
-<div class="question-block">
-  <div class="q">Q5: Or must we <em>be</em> the OTel Collector?</div>
-  <div class="a"><strong>We can, but we don't have to.</strong> There are two viable architectures (see Section 8). We can either (a) <strong>be an OTLP receiver endpoint</strong> that the customer's Collector exports to, or (b) <strong>run our own Collector instance</strong> (as a downstream gateway) that receives data from their Collector, processes it for our needs, and feeds our backend. Option (a) is simpler; option (b) gives us more control over filtering and transformation. In neither case do we replace the customer's existing Collector.</div>
-</div>
-</section>
-
-<!-- FINOPS INTEGRATION -->
-<section id="finops">
-<h2>8. FinOps integration patterns: how we plug in</h2>
-
-<p>As a FinOps company, we have two primary integration architectures for consuming OTel trace data from customers. Both preserve the customer's existing observability setup.</p>
-
-<h3>Option A — OTLP receiver endpoint (simpler)</h3>
-<p>We expose an OTLP-compatible endpoint (gRPC on port 4317, HTTP on port 4318). The customer adds our endpoint as an additional exporter in their existing Collector configuration. We receive spans, process them in our own backend, and correlate them with cost data.</p>
-
-<div class="diagram-card">
-  <div class="diagram-title">Diagram 7 — Option A: We are an OTLP endpoint</div>
-  <pre class="mermaid">
+<div class="mermaid">
 flowchart LR
-    App["Customer's<br/>applications"] -->|spans| CC["Customer's<br/>OTel Collector"]
-    CC -->|exporter 1| DD["Datadog /<br/>X-Ray / etc."]
-    CC -->|"exporter 2 (OTLP)"| US["Our OTLP<br/>endpoint<br/><i>finops.example.com:4317</i>"]
-    US --> DB["Our backend<br/><i>correlate traces<br/>with cost data</i>"]
-
-    style App fill:#E6F1FB,stroke:#85B7EB,color:#0C447C
-    style CC fill:#FAEEDA,stroke:#FAC775,color:#633806
-    style DD fill:#E1F5EE,stroke:#5DCAA5,color:#085041
-    style US fill:#EEEDFE,stroke:#AFA9EC,color:#3C3489
-    style DB fill:#EEEDFE,stroke:#AFA9EC,color:#3C3489
-  </pre>
+    A[Author drafts] --> B[Opens PR]
+    B --> C{Reviewer<br/>opens PR}
+    C -->|Reads rendered doc| D[Leaves inline comment]
+    D --> E[Author edits]
+    E --> F[Reviewer approves]
+    F --> G[Merged to main]
 </div>
 
-<h3>Option B — Our own Collector gateway (more control)</h3>
-<p>We run our own OTel Collector instance as a downstream gateway. The customer's Collector exports to ours via OTLP. Our Collector can then apply FinOps-specific processing — filtering to only cost-relevant spans, enriching with our own attributes, sampling — before ingesting into our backend.</p>
+<p>And here is a second diagram showing the internal state of a reviewer's queue — the three buckets every review passes through on the way to being accepted or rejected.</p>
 
-<div class="diagram-card">
-  <div class="diagram-title">Diagram 8 — Option B: We run a downstream Collector</div>
-  <pre class="mermaid">
-flowchart LR
-    App["Customer's<br/>applications"] -->|spans| CC["Customer's<br/>OTel Collector"]
-    CC -->|exporter 1| DD["Datadog /<br/>X-Ray / etc."]
-    CC -->|"exporter 2 (OTLP)"| OUR["Our OTel<br/>Collector<br/><i>gateway mode</i>"]
-    OUR -->|"filter + enrich"| DB["Our backend<br/><i>cost correlation</i>"]
-
-    subgraph Our_Infra["Our infrastructure"]
-        OUR
-        DB
-    end
-
-    style App fill:#E6F1FB,stroke:#85B7EB,color:#0C447C
-    style CC fill:#FAEEDA,stroke:#FAC775,color:#633806
-    style DD fill:#E1F5EE,stroke:#5DCAA5,color:#085041
-    style Our_Infra fill:#EEEDFE,stroke:#AFA9EC,color:#3C3489
-    style OUR fill:#EEEDFE,stroke:#AFA9EC,color:#3C3489
-    style DB fill:#EEEDFE,stroke:#AFA9EC,color:#3C3489
-  </pre>
+<div class="mermaid">
+stateDiagram-v2
+    [*] --> Pending
+    Pending --> Reading: Reviewer opens the doc
+    Reading --> Commenting: Highlights a passage
+    Commenting --> Reading: Finishes a thought
+    Reading --> Submitted: Clicks Submit review
+    Submitted --> [*]
 </div>
 
-<div class="callout finops">
-  <strong>FinOps-specific value:</strong> By receiving trace data, we can map individual request paths to cloud resource consumption. A span that shows <code>cloud.region = us-east-1</code>, <code>cloud.platform = aws_lambda</code>, and <code>finops.cost_center = team-alpha</code> lets us attribute the Lambda invocation cost to the specific team, service, and even API endpoint that triggered it.
+<h2>What a good review comment looks like</h2>
+
+<p>A review comment is a small, structured piece of writing — not a passing thought. It has a target, a claim, and a suggested direction. It assumes the author is doing their best and that the reader of the comment is trying to learn something.</p>
+
+<div class="callout">
+  <strong>Rule of thumb.</strong> If a comment doesn't name what it is pointing at, it is not a review comment — it is a vague feeling. Point at the thing, say what you think, and say what you would change.
 </div>
 
-<h3>What the customer needs to do</h3>
-<p>In either option, the customer change is minimal — they add a few lines to their Collector config:</p>
+<h3>An example</h3>
 
-<div style="background:#2C2C2A; color:#D3D1C7; border-radius:8px; padding:20px; margin:20px 0; font-family:'JetBrains Mono',monospace; font-size:13px; line-height:1.6; overflow-x:auto;">
-<pre style="margin:0;"><span style="color:#5DCAA5;">exporters:</span>
-  <span style="color:#85B7EB;">otlp/existing-backend:</span>
-    endpoint: datadog-agent:4317
+<p>Consider the following draft sentence in a product spec:</p>
 
-  <span style="color:#AFA9EC;">otlp/finops:                           # ← new</span>
-    <span style="color:#AFA9EC;">endpoint: finops.example.com:4317    # ← new</span>
-    <span style="color:#AFA9EC;">headers:                              # ← new</span>
-      <span style="color:#AFA9EC;">api-key: "${FINOPS_API_KEY}"       # ← new</span>
+<pre><code>The system will attempt to retry failed requests
+up to a reasonable number of times.</code></pre>
 
-<span style="color:#5DCAA5;">service:</span>
-  <span style="color:#85B7EB;">pipelines:</span>
-    <span style="color:#85B7EB;">traces:</span>
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [otlp/existing-backend, <span style="color:#AFA9EC;">otlp/finops</span>]  <span style="color:#888780;"># ← added</span>
-</pre>
+<p>The word <code>reasonable</code> is doing a lot of work there. A useful comment does not just flag the word; it proposes a replacement. "Reasonable — can we name a specific number? Three retries with exponential backoff seems to be the shape we use elsewhere." That comment gives the author a clear next action and a reference point.</p>
+
+<div class="callout ok">
+  <strong>Good comment.</strong> "Reasonable is vague — propose three retries with exponential backoff, matching the rest of the codebase."
 </div>
-</section>
 
-<!-- DECISION MATRIX -->
-<section id="decision">
-<h2>9. Decision matrix</h2>
-
-<table>
-  <thead>
-    <tr>
-      <th>Consideration</th>
-      <th>Option A: OTLP endpoint</th>
-      <th>Option B: Our Collector</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Setup complexity for us</td>
-      <td>Lower — build an OTLP-compatible ingestion API</td>
-      <td>Higher — deploy + operate a Collector fleet</td>
-    </tr>
-    <tr>
-      <td>Setup complexity for customer</td>
-      <td>Same (add exporter config)</td>
-      <td>Same (add exporter config)</td>
-    </tr>
-    <tr>
-      <td>Filtering / transformation</td>
-      <td>Done in our application code</td>
-      <td>Done in Collector config (more flexible, standard)</td>
-    </tr>
-    <tr>
-      <td>Data volume control</td>
-      <td>Customer controls sampling</td>
-      <td>We can add our own sampling layer</td>
-    </tr>
-    <tr>
-      <td>Protocol flexibility</td>
-      <td>OTLP only</td>
-      <td>Can also accept Jaeger, Zipkin, Prometheus</td>
-    </tr>
-    <tr>
-      <td>Best for</td>
-      <td>MVP / quick integration</td>
-      <td>Production scale / multi-tenant</td>
-    </tr>
-  </tbody>
-</table>
-
-<div class="callout answer">
-  <strong>Recommendation:</strong> Start with <strong>Option A</strong> (OTLP receiver endpoint) for the initial integration. It's the fastest path to receiving trace data and proving value. Migrate to <strong>Option B</strong> (our own Collector) as we scale and need finer-grained control over filtering, sampling, and multi-tenant processing.
+<div class="callout warn">
+  <strong>Less useful.</strong> "Vague." — no target, no proposed direction, no context. The author has to guess what a better sentence would look like.
 </div>
-</section>
 
-<!-- FOOTER -->
-<footer class="footer">
-  <p>Prepared for leadership and engineering alignment. References: <a href="https://www.w3.org/TR/trace-context/">W3C Trace Context</a>, <a href="https://opentelemetry.io/docs/collector/">OTel Collector docs</a>, <a href="https://aws-otel.github.io/">ADOT</a>, <a href="https://learn.microsoft.com/en-us/azure/azure-monitor/app/opentelemetry">Azure OTel</a>, <a href="https://docs.cloud.google.com/stackdriver/docs/managed-prometheus/setup-otel">GCP OTel</a>.</p>
+<h2>What to try in this demo</h2>
+
+<p>This document is live inside MarDoc. Try these things:</p>
+
+<ul>
+  <li>Select a short sentence and click the comment button that appears.</li>
+  <li>Select a whole paragraph and leave a longer note.</li>
+  <li>Try selecting across two different headings to see how the line range is recorded.</li>
+  <li>Switch to source view and watch the same comments map back to the underlying HTML.</li>
+  <li>Open the comment panel on the right and reply to one of your own comments.</li>
+</ul>
+
+<p>When you're done, you'll have a queued review ready to submit as a single inline GitHub comment — the same way MarDoc handles markdown files. Nothing about the submission path changes; only the rendering layer does.</p>
+
+<footer>
+  <p>Sample document shipped with MarDoc. The text is fictional and exists only to give reviewers something to comment on. Feel free to overwrite it with your own content when you fork.</p>
 </footer>
 
-</div>
+</main>
 </body>
 </html>

--- a/public/demo.html
+++ b/public/demo.html
@@ -1,0 +1,785 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>OpenTelemetry Architecture &amp; Integration Guide — FinOps Knowledge Article</title>
+<script type="module">
+import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+mermaid.initialize({
+  startOnLoad: true,
+  theme: 'base',
+  themeVariables: {
+    primaryColor: '#E6F1FB',
+    primaryTextColor: '#0C447C',
+    primaryBorderColor: '#85B7EB',
+    secondaryColor: '#E1F5EE',
+    secondaryTextColor: '#085041',
+    secondaryBorderColor: '#5DCAA5',
+    tertiaryColor: '#FAEEDA',
+    tertiaryTextColor: '#633806',
+    tertiaryBorderColor: '#FAC775',
+    lineColor: '#5F5E5A',
+    textColor: '#2C2C2A',
+    fontSize: '14px',
+    fontFamily: '"Inter", "Segoe UI", system-ui, sans-serif',
+    noteTextColor: '#2C2C2A',
+    noteBkgColor: '#F1EFE8',
+    noteBorderColor: '#B4B2A9',
+    edgeLabelBackground: '#ffffff',
+  },
+  flowchart: { curve: 'basis', padding: 16 },
+  sequence: { actorMargin: 60, messageMargin: 40 }
+});
+</script>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+
+  :root {
+    --bg: #FAFAF8;
+    --surface: #FFFFFF;
+    --border: #E2E0D8;
+    --text: #1A1A18;
+    --text-secondary: #5F5E5A;
+    --accent: #185FA5;
+    --accent-light: #E6F1FB;
+    --teal: #0F6E56;
+    --teal-light: #E1F5EE;
+    --coral: #993C1D;
+    --coral-light: #FAECE7;
+    --amber: #854F0B;
+    --amber-light: #FAEEDA;
+    --purple: #534AB7;
+    --purple-light: #EEEDFE;
+    --red: #A32D2D;
+    --red-light: #FCEBEB;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: 'Inter', system-ui, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.7;
+    font-size: 15px;
+  }
+
+  .page-wrapper {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 40px 24px 80px;
+  }
+
+  /* Header */
+  .doc-header {
+    border-bottom: 2px solid var(--text);
+    padding-bottom: 24px;
+    margin-bottom: 40px;
+  }
+  .doc-header .meta {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    color: var(--text-secondary);
+    margin-bottom: 12px;
+    font-weight: 600;
+  }
+  .doc-header h1 {
+    font-size: 32px;
+    font-weight: 700;
+    line-height: 1.2;
+    margin-bottom: 8px;
+  }
+  .doc-header .subtitle {
+    font-size: 17px;
+    color: var(--text-secondary);
+    font-weight: 400;
+  }
+
+  /* Audience badges */
+  .audience {
+    display: flex;
+    gap: 8px;
+    margin-top: 16px;
+    flex-wrap: wrap;
+  }
+  .badge {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    padding: 4px 10px;
+    border-radius: 4px;
+  }
+  .badge.lt { background: var(--purple-light); color: var(--purple); }
+  .badge.eng { background: var(--teal-light); color: var(--teal); }
+
+  /* Section headers */
+  h2 {
+    font-size: 22px;
+    font-weight: 700;
+    margin: 48px 0 8px;
+    padding-top: 24px;
+    border-top: 1px solid var(--border);
+  }
+  h2:first-of-type { border-top: none; padding-top: 0; }
+  h3 {
+    font-size: 17px;
+    font-weight: 600;
+    margin: 32px 0 8px;
+    color: var(--text);
+  }
+  h4 {
+    font-size: 15px;
+    font-weight: 600;
+    margin: 20px 0 6px;
+  }
+
+  p { margin-bottom: 14px; }
+
+  /* Diagram containers */
+  .diagram-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 28px 20px;
+    margin: 24px 0;
+    overflow-x: auto;
+  }
+  .diagram-card .diagram-title {
+    font-size: 13px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--text-secondary);
+    margin-bottom: 16px;
+  }
+  .mermaid {
+    display: flex;
+    justify-content: center;
+  }
+
+  /* Callout boxes */
+  .callout {
+    border-left: 3px solid;
+    padding: 16px 20px;
+    margin: 20px 0;
+    border-radius: 0 6px 6px 0;
+    font-size: 14px;
+  }
+  .callout.key { border-color: var(--accent); background: var(--accent-light); }
+  .callout.key strong { color: var(--accent); }
+  .callout.answer { border-color: var(--teal); background: var(--teal-light); }
+  .callout.answer strong { color: var(--teal); }
+  .callout.warning { border-color: var(--coral); background: var(--coral-light); }
+  .callout.warning strong { color: var(--coral); }
+  .callout.finops { border-color: var(--purple); background: var(--purple-light); }
+  .callout.finops strong { color: var(--purple); }
+
+  /* Numbered questions */
+  .question-block {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 20px 24px;
+    margin: 20px 0;
+  }
+  .question-block .q {
+    font-weight: 600;
+    color: var(--accent);
+    margin-bottom: 8px;
+    font-size: 15px;
+  }
+  .question-block .a {
+    color: var(--text);
+  }
+
+  /* Table */
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 20px 0;
+    font-size: 14px;
+  }
+  th {
+    text-align: left;
+    font-weight: 600;
+    padding: 10px 14px;
+    border-bottom: 2px solid var(--text);
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    color: var(--text-secondary);
+  }
+  td {
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+  }
+  tr:last-child td { border-bottom: none; }
+
+  code {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 13px;
+    background: #F1EFE8;
+    padding: 2px 6px;
+    border-radius: 3px;
+  }
+
+  /* TOC */
+  .toc {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 20px 24px;
+    margin-bottom: 36px;
+  }
+  .toc-title {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1.2px;
+    color: var(--text-secondary);
+    margin-bottom: 12px;
+  }
+  .toc ol { padding-left: 20px; }
+  .toc li { margin-bottom: 6px; font-size: 14px; }
+  .toc a { color: var(--accent); text-decoration: none; }
+  .toc a:hover { text-decoration: underline; }
+
+  /* Summary strip */
+  .summary-strip {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 16px;
+    margin: 24px 0;
+  }
+  .summary-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px;
+  }
+  .summary-card .label {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--text-secondary);
+    font-weight: 600;
+    margin-bottom: 4px;
+  }
+  .summary-card .value {
+    font-size: 18px;
+    font-weight: 700;
+  }
+
+  .footer {
+    margin-top: 48px;
+    padding-top: 20px;
+    border-top: 1px solid var(--border);
+    font-size: 12px;
+    color: var(--text-secondary);
+  }
+</style>
+</head>
+<body>
+<div class="page-wrapper">
+
+<!-- HEADER -->
+<header class="doc-header">
+  <div class="meta">Knowledge Article &middot; Architecture &middot; Observability</div>
+  <h1>OpenTelemetry: Architecture, Trace Context &amp; Integration Patterns</h1>
+  <p class="subtitle">How OTel works, what the Collector does, how cloud providers implement it, and how we (as a FinOps integrator) can consume trace data.</p>
+  <div class="audience">
+    <span class="badge lt">Leadership</span>
+    <span class="badge eng">Engineering</span>
+  </div>
+</header>
+
+<!-- TOC -->
+<nav class="toc">
+  <div class="toc-title">Contents</div>
+  <ol>
+    <li><a href="#tldr">Executive summary</a></li>
+    <li><a href="#what-is-otel">What is OpenTelemetry?</a></li>
+    <li><a href="#trace-context">W3C Trace Context &amp; how correlation works</a></li>
+    <li><a href="#spans-events">Spans, events, and custom attributes</a></li>
+    <li><a href="#collector">The OTel Collector: what it does</a></li>
+    <li><a href="#cloud">Cloud-provider OTel collectors (AWS, GCP, Azure)</a></li>
+    <li><a href="#questions">Answering our five questions</a></li>
+    <li><a href="#finops">FinOps integration patterns: how we plug in</a></li>
+    <li><a href="#decision">Decision matrix</a></li>
+  </ol>
+</nav>
+
+<!-- EXECUTIVE SUMMARY -->
+<section id="tldr">
+<h2>1. Executive summary</h2>
+
+<div class="summary-strip">
+  <div class="summary-card">
+    <div class="label">What OTel is</div>
+    <div class="value" style="font-size:14px; font-weight:500; line-height:1.5">A vendor-neutral standard for collecting traces, metrics, and logs from applications.</div>
+  </div>
+  <div class="summary-card">
+    <div class="label">Core idea</div>
+    <div class="value" style="font-size:14px; font-weight:500; line-height:1.5">A single <code>traceparent</code> header flows through every service; a Collector aggregates the data.</div>
+  </div>
+  <div class="summary-card">
+    <div class="label">Our opportunity</div>
+    <div class="value" style="font-size:14px; font-weight:500; line-height:1.5">We can receive OTel data as an additional exporter — we do not need to replace anything.</div>
+  </div>
+</div>
+
+<p>OpenTelemetry (OTel) is a CNCF-graduated open-source standard that gives every participating application a common way to emit telemetry — traces, metrics, and logs. A <strong>W3C Trace Context</strong> header (<code>traceparent</code>) carries a trace ID across service boundaries so that downstream systems can correlate all the spans belonging to a single request. The <strong>OTel Collector</strong> sits between applications and observability backends, receiving, processing, and exporting telemetry. As a FinOps integrator, we can tap into this pipeline without disrupting existing observability setups.</p>
+</section>
+
+<!-- WHAT IS OTEL -->
+<section id="what-is-otel">
+<h2>2. What is OpenTelemetry?</h2>
+
+<p>OpenTelemetry is an instrumentation framework — it standardizes <em>how</em> applications generate and transmit telemetry data. It is <strong>not</strong> a storage or visualization backend (like Datadog, Grafana, or AWS X-Ray). Instead, it provides SDKs that applications embed, and a Collector process that routes the data to one or more backends of your choice.</p>
+
+<p>OTel covers three "signal types": <strong>traces</strong> (a request's journey across services), <strong>metrics</strong> (numeric measurements like latency or error rates), and <strong>logs</strong> (structured event records). For our purposes, traces are the primary concern because they carry the correlation ID that ties an entire request lifecycle together.</p>
+
+<div class="diagram-card">
+  <div class="diagram-title">Diagram 1 — The three pillars of OTel</div>
+  <pre class="mermaid">
+flowchart LR
+  subgraph Application["Instrumented application"]
+    direction TB
+    T["Traces<br/><i>request flow</i>"]
+    M["Metrics<br/><i>counters, histograms</i>"]
+    L["Logs<br/><i>structured events</i>"]
+  end
+  Application -->|OTLP| C["OTel Collector"]
+  C -->|export| B1["Backend A<br/><i>e.g. Datadog</i>"]
+  C -->|export| B2["Backend B<br/><i>e.g. X-Ray</i>"]
+  C -->|export| B3["Backend C<br/><i>e.g. Us (FinOps)</i>"]
+  style Application fill:#E6F1FB,stroke:#85B7EB,color:#0C447C
+  style C fill:#FAEEDA,stroke:#FAC775,color:#633806
+  style B1 fill:#E1F5EE,stroke:#5DCAA5,color:#085041
+  style B2 fill:#E1F5EE,stroke:#5DCAA5,color:#085041
+  style B3 fill:#EEEDFE,stroke:#AFA9EC,color:#3C3489
+  </pre>
+</div>
+
+<div class="callout key">
+  <strong>Key insight for leadership:</strong> OTel is the industry standard. AWS, GCP, and Azure all ship their own OTel distributions. Customers who adopt OTel can send their telemetry to <em>multiple</em> backends simultaneously — including us — with a configuration change, not a code change.
+</div>
+</section>
+
+<!-- TRACE CONTEXT -->
+<section id="trace-context">
+<h2>3. W3C Trace Context &amp; how correlation works</h2>
+
+<p>The <a href="https://www.w3.org/TR/trace-context/">W3C Trace Context</a> specification defines an HTTP header called <code>traceparent</code> that propagates tracing identity across service boundaries. Its format is:</p>
+
+<p style="text-align:center; margin:20px 0;">
+  <code style="font-size:15px; padding:8px 16px; background:#F1EFE8; border-radius:6px;">
+    traceparent: 00-&lt;trace-id&gt;-&lt;parent-span-id&gt;-&lt;trace-flags&gt;
+  </code>
+</p>
+
+<p>The <strong>trace ID</strong> (32 hex characters) is the correlation key. It is generated by the first service that handles a request and propagated — unchanged — to every downstream service. Each service creates its own <strong>span</strong> (with a unique 16-character span ID) and attaches that span to the shared trace ID. The Collector (or backend) then reconstructs the full call tree by grouping spans that share the same trace ID.</p>
+
+<div class="diagram-card">
+  <div class="diagram-title">Diagram 2 — Trace context propagation across services</div>
+  <pre class="mermaid">
+sequenceDiagram
+    participant U as User / Browser
+    participant A as Service A<br/>(API Gateway)
+    participant B as Service B<br/>(Order Service)
+    participant C as Service C<br/>(Payment Service)
+    participant Col as OTel Collector
+
+    U->>A: POST /order
+    Note over A: Generates trace ID<br/>abc123...
+    A->>B: traceparent: 00-abc123...-span_a-01
+    Note over B: Creates span_b,<br/>same trace ID
+    B->>C: traceparent: 00-abc123...-span_b-01
+    Note over C: Creates span_c,<br/>same trace ID
+
+    A-->>Col: span_a (trace: abc123)
+    B-->>Col: span_b (trace: abc123)
+    C-->>Col: span_c (trace: abc123)
+
+    Note over Col: Correlates all 3 spans<br/>into one trace tree
+  </pre>
+</div>
+
+<div class="callout key">
+  <strong>Key insight:</strong> The trace ID is the universal correlation key. Any system that receives spans tagged with the same trace ID can reconstruct the request's full journey. This is exactly how we, as an integrator, can correlate cost data with application request paths.
+</div>
+</section>
+
+<!-- SPANS AND EVENTS -->
+<section id="spans-events">
+<h2>4. Spans, events, and custom attributes</h2>
+
+<p>A <strong>span</strong> represents a single unit of work — an HTTP handler, a database query, a message consumer. Every span contains a start time, an end time, a name, and a status. Beyond these basics, there are two mechanisms for attaching custom data to a span:</p>
+
+<h3>Span attributes</h3>
+<p>Key-value pairs set on the span itself. These describe the work being done: <code>http.method = "POST"</code>, <code>db.system = "postgresql"</code>, <code>cloud.region = "us-east-1"</code>. OTel defines "semantic conventions" — standardized attribute names — so that tooling can interpret them consistently. Applications can also add their own custom attributes (e.g. <code>finops.cost_center = "team-alpha"</code>).</p>
+
+<h3>Span events</h3>
+<p>Timestamped log entries attached to a span. Think of them as "something interesting happened during this span." An event has a name, a timestamp, and its own set of attributes. For example, a span representing an HTTP request might have an event named <code>cache.miss</code> with an attribute <code>cache.key = "user:42"</code>.</p>
+
+<div class="diagram-card">
+  <div class="diagram-title">Diagram 3 — Anatomy of a span</div>
+  <pre class="mermaid">
+flowchart TB
+    subgraph Span["Span: POST /api/order"]
+        direction TB
+        H["Span headers<br/><i>trace_id, span_id, parent_span_id,<br/>start_time, end_time, status</i>"]
+        A["Attributes (key-value pairs)<br/><i>http.method=POST, http.route=/api/order,<br/>cloud.region=us-east-1,<br/>finops.cost_center=team-alpha</i>"]
+        E["Events (timestamped entries)<br/><i>event: db.query.start { db.statement=SELECT... }<br/>event: cache.miss { cache.key=user:42 }</i>"]
+    end
+    H --> A --> E
+    style Span fill:#E6F1FB,stroke:#85B7EB,color:#0C447C
+    style H fill:#ffffff,stroke:#85B7EB,color:#0C447C
+    style A fill:#ffffff,stroke:#85B7EB,color:#0C447C
+    style E fill:#ffffff,stroke:#85B7EB,color:#0C447C
+  </pre>
+</div>
+
+<div class="callout answer">
+  <strong>Answer to "Does the application need to emit an OTel event with attributes?":</strong> Yes — if you want to track <em>unique, domain-specific</em> data within each span (like cost center, tenant ID, or billing tier), the application must explicitly set those as span attributes or emit span events with attributes. The trace ID and basic span metadata are handled automatically by the OTel SDK, but custom business data requires instrumentation code.
+</div>
+</section>
+
+<!-- COLLECTOR -->
+<section id="collector">
+<h2>5. The OTel Collector: what it does</h2>
+
+<p>The Collector is a standalone process (a binary, container, or sidecar) that acts as a telemetry pipeline. It has three stages:</p>
+
+<div class="diagram-card">
+  <div class="diagram-title">Diagram 4 — OTel Collector internal pipeline</div>
+  <pre class="mermaid">
+flowchart LR
+    subgraph Receivers["Receivers"]
+        R1["OTLP<br/>(gRPC / HTTP)"]
+        R2["Jaeger"]
+        R3["Prometheus"]
+    end
+    subgraph Processors["Processors"]
+        P1["Batching"]
+        P2["Filtering"]
+        P3["Attribute<br/>enrichment"]
+        P4["Sampling"]
+    end
+    subgraph Exporters["Exporters"]
+        E1["OTLP → Backend A"]
+        E2["OTLP → Backend B"]
+        E3["AWS X-Ray"]
+        E4["OTLP → FinOps"]
+    end
+    R1 --> P1
+    R2 --> P1
+    R3 --> P1
+    P1 --> P2 --> P3 --> P4
+    P4 --> E1
+    P4 --> E2
+    P4 --> E3
+    P4 --> E4
+    style Receivers fill:#E6F1FB,stroke:#85B7EB,color:#0C447C
+    style Processors fill:#FAEEDA,stroke:#FAC775,color:#633806
+    style Exporters fill:#E1F5EE,stroke:#5DCAA5,color:#085041
+  </pre>
+</div>
+
+<p><strong>Receivers</strong> accept data in various formats (OTLP, Jaeger, Prometheus, etc.). <strong>Processors</strong> transform the data — batching for efficiency, filtering out noise, enriching with metadata, sampling to reduce volume. <strong>Exporters</strong> send the processed data to one or more destinations. This fan-out capability is critical: a single Collector can feed data to AWS X-Ray, Datadog, <em>and</em> a FinOps platform simultaneously.</p>
+
+<h3>Deployment patterns</h3>
+
+<div class="diagram-card">
+  <div class="diagram-title">Diagram 5 — Agent vs. Gateway deployment</div>
+  <pre class="mermaid">
+flowchart TB
+    subgraph Pattern_A["Pattern A: Agent (sidecar)"]
+        direction LR
+        App1A["App 1"] --> Col1A["Collector<br/>(sidecar)"]
+        App2A["App 2"] --> Col2A["Collector<br/>(sidecar)"]
+        Col1A --> Backend_A["Backend"]
+        Col2A --> Backend_A
+    end
+
+    subgraph Pattern_B["Pattern B: Gateway (centralized)"]
+        direction LR
+        App1B["App 1"] --> GW["Collector<br/>(gateway)"]
+        App2B["App 2"] --> GW
+        App3B["App 3"] --> GW
+        GW --> Backend_B1["Backend A"]
+        GW --> Backend_B2["Backend B"]
+    end
+
+    subgraph Pattern_C["Pattern C: Agent + Gateway (recommended)"]
+        direction LR
+        App1C["App 1"] --> Col1C["Agent"]
+        App2C["App 2"] --> Col2C["Agent"]
+        Col1C --> GWC["Gateway<br/>Collector"]
+        Col2C --> GWC
+        GWC --> Backend_C1["Backend A"]
+        GWC --> Backend_C2["Backend B"]
+    end
+
+    style Pattern_A fill:#ffffff,stroke:#85B7EB
+    style Pattern_B fill:#ffffff,stroke:#5DCAA5
+    style Pattern_C fill:#ffffff,stroke:#AFA9EC
+  </pre>
+</div>
+
+<p>The recommended production pattern is <strong>Agent + Gateway</strong> (Pattern C): lightweight agent collectors run alongside each application (low-latency ingestion, local buffering), forwarding to a centralized gateway collector that handles cross-cutting concerns like sampling, attribute enrichment, and multi-backend export.</p>
+
+<div class="callout warning">
+  <strong>Common misconception:</strong> "There is only one Collector." In practice, organizations often run <em>many</em> Collector instances — one per pod/host (agents) plus one or more centralized gateways. The architecture is flexible and scalable.
+</div>
+</section>
+
+<!-- CLOUD PROVIDERS -->
+<section id="cloud">
+<h2>6. Cloud-provider OTel collectors</h2>
+
+<p>Each major cloud provider ships its own distribution of the OTel Collector, pre-configured with cloud-specific receivers, processors, and exporters:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Cloud</th>
+      <th>Distribution</th>
+      <th>Trace backend</th>
+      <th>Metrics backend</th>
+      <th>Key detail</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>AWS</strong></td>
+      <td>AWS Distro for OpenTelemetry (ADOT)</td>
+      <td>AWS X-Ray</td>
+      <td>CloudWatch, Managed Prometheus</td>
+      <td>Runs on ECS, EKS, EC2, Lambda. Includes AWS resource detectors and SigV4 auth. Pre-built Docker image on ECR.</td>
+    </tr>
+    <tr>
+      <td><strong>GCP</strong></td>
+      <td>Google Cloud OpenTelemetry Collector</td>
+      <td>Cloud Trace (native OTLP endpoint)</td>
+      <td>Cloud Monitoring, Managed Prometheus</td>
+      <td>Native OTLP ingestion via <code>telemetry.googleapis.com</code>. GKE resource detection built in. Largest attribute size limits.</td>
+    </tr>
+    <tr>
+      <td><strong>Azure</strong></td>
+      <td>Azure Monitor OpenTelemetry Distro</td>
+      <td>Application Insights</td>
+      <td>Azure Monitor Metrics</td>
+      <td>Managed OTel agent in Container Apps. Uses Application Insights connection string. Supports Managed Identity auth.</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="diagram-card">
+  <div class="diagram-title">Diagram 6 — Cloud OTel ecosystem (multi-cloud view)</div>
+  <pre class="mermaid">
+flowchart TB
+    subgraph AWS["AWS"]
+        AApp["Application"] --> ADOT["ADOT Collector"]
+        ADOT --> XRay["X-Ray"]
+        ADOT --> CW["CloudWatch"]
+    end
+    subgraph GCP["GCP"]
+        GApp["Application"] --> GCOL["GCP OTel Collector"]
+        GCOL --> CT["Cloud Trace"]
+        GCOL --> CM["Cloud Monitoring"]
+    end
+    subgraph Azure["Azure"]
+        ZApp["Application"] --> AZCOL["Azure OTel Distro"]
+        AZCOL --> AI["App Insights"]
+        AZCOL --> AM["Azure Monitor"]
+    end
+
+    ADOT -->|OTLP export| US["Our FinOps<br/>Platform"]
+    GCOL -->|OTLP export| US
+    AZCOL -->|OTLP export| US
+
+    style AWS fill:#FAEEDA,stroke:#FAC775,color:#633806
+    style GCP fill:#E6F1FB,stroke:#85B7EB,color:#0C447C
+    style Azure fill:#E1F5EE,stroke:#5DCAA5,color:#085041
+    style US fill:#EEEDFE,stroke:#AFA9EC,color:#3C3489
+  </pre>
+</div>
+
+<div class="callout key">
+  <strong>Key insight:</strong> All three cloud providers use the standard OTel Collector architecture with OTLP as the common protocol. This means a customer on any cloud can add our OTLP endpoint as an additional exporter without replacing their existing observability tooling.
+</div>
+</section>
+
+<!-- FIVE QUESTIONS -->
+<section id="questions">
+<h2>7. Answering our five questions</h2>
+
+<div class="question-block">
+  <div class="q">Q1: Is there typically an OTel Collector configured to receive application data from each application?</div>
+  <div class="a"><strong>Yes.</strong> In production, most organizations deploy at least one Collector layer. The most common pattern is an agent-mode Collector running as a sidecar or DaemonSet alongside each application, feeding into a gateway-mode Collector for centralized processing and export. The Collector handles batching, retries, enrichment, and multi-destination export — things you don't want each application doing individually.</div>
+</div>
+
+<div class="question-block">
+  <div class="q">Q2: Is there usually only one OTel Collector?</div>
+  <div class="a"><strong>No — there are usually many.</strong> A typical Kubernetes deployment runs one agent Collector per node (as a DaemonSet) plus one or more gateway Collector instances. In a multi-cloud setup, each cloud environment typically has its own Collector fleet. The "one Collector" mental model only applies to the simplest dev/test setups.</div>
+</div>
+
+<div class="question-block">
+  <div class="q">Q3: What are the standard OTel Collectors in AWS, GCP, Azure?</div>
+  <div class="a">See the table in Section 6. In short: <strong>AWS → ADOT</strong> (feeds X-Ray, CloudWatch), <strong>GCP → Google Cloud OTel Collector</strong> (feeds Cloud Trace, Cloud Monitoring with native OTLP), <strong>Azure → Azure Monitor OpenTelemetry Distro</strong> (feeds Application Insights, Azure Monitor). All are distributions of the upstream open-source OTel Collector with cloud-specific plugins.</div>
+</div>
+
+<div class="question-block">
+  <div class="q">Q4: If we want to inspect OTel data from a trace, can we integrate <em>with</em> the OTel Collector?</div>
+  <div class="a"><strong>Yes — this is the recommended approach.</strong> The customer's existing Collector is configured to add our OTLP endpoint as an additional exporter. Their Collector fans out data to their existing backend (e.g. Datadog) <em>and</em> to us simultaneously. We receive a copy of the telemetry; we don't intercept or modify the existing flow. This is a <strong>configuration change</strong> on the customer's Collector — no code changes in their applications.</div>
+</div>
+
+<div class="question-block">
+  <div class="q">Q5: Or must we <em>be</em> the OTel Collector?</div>
+  <div class="a"><strong>We can, but we don't have to.</strong> There are two viable architectures (see Section 8). We can either (a) <strong>be an OTLP receiver endpoint</strong> that the customer's Collector exports to, or (b) <strong>run our own Collector instance</strong> (as a downstream gateway) that receives data from their Collector, processes it for our needs, and feeds our backend. Option (a) is simpler; option (b) gives us more control over filtering and transformation. In neither case do we replace the customer's existing Collector.</div>
+</div>
+</section>
+
+<!-- FINOPS INTEGRATION -->
+<section id="finops">
+<h2>8. FinOps integration patterns: how we plug in</h2>
+
+<p>As a FinOps company, we have two primary integration architectures for consuming OTel trace data from customers. Both preserve the customer's existing observability setup.</p>
+
+<h3>Option A — OTLP receiver endpoint (simpler)</h3>
+<p>We expose an OTLP-compatible endpoint (gRPC on port 4317, HTTP on port 4318). The customer adds our endpoint as an additional exporter in their existing Collector configuration. We receive spans, process them in our own backend, and correlate them with cost data.</p>
+
+<div class="diagram-card">
+  <div class="diagram-title">Diagram 7 — Option A: We are an OTLP endpoint</div>
+  <pre class="mermaid">
+flowchart LR
+    App["Customer's<br/>applications"] -->|spans| CC["Customer's<br/>OTel Collector"]
+    CC -->|exporter 1| DD["Datadog /<br/>X-Ray / etc."]
+    CC -->|"exporter 2 (OTLP)"| US["Our OTLP<br/>endpoint<br/><i>finops.example.com:4317</i>"]
+    US --> DB["Our backend<br/><i>correlate traces<br/>with cost data</i>"]
+
+    style App fill:#E6F1FB,stroke:#85B7EB,color:#0C447C
+    style CC fill:#FAEEDA,stroke:#FAC775,color:#633806
+    style DD fill:#E1F5EE,stroke:#5DCAA5,color:#085041
+    style US fill:#EEEDFE,stroke:#AFA9EC,color:#3C3489
+    style DB fill:#EEEDFE,stroke:#AFA9EC,color:#3C3489
+  </pre>
+</div>
+
+<h3>Option B — Our own Collector gateway (more control)</h3>
+<p>We run our own OTel Collector instance as a downstream gateway. The customer's Collector exports to ours via OTLP. Our Collector can then apply FinOps-specific processing — filtering to only cost-relevant spans, enriching with our own attributes, sampling — before ingesting into our backend.</p>
+
+<div class="diagram-card">
+  <div class="diagram-title">Diagram 8 — Option B: We run a downstream Collector</div>
+  <pre class="mermaid">
+flowchart LR
+    App["Customer's<br/>applications"] -->|spans| CC["Customer's<br/>OTel Collector"]
+    CC -->|exporter 1| DD["Datadog /<br/>X-Ray / etc."]
+    CC -->|"exporter 2 (OTLP)"| OUR["Our OTel<br/>Collector<br/><i>gateway mode</i>"]
+    OUR -->|"filter + enrich"| DB["Our backend<br/><i>cost correlation</i>"]
+
+    subgraph Our_Infra["Our infrastructure"]
+        OUR
+        DB
+    end
+
+    style App fill:#E6F1FB,stroke:#85B7EB,color:#0C447C
+    style CC fill:#FAEEDA,stroke:#FAC775,color:#633806
+    style DD fill:#E1F5EE,stroke:#5DCAA5,color:#085041
+    style Our_Infra fill:#EEEDFE,stroke:#AFA9EC,color:#3C3489
+    style OUR fill:#EEEDFE,stroke:#AFA9EC,color:#3C3489
+    style DB fill:#EEEDFE,stroke:#AFA9EC,color:#3C3489
+  </pre>
+</div>
+
+<div class="callout finops">
+  <strong>FinOps-specific value:</strong> By receiving trace data, we can map individual request paths to cloud resource consumption. A span that shows <code>cloud.region = us-east-1</code>, <code>cloud.platform = aws_lambda</code>, and <code>finops.cost_center = team-alpha</code> lets us attribute the Lambda invocation cost to the specific team, service, and even API endpoint that triggered it.
+</div>
+
+<h3>What the customer needs to do</h3>
+<p>In either option, the customer change is minimal — they add a few lines to their Collector config:</p>
+
+<div style="background:#2C2C2A; color:#D3D1C7; border-radius:8px; padding:20px; margin:20px 0; font-family:'JetBrains Mono',monospace; font-size:13px; line-height:1.6; overflow-x:auto;">
+<pre style="margin:0;"><span style="color:#5DCAA5;">exporters:</span>
+  <span style="color:#85B7EB;">otlp/existing-backend:</span>
+    endpoint: datadog-agent:4317
+
+  <span style="color:#AFA9EC;">otlp/finops:                           # ← new</span>
+    <span style="color:#AFA9EC;">endpoint: finops.example.com:4317    # ← new</span>
+    <span style="color:#AFA9EC;">headers:                              # ← new</span>
+      <span style="color:#AFA9EC;">api-key: "${FINOPS_API_KEY}"       # ← new</span>
+
+<span style="color:#5DCAA5;">service:</span>
+  <span style="color:#85B7EB;">pipelines:</span>
+    <span style="color:#85B7EB;">traces:</span>
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/existing-backend, <span style="color:#AFA9EC;">otlp/finops</span>]  <span style="color:#888780;"># ← added</span>
+</pre>
+</div>
+</section>
+
+<!-- DECISION MATRIX -->
+<section id="decision">
+<h2>9. Decision matrix</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>Consideration</th>
+      <th>Option A: OTLP endpoint</th>
+      <th>Option B: Our Collector</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Setup complexity for us</td>
+      <td>Lower — build an OTLP-compatible ingestion API</td>
+      <td>Higher — deploy + operate a Collector fleet</td>
+    </tr>
+    <tr>
+      <td>Setup complexity for customer</td>
+      <td>Same (add exporter config)</td>
+      <td>Same (add exporter config)</td>
+    </tr>
+    <tr>
+      <td>Filtering / transformation</td>
+      <td>Done in our application code</td>
+      <td>Done in Collector config (more flexible, standard)</td>
+    </tr>
+    <tr>
+      <td>Data volume control</td>
+      <td>Customer controls sampling</td>
+      <td>We can add our own sampling layer</td>
+    </tr>
+    <tr>
+      <td>Protocol flexibility</td>
+      <td>OTLP only</td>
+      <td>Can also accept Jaeger, Zipkin, Prometheus</td>
+    </tr>
+    <tr>
+      <td>Best for</td>
+      <td>MVP / quick integration</td>
+      <td>Production scale / multi-tenant</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="callout answer">
+  <strong>Recommendation:</strong> Start with <strong>Option A</strong> (OTLP receiver endpoint) for the initial integration. It's the fastest path to receiving trace data and proving value. Migrate to <strong>Option B</strong> (our own Collector) as we scale and need finer-grained control over filtering, sampling, and multi-tenant processing.
+</div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <p>Prepared for leadership and engineering alignment. References: <a href="https://www.w3.org/TR/trace-context/">W3C Trace Context</a>, <a href="https://opentelemetry.io/docs/collector/">OTel Collector docs</a>, <a href="https://aws-otel.github.io/">ADOT</a>, <a href="https://learn.microsoft.com/en-us/azure/azure-monitor/app/opentelemetry">Azure OTel</a>, <a href="https://docs.cloud.google.com/stackdriver/docs/managed-prometheus/setup-otel">GCP OTel</a>.</p>
+</footer>
+
+</div>
+</body>
+</html>

--- a/src/__tests__/html-iframe-script.test.ts
+++ b/src/__tests__/html-iframe-script.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for the iframe selection script — the string that ships
+ * into the sandboxed HTML review iframe.
+ *
+ * We can't run the script inside a real iframe in vitest (jsdom
+ * has limited iframe support), so we evaluate it in the current
+ * jsdom window with a fake `window.parent` that captures the
+ * posted messages. That's enough to verify the contract:
+ *
+ *   - On mouseup with a non-empty selection, the script posts
+ *     a `mardoc-html-selection` message with text, startLine, endLine.
+ *   - When the selection endpoints walk up to tagged ancestors,
+ *     the reported lines match the attribute values.
+ *   - When no ancestor is tagged, the script posts nothing.
+ *   - Collapsed/empty selections post nothing.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { buildIframeSelectionScript } from "@/lib/html-selection";
+
+function runScript(): void {
+  // Evaluate the script in the jsdom context. The script is an
+  // IIFE so it runs immediately and installs its own listeners.
+  // We use the Function constructor instead of eval to keep
+  // strict-mode linting happy — the behavior is identical for
+  // this test's purposes.
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  new Function(buildIframeSelectionScript())();
+}
+
+function selectNodes(anchor: Node, focus: Node): void {
+  const sel = window.getSelection()!;
+  sel.removeAllRanges();
+  const range = document.createRange();
+  range.setStart(anchor, 0);
+  range.setEnd(focus, focus.nodeType === Node.TEXT_NODE ? (focus as Text).length : 1);
+  sel.addRange(range);
+}
+
+function dispatchMouseUp(): void {
+  const event = new MouseEvent("mouseup", { bubbles: true });
+  document.dispatchEvent(event);
+}
+
+describe("iframe selection script — postMessage contract", () => {
+  let postMessageSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    // Reset DOM and listeners between tests. jsdom shares
+    // document across tests in the same file, so we have to
+    // clear any listeners the previous test installed. The
+    // cleanest way is to replace the documentElement — but
+    // that's heavy. Instead, we reuse the document and rely on
+    // each test installing its own listeners via runScript(),
+    // and clearing the spy between tests.
+    document.body.innerHTML = "";
+    postMessageSpy = vi.fn();
+    // The script posts to window.parent — in jsdom, window.parent
+    // === window unless we override. Monkey-patch postMessage on
+    // the parent so we can observe calls.
+    Object.defineProperty(window.parent, "postMessage", {
+      value: postMessageSpy,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it("posts a selection message when the user selects tagged text", async () => {
+    document.body.innerHTML =
+      '<p data-mardoc-line="5">hello world selection target</p>';
+    const text = document.querySelector("p")!.firstChild!;
+
+    runScript();
+    selectNodes(text, text);
+    dispatchMouseUp();
+
+    // setTimeout(..., 0) inside the script defers the post
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(postMessageSpy).toHaveBeenCalledTimes(1);
+    const [message] = postMessageSpy.mock.calls[0];
+    expect(message.type).toBe("mardoc-html-selection");
+    expect(message.startLine).toBe(5);
+    expect(message.endLine).toBe(5);
+    expect(typeof message.text).toBe("string");
+    expect(message.text.length).toBeGreaterThan(0);
+  });
+
+  it("posts a multi-line range when the selection crosses elements", async () => {
+    document.body.innerHTML =
+      '<h1 data-mardoc-line="3">Title</h1>' +
+      '<p data-mardoc-line="5">Body text here</p>';
+    const h1Text = document.querySelector("h1")!.firstChild!;
+    const pText = document.querySelector("p")!.firstChild!;
+
+    runScript();
+    selectNodes(h1Text, pText);
+    dispatchMouseUp();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(postMessageSpy).toHaveBeenCalledTimes(1);
+    const [message] = postMessageSpy.mock.calls[0];
+    expect(message.startLine).toBe(3);
+    expect(message.endLine).toBe(5);
+  });
+
+  it("does NOT post when no ancestor has data-mardoc-line", async () => {
+    document.body.innerHTML = "<p>untagged content</p>";
+    const text = document.querySelector("p")!.firstChild!;
+
+    runScript();
+    selectNodes(text, text);
+    dispatchMouseUp();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(postMessageSpy).not.toHaveBeenCalled();
+  });
+
+  it("does NOT post on a collapsed selection", async () => {
+    document.body.innerHTML = '<p data-mardoc-line="2">text</p>';
+
+    runScript();
+    // Clear any selection
+    window.getSelection()!.removeAllRanges();
+    dispatchMouseUp();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(postMessageSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/html-selection-lines.test.ts
+++ b/src/__tests__/html-selection-lines.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Tests for resolving a selection inside a rendered HTML document
+ * back to a source line range.
+ *
+ * Contract:
+ *
+ *   1. The HTML has been pre-processed with
+ *      `injectSourceLineAttributes` so every element carries a
+ *      `data-mardoc-line="N"` attribute.
+ *   2. The user selects text inside the iframe. The anchor and
+ *      focus nodes of `window.getSelection()` may be text nodes.
+ *   3. `resolveSelectionSourceLines(anchor, focus)` walks up each
+ *      endpoint to the nearest ancestor element with a
+ *      `data-mardoc-line` attribute and returns the minimum and
+ *      maximum source lines.
+ *
+ * When the iframe script calls this function on the current
+ * selection and posts the result back to the parent, the parent
+ * drops the range directly into the comment submission pipeline
+ * — same shape `mapSelectionToLines` produces for markdown.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { resolveSelectionSourceLines } from "@/lib/html-selection";
+import { injectSourceLineAttributes } from "@/lib/html-source-lines";
+
+function setBody(html: string): HTMLElement {
+  document.body.innerHTML = html;
+  return document.body;
+}
+
+describe("resolveSelectionSourceLines — element endpoints", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("returns the line of a single tagged element", () => {
+    setBody('<p data-mardoc-line="5">hello</p>');
+    const p = document.querySelector("p")!;
+    expect(resolveSelectionSourceLines(p, p)).toEqual({
+      startLine: 5,
+      endLine: 5,
+    });
+  });
+
+  it("returns the range spanning two sibling elements", () => {
+    setBody(
+      '<h1 data-mardoc-line="3">Title</h1>' +
+        '<p data-mardoc-line="4">Body</p>'
+    );
+    const h1 = document.querySelector("h1")!;
+    const p = document.querySelector("p")!;
+    expect(resolveSelectionSourceLines(h1, p)).toEqual({
+      startLine: 3,
+      endLine: 4,
+    });
+  });
+
+  it("returns the range regardless of endpoint order (focus before anchor)", () => {
+    setBody(
+      '<h1 data-mardoc-line="3">Title</h1>' +
+        '<p data-mardoc-line="7">Body</p>'
+    );
+    const h1 = document.querySelector("h1")!;
+    const p = document.querySelector("p")!;
+    // Anchor at p (line 7), focus at h1 (line 3) — still {3,7}
+    expect(resolveSelectionSourceLines(p, h1)).toEqual({
+      startLine: 3,
+      endLine: 7,
+    });
+  });
+});
+
+describe("resolveSelectionSourceLines — text-node endpoints", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("walks up from a text node to its parent element's line", () => {
+    setBody('<p data-mardoc-line="10">hello world</p>');
+    const textNode = document.querySelector("p")!.firstChild!;
+    expect(textNode.nodeType).toBe(Node.TEXT_NODE);
+    expect(resolveSelectionSourceLines(textNode, textNode)).toEqual({
+      startLine: 10,
+      endLine: 10,
+    });
+  });
+
+  it("walks up from a nested text node through an untagged inline element", () => {
+    // The <strong> has no data-mardoc-line (inline injection could
+    // miss it, or the user modified HTML). The walker must keep
+    // going up until it finds a tagged ancestor.
+    setBody('<p data-mardoc-line="4"><strong>bold</strong> rest</p>');
+    const strong = document.querySelector("strong")!;
+    const textNode = strong.firstChild!;
+    expect(resolveSelectionSourceLines(textNode, textNode)).toEqual({
+      startLine: 4,
+      endLine: 4,
+    });
+  });
+});
+
+describe("resolveSelectionSourceLines — nested and multi-line", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("returns the child's line, not the container's, for a nested selection", () => {
+    setBody(
+      '<div data-mardoc-line="2">' +
+        '<h1 data-mardoc-line="3">Title</h1>' +
+        '<p data-mardoc-line="5">Body</p>' +
+        "</div>"
+    );
+    const h1 = document.querySelector("h1")!;
+    expect(resolveSelectionSourceLines(h1, h1)).toEqual({
+      startLine: 3,
+      endLine: 3,
+    });
+  });
+
+  it("returns the range across children of a shared container", () => {
+    setBody(
+      '<div data-mardoc-line="2">' +
+        '<h1 data-mardoc-line="3">Title</h1>' +
+        '<p data-mardoc-line="5">Body</p>' +
+        "</div>"
+    );
+    const h1 = document.querySelector("h1")!;
+    const p = document.querySelector("p")!;
+    expect(resolveSelectionSourceLines(h1, p)).toEqual({
+      startLine: 3,
+      endLine: 5,
+    });
+  });
+
+  it("handles deeply nested text-node endpoints", () => {
+    setBody(
+      '<article data-mardoc-line="1">' +
+        '<section data-mardoc-line="2">' +
+        '<p data-mardoc-line="8">final paragraph</p>' +
+        "</section>" +
+        "</article>"
+    );
+    const text = document.querySelector("p")!.firstChild!;
+    expect(resolveSelectionSourceLines(text, text)).toEqual({
+      startLine: 8,
+      endLine: 8,
+    });
+  });
+});
+
+describe("resolveSelectionSourceLines — end-to-end with injector", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("runs the injector on real HTML and resolves a selection on the result", () => {
+    const htmlSource = [
+      "<html>",
+      "<body>",
+      "<h1>Findings</h1>",
+      "<p>The system behaved as expected.</p>",
+      "<ul>",
+      "<li>Item one</li>",
+      "<li>Item two</li>",
+      "</ul>",
+      "</body>",
+      "</html>",
+    ].join("\n");
+
+    const injected = injectSourceLineAttributes(htmlSource);
+    document.body.innerHTML = injected;
+
+    // Simulate selecting "Item two" on line 7
+    const lis = document.querySelectorAll("li");
+    expect(lis.length).toBe(2);
+    const secondLi = lis[1];
+    const textNode = secondLi.firstChild!;
+    expect(resolveSelectionSourceLines(textNode, textNode)).toEqual({
+      startLine: 7,
+      endLine: 7,
+    });
+  });
+
+  it("resolves a multi-element selection on injected HTML", () => {
+    const htmlSource = [
+      "<html>",
+      "<body>",
+      "<h1>Findings</h1>",
+      "<p>Intro.</p>",
+      "<p>Body.</p>",
+      "<p>Closing.</p>",
+      "</body>",
+      "</html>",
+    ].join("\n");
+    const injected = injectSourceLineAttributes(htmlSource);
+    document.body.innerHTML = injected;
+
+    const paragraphs = document.querySelectorAll("p");
+    const startText = paragraphs[0].firstChild!; // p on line 4
+    const endText = paragraphs[2].firstChild!; // p on line 6
+    expect(resolveSelectionSourceLines(startText, endText)).toEqual({
+      startLine: 4,
+      endLine: 6,
+    });
+  });
+});
+
+describe("resolveSelectionSourceLines — degraded input", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("returns null when no ancestor has a data-mardoc-line attribute", () => {
+    // None of these elements are tagged (e.g. user-injected HTML
+    // without running the injector). The resolver returns null so
+    // the caller can surface a graceful fallback instead of
+    // attributing the comment to the wrong line.
+    setBody("<p>hello</p>");
+    const p = document.querySelector("p")!;
+    expect(resolveSelectionSourceLines(p, p)).toBeNull();
+  });
+
+  it("returns null for null endpoints", () => {
+    expect(resolveSelectionSourceLines(null, null)).toBeNull();
+  });
+});

--- a/src/__tests__/html-source-lines.test.ts
+++ b/src/__tests__/html-source-lines.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests for the HTML source-line attribute injector.
+ *
+ * This is the foundation of feature 033 (inline comments on HTML
+ * files). Before we can tell an iframe-sandboxed HTML document "tell
+ * me what line the user selected," we need every element to know
+ * what line it came from in the source. The injector walks the HTML
+ * source string and adds a `data-mardoc-line="N"` attribute to every
+ * element, where N is the 1-indexed line where its opening tag
+ * appears in the source.
+ *
+ * When a reviewer selects text in the rendered HTML, an injected
+ * iframe script walks up from the selection's container to the
+ * nearest ancestor with `data-mardoc-line` and postMessages that
+ * line number back to the parent, where it flows into the same
+ * comment-submission pipeline that markdown uses.
+ *
+ * These tests pin down the contract so the injector stays correct
+ * as the surface area grows. Every test is a specific invariant the
+ * HTML review flow depends on.
+ */
+import { describe, it, expect } from "vitest";
+import { injectSourceLineAttributes } from "@/lib/html-source-lines";
+
+describe("injectSourceLineAttributes — trivial", () => {
+  it("returns empty string for empty input", () => {
+    expect(injectSourceLineAttributes("")).toBe("");
+  });
+
+  it("returns plain text unchanged", () => {
+    expect(injectSourceLineAttributes("hello world")).toBe("hello world");
+  });
+
+  it("returns a string with no tags unchanged", () => {
+    const src = "line 1\nline 2\nline 3";
+    expect(injectSourceLineAttributes(src)).toBe(src);
+  });
+});
+
+describe("injectSourceLineAttributes — single element", () => {
+  it("tags a single-line element with its source line", () => {
+    const out = injectSourceLineAttributes("<p>hello</p>");
+    expect(out).toContain('data-mardoc-line="1"');
+    expect(out).toContain("<p");
+    expect(out).toContain(">hello</p>");
+  });
+
+  it("tags an element on line 3", () => {
+    const src = "\n\n<p>hello</p>";
+    const out = injectSourceLineAttributes(src);
+    expect(out).toMatch(/<p[^>]*data-mardoc-line="3"/);
+  });
+
+  it("preserves existing attributes", () => {
+    const out = injectSourceLineAttributes('<div class="foo" id="bar">x</div>');
+    expect(out).toContain('class="foo"');
+    expect(out).toContain('id="bar"');
+    expect(out).toContain('data-mardoc-line="1"');
+  });
+
+  it("does not add a duplicate attribute if one is already present", () => {
+    const src = '<p data-mardoc-line="99">already tagged</p>';
+    const out = injectSourceLineAttributes(src);
+    // Only one data-mardoc-line attribute on this element
+    const matches = out.match(/data-mardoc-line=/g) || [];
+    expect(matches.length).toBe(1);
+    // And the original value wasn't clobbered
+    expect(out).toContain('data-mardoc-line="99"');
+  });
+});
+
+describe("injectSourceLineAttributes — multiple elements", () => {
+  it("tags each of two consecutive elements with its own line", () => {
+    const src = "<h1>Title</h1>\n<p>Body</p>";
+    const out = injectSourceLineAttributes(src);
+    expect(out).toMatch(/<h1[^>]*data-mardoc-line="1"/);
+    expect(out).toMatch(/<p[^>]*data-mardoc-line="2"/);
+  });
+
+  it("tags nested elements with their own opening-tag lines", () => {
+    const src = "<div>\n  <p>inner</p>\n</div>";
+    const out = injectSourceLineAttributes(src);
+    expect(out).toMatch(/<div[^>]*data-mardoc-line="1"/);
+    expect(out).toMatch(/<p[^>]*data-mardoc-line="2"/);
+  });
+
+  it("tags elements in a realistic document", () => {
+    const src = [
+      "<!DOCTYPE html>",
+      "<html>",
+      "<head>",
+      "  <title>Report</title>",
+      "</head>",
+      "<body>",
+      "  <h1>Findings</h1>",
+      "  <p>The system behaved as expected.</p>",
+      "  <ul>",
+      "    <li>Item one</li>",
+      "    <li>Item two</li>",
+      "  </ul>",
+      "</body>",
+      "</html>",
+    ].join("\n");
+    const out = injectSourceLineAttributes(src);
+    // html on line 2
+    expect(out).toMatch(/<html[^>]*data-mardoc-line="2"/);
+    // head on line 3
+    expect(out).toMatch(/<head[^>]*data-mardoc-line="3"/);
+    // title on line 4
+    expect(out).toMatch(/<title[^>]*data-mardoc-line="4"/);
+    // h1 on line 7
+    expect(out).toMatch(/<h1[^>]*data-mardoc-line="7"/);
+    // p on line 8
+    expect(out).toMatch(/<p[^>]*data-mardoc-line="8"/);
+    // first li on line 10
+    expect(out).toMatch(/<li[^>]*data-mardoc-line="10"[^>]*>Item one/);
+    // second li on line 11
+    expect(out).toMatch(/<li[^>]*data-mardoc-line="11"[^>]*>Item two/);
+  });
+});
+
+describe("injectSourceLineAttributes — void / self-closing elements", () => {
+  it("tags a void element like <br>", () => {
+    const src = "first<br>\nsecond";
+    const out = injectSourceLineAttributes(src);
+    expect(out).toMatch(/<br[^>]*data-mardoc-line="1"/);
+  });
+
+  it("tags a self-closing element like <br/> without breaking it", () => {
+    const out = injectSourceLineAttributes("<p>a<br/>b</p>");
+    // The br element still closes correctly; the p still tags as line 1
+    expect(out).toMatch(/<br[^>]*data-mardoc-line="1"[^>]*\/>/);
+    expect(out).toMatch(/<p[^>]*data-mardoc-line="1"/);
+  });
+
+  it("tags <img src=...> with its source line", () => {
+    const out = injectSourceLineAttributes('<img src="x.png" alt="x">');
+    expect(out).toContain('src="x.png"');
+    expect(out).toContain('alt="x"');
+    expect(out).toContain('data-mardoc-line="1"');
+  });
+});
+
+describe("injectSourceLineAttributes — skip regions", () => {
+  it("does NOT inject inside HTML comments", () => {
+    const out = injectSourceLineAttributes("<!-- <p>hidden</p> -->\n<p>real</p>");
+    // The commented-out <p> should NOT be tagged
+    const commentMatches =
+      (out.match(/<!--[\s\S]*?-->/g) || []).join("");
+    expect(commentMatches).not.toContain("data-mardoc-line");
+    // The real <p> on line 2 should be tagged
+    expect(out).toMatch(/<p[^>]*data-mardoc-line="2"/);
+  });
+
+  it("does NOT inject inside <script> tag content", () => {
+    const src = [
+      "<script>",
+      'var html = "<p>not real</p>";',
+      "</script>",
+      "<p>real</p>",
+    ].join("\n");
+    const out = injectSourceLineAttributes(src);
+    // The <script> itself is tagged
+    expect(out).toMatch(/<script[^>]*data-mardoc-line="1"/);
+    // The <p> on line 4 is tagged
+    expect(out).toMatch(/<p[^>]*data-mardoc-line="4"/);
+    // The <p> inside the script string is NOT tagged
+    const scriptBody = out.match(/<script[^>]*>([\s\S]*?)<\/script>/);
+    expect(scriptBody).not.toBeNull();
+    expect(scriptBody![1]).not.toContain("data-mardoc-line");
+  });
+
+  it("does NOT inject inside <style> tag content", () => {
+    const src = [
+      "<style>",
+      "p::before { content: '<p>'; }",
+      "</style>",
+      "<p>real</p>",
+    ].join("\n");
+    const out = injectSourceLineAttributes(src);
+    expect(out).toMatch(/<style[^>]*data-mardoc-line="1"/);
+    expect(out).toMatch(/<p[^>]*data-mardoc-line="4"/);
+    const styleBody = out.match(/<style[^>]*>([\s\S]*?)<\/style>/);
+    expect(styleBody).not.toBeNull();
+    expect(styleBody![1]).not.toContain("data-mardoc-line");
+  });
+
+  it("does NOT inject inside the DOCTYPE declaration", () => {
+    const out = injectSourceLineAttributes("<!DOCTYPE html>\n<html></html>");
+    // The DOCTYPE is untouched
+    expect(out).toContain("<!DOCTYPE html>");
+    // The html on line 2 is tagged
+    expect(out).toMatch(/<html[^>]*data-mardoc-line="2"/);
+  });
+});
+
+describe("injectSourceLineAttributes — attribute-value edge cases", () => {
+  it("does not break on attributes containing > inside quotes", () => {
+    const src = '<a title="1 > 0">link</a>';
+    const out = injectSourceLineAttributes(src);
+    expect(out).toContain('title="1 > 0"');
+    expect(out).toContain('data-mardoc-line="1"');
+    // The tag is not prematurely closed
+    expect(out).toContain("link</a>");
+  });
+
+  it("does not break on attributes containing newlines", () => {
+    const src = '<div\n  class="foo"\n  id="bar">x</div>';
+    const out = injectSourceLineAttributes(src);
+    // The tag started on line 1 — that's what gets reported
+    expect(out).toMatch(/data-mardoc-line="1"/);
+    expect(out).toContain('class="foo"');
+    expect(out).toContain('id="bar"');
+  });
+
+  it("preserves the closing > character", () => {
+    const out = injectSourceLineAttributes("<p>x</p>");
+    // The injection should not eat or duplicate the closing >
+    const opens = (out.match(/<p[^>]*>/g) || []).length;
+    expect(opens).toBe(1);
+  });
+});
+
+describe("injectSourceLineAttributes — round trip", () => {
+  it("the injected HTML still parses as the same DOM shape", () => {
+    const src = "<div><h1>A</h1><p>B</p></div>";
+    const out = injectSourceLineAttributes(src);
+    // Strip all data-mardoc-line attrs and confirm we get the
+    // original back. Whitespace is preserved byte-for-byte except
+    // for the injected attribute.
+    const stripped = out.replace(/\s*data-mardoc-line="\d+"/g, "");
+    expect(stripped).toBe(src);
+  });
+
+  it("preserves every non-attribute byte in the source", () => {
+    const src = "<html>\n  <body>\n    <p>hello\nworld</p>\n  </body>\n</html>\n";
+    const out = injectSourceLineAttributes(src);
+    const stripped = out.replace(/\s*data-mardoc-line="\d+"/g, "");
+    expect(stripped).toBe(src);
+  });
+});

--- a/src/__tests__/readme-claims.test.ts
+++ b/src/__tests__/readme-claims.test.ts
@@ -30,6 +30,8 @@ import { mapSelectionToLines } from "@/lib/github-api";
 import { mergeFreshComments } from "@/lib/comment-merge";
 import { buildSuggestionBody, parseSuggestionBody } from "@/lib/suggestion-body";
 import { isLineResolutionError } from "@/lib/review-fallback";
+import { injectSourceLineAttributes } from "@/lib/html-source-lines";
+import { resolveSelectionSourceLines } from "@/lib/html-selection";
 import type { PRComment } from "@/types";
 
 // ─── Claim: "rich, formatted documents — not raw text with + and -" ──
@@ -263,6 +265,68 @@ describe("README claim: posted back to GitHub as an inline review comment", () =
         message: "Review Can not approve your own pull request",
       })
     ).toBe(false);
+  });
+});
+
+// ─── Claim: "markdown and HTML" — HTML review parity ────────────────
+
+describe("README claim: HTML files support the same review flow as markdown", () => {
+  // The README says MarDoc works on "any `.md` or `.html` file in a
+  // pull request". Feature 033 makes the select-passage/leave-a-comment
+  // flow work on HTML. These tests pin the load-bearing invariants.
+
+  const htmlSource = [
+    "<!DOCTYPE html>",
+    "<html>",
+    "<body>",
+    "<h1>Findings</h1>",
+    "<p>The system behaved as expected.</p>",
+    "<ul>",
+    "<li>Item one</li>",
+    "<li>Item two</li>",
+    "</ul>",
+    "</body>",
+    "</html>",
+  ].join("\n");
+
+  it("HTML source can be tagged with per-element source-line attributes", () => {
+    const injected = injectSourceLineAttributes(htmlSource);
+    // Every element opening tag carries a data-mardoc-line
+    expect(injected).toMatch(/<h1[^>]*data-mardoc-line="4"/);
+    expect(injected).toMatch(/<p[^>]*data-mardoc-line="5"/);
+    expect(injected).toMatch(/<li[^>]*data-mardoc-line="7"/);
+    expect(injected).toMatch(/<li[^>]*data-mardoc-line="8"/);
+  });
+
+  it("a selection in a tagged HTML document resolves to the correct source-line range", () => {
+    const injected = injectSourceLineAttributes(htmlSource);
+    document.body.innerHTML = injected;
+
+    // User selects "Item one" (li on source line 7)
+    const firstLi = document.querySelectorAll("li")[0];
+    const textNode = firstLi.firstChild!;
+    const range = resolveSelectionSourceLines(textNode, textNode);
+    expect(range).toEqual({ startLine: 7, endLine: 7 });
+  });
+
+  it("a multi-element HTML selection produces a range spanning both source lines", () => {
+    const injected = injectSourceLineAttributes(htmlSource);
+    document.body.innerHTML = injected;
+
+    // User drags from the h1 (line 4) to the p (line 5)
+    const h1Text = document.querySelector("h1")!.firstChild!;
+    const pText = document.querySelector("p")!.firstChild!;
+    const range = resolveSelectionSourceLines(h1Text, pText);
+    expect(range).toEqual({ startLine: 4, endLine: 5 });
+  });
+
+  it("injected HTML is still byte-identical to the source after stripping the attribute", () => {
+    // Round-trip guarantee: injection doesn't reformat the source in
+    // any way a reviewer would notice. The rendered output matches
+    // the reviewer's expectations of the file they pushed.
+    const injected = injectSourceLineAttributes(htmlSource);
+    const stripped = injected.replace(/\s*data-mardoc-line="\d+"/g, "");
+    expect(stripped).toBe(htmlSource);
   });
 });
 

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -47,6 +47,8 @@ import { renderMermaidBlocks } from "@/lib/mermaid";
 import { highlightCodeBlocks } from "@/lib/highlight";
 import { useWideFormat } from "@/lib/use-wide-format";
 import { isHtmlFile } from "@/lib/file-types";
+import { injectSourceLineAttributes } from "@/lib/html-source-lines";
+import { buildIframeSelectionScript } from "@/lib/html-selection";
 import { extractCommentSuggestions, mergeSuggestions } from "@/lib/suggestion-extract";
 import { parseSuggestionBody } from "@/lib/suggestion-body";
 
@@ -695,6 +697,13 @@ export default function DiffViewer({
   const [activeCommentId, setActiveCommentId] = useState<string | null>(null);
   const [pendingSelection, setPendingSelection] = useState<string | null>(null);
   const [pendingCommentInput, setPendingCommentInput] = useState("");
+  // Pre-computed source-line range for the pending selection — set
+  // when the selection comes from the HTML review iframe (which has
+  // the data-mardoc-line attributes to resolve lines exactly).
+  // Markdown selections still compute the range via mapSelectionToLines
+  // at submit time.
+  const [pendingSelectionRange, setPendingSelectionRange] =
+    useState<{ startLine: number; endLine: number } | null>(null);
 
   // Suggest mode state
   const [pendingSuggestions, setPendingSuggestions] = useState<PendingSuggestion[]>([]);
@@ -716,27 +725,57 @@ export default function DiffViewer({
     renderMermaidBlocks(contentRef.current);
   }, [file, viewMode, fileIsHtml, comments]);
 
-  // Listen for iframe resize messages (HTML file rendering)
+  // Listen for iframe messages (HTML file rendering):
+  //   - mardoc-iframe-resize: auto-size the iframe to its content
+  //   - mardoc-html-selection: user selected text inside the iframe,
+  //     flow it into the pending-comment pipeline
   useEffect(() => {
     if (!fileIsHtml) return;
     const iframe = htmlIframeRef.current;
-    if (!iframe) return;
     const handleMessage = (event: MessageEvent) => {
-      if (event.data?.type === "mardoc-iframe-resize" && typeof event.data.height === "number") {
-        iframe.style.height = `${event.data.height + 20}px`;
+      const data = event.data;
+      if (!data || typeof data !== "object") return;
+
+      if (data.type === "mardoc-iframe-resize" && typeof data.height === "number" && iframe) {
+        iframe.style.height = `${data.height + 20}px`;
+        return;
+      }
+
+      if (data.type === "mardoc-html-selection" && typeof data.text === "string") {
+        // Only accept selections from our own iframe
+        if (iframe && event.source !== iframe.contentWindow) return;
+        const startLine = typeof data.startLine === "number" ? data.startLine : 1;
+        const endLine = typeof data.endLine === "number" ? data.endLine : startLine;
+        setPendingSelection(data.text);
+        setPendingSelectionRange({ startLine, endLine });
+        setShowPanel(true);
       }
     };
     window.addEventListener("message", handleMessage);
     return () => window.removeEventListener("message", handleMessage);
   }, [fileIsHtml, htmlViewMode, htmlShowBase]);
 
-  // Prepare HTML srcdoc with injected resize script
+  // Prepare HTML srcdoc with injected source-line attributes,
+  // resize script, and selection listener. Source-line injection
+  // tags every element with `data-mardoc-line` so that when a user
+  // selects text inside the iframe, the selection script can walk
+  // up to find the source line and postMessage it to the parent.
   const htmlSrcdoc = useMemo(() => {
     if (!fileIsHtml) return "";
     const raw = htmlShowBase ? file.baseContent : file.headContent;
+    // Inject per-element source line attributes. Only on the head
+    // (new) view — we don't need comment-target lines on the base
+    // since comments always target the head revision.
+    const tagged = htmlShowBase ? raw : injectSourceLineAttributes(raw);
     const resizeScript = `<script>(function(){function p(){window.parent.postMessage({type:'mardoc-iframe-resize',height:document.documentElement.scrollHeight},'*')}window.addEventListener('load',function(){setTimeout(p,100)});new MutationObserver(p).observe(document.body,{childList:true,subtree:true,attributes:true});setTimeout(p,500);setTimeout(p,2000)})()</script>`;
-    if (raw.includes("</body>")) return raw.replace("</body>", `${resizeScript}</body>`);
-    return raw + resizeScript;
+    // Only attach the selection listener in head view — base is
+    // reference-only and shouldn't accept comments.
+    const selectionScript = htmlShowBase
+      ? ""
+      : `<script>${buildIframeSelectionScript()}</script>`;
+    const injected = resizeScript + selectionScript;
+    if (tagged.includes("</body>")) return tagged.replace("</body>", `${injected}</body>`);
+    return tagged + injected;
   }, [fileIsHtml, file.baseContent, file.headContent, htmlShowBase]);
 
   // Simple source diff for HTML files
@@ -1001,15 +1040,28 @@ export default function DiffViewer({
   const submitSelectionComment = useCallback(() => {
     if (!pendingSelection || !pendingCommentInput.trim()) return;
 
-    // Map selected text to line numbers in the head content
-    const { startLine, endLine } = mapSelectionToLines(file.headContent, pendingSelection);
+    // If we already have a source-line range (from the HTML iframe
+    // selection listener — which resolves lines exactly via
+    // data-mardoc-line attributes), trust it. Otherwise fall back
+    // to fuzzy-matching the selected text against the source, which
+    // is how the markdown flow has always worked.
+    const { startLine, endLine } =
+      pendingSelectionRange ??
+      mapSelectionToLines(file.headContent, pendingSelection);
 
     // Let PRDetail handle state + GitHub API — it flows back through the comments prop
     onAddComment(0, pendingCommentInput.trim(), pendingSelection, startLine, endLine);
 
     setPendingSelection(null);
+    setPendingSelectionRange(null);
     setPendingCommentInput("");
-  }, [pendingSelection, pendingCommentInput, file.headContent, onAddComment]);
+  }, [
+    pendingSelection,
+    pendingSelectionRange,
+    pendingCommentInput,
+    file.headContent,
+    onAddComment,
+  ]);
 
   const handleReply = useCallback((commentId: string, body: string) => {
     if (onReplyComment) {
@@ -1251,6 +1303,7 @@ export default function DiffViewer({
                   }
                   if (e.key === "Escape") {
                     setPendingSelection(null);
+                    setPendingSelectionRange(null);
                     setPendingCommentInput("");
                   }
                 }}
@@ -1265,6 +1318,7 @@ export default function DiffViewer({
               <button
                 onClick={() => {
                   setPendingSelection(null);
+                  setPendingSelectionRange(null);
                   setPendingCommentInput("");
                 }}
                 className="text-xs px-2 py-1.5 text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"

--- a/src/lib/html-selection.ts
+++ b/src/lib/html-selection.ts
@@ -1,0 +1,138 @@
+/**
+ * Selection resolution for HTML review (feature 033).
+ *
+ * Paired with `injectSourceLineAttributes`: the injector pre-tags
+ * every element in the HTML source with `data-mardoc-line="N"`,
+ * and this module walks from a selection endpoint up to the
+ * nearest tagged ancestor to recover the source line.
+ *
+ * The logic runs in two places:
+ *
+ *   1. Unit-testable via jsdom (this file).
+ *   2. Inside the review iframe itself, bundled into a string by
+ *      `buildIframeSelectionScript` and injected into the
+ *      sandboxed `srcdoc`. The script runs the same walk on the
+ *      iframe's live DOM and postMessages the result to the
+ *      parent app.
+ *
+ * Keep the script self-contained (no imports, no closures over
+ * outside state) so it can be serialized into the srcdoc.
+ */
+
+export interface SourceLineRange {
+  startLine: number;
+  endLine: number;
+}
+
+/**
+ * Walk up from a selection endpoint to the nearest ancestor
+ * element carrying `data-mardoc-line`. Returns the combined line
+ * range spanning both endpoints. Returns `null` if no tagged
+ * ancestor exists for either endpoint (degraded input — the
+ * caller should surface an error, not guess).
+ */
+export function resolveSelectionSourceLines(
+  anchor: Node | null,
+  focus: Node | null
+): SourceLineRange | null {
+  if (!anchor || !focus) return null;
+
+  const anchorLine = findSourceLine(anchor);
+  const focusLine = findSourceLine(focus);
+
+  if (anchorLine === null || focusLine === null) return null;
+
+  return {
+    startLine: Math.min(anchorLine, focusLine),
+    endLine: Math.max(anchorLine, focusLine),
+  };
+}
+
+function findSourceLine(node: Node): number | null {
+  let current: Node | null = node;
+  while (current) {
+    if (current.nodeType === 1 /* ELEMENT_NODE */) {
+      const el = current as Element;
+      const attr = el.getAttribute("data-mardoc-line");
+      if (attr) {
+        const parsed = parseInt(attr, 10);
+        if (!isNaN(parsed)) return parsed;
+      }
+    }
+    current = current.parentNode;
+  }
+  return null;
+}
+
+/**
+ * Build the script string that runs inside the HTML review iframe.
+ *
+ * The script:
+ *   1. Listens for `mouseup` and `selectionchange`
+ *   2. Reads the current selection
+ *   3. Walks anchor and focus up to the nearest tagged ancestor
+ *   4. Posts `{type: "mardoc-html-selection", text, startLine, endLine}`
+ *      back to the parent window
+ *
+ * The parent listens for this message in `DiffViewer` and flows the
+ * selection into the same pending-comment pipeline that markdown
+ * uses, so the inline comment lands on the correct source line.
+ */
+export function buildIframeSelectionScript(): string {
+  return `
+(function() {
+  // If a previous install exists (HMR, re-renders, srcdoc refreshes),
+  // abort its listeners before wiring new ones.
+  if (window.__mardocHtmlSelectionAbort) {
+    window.__mardocHtmlSelectionAbort.abort();
+  }
+  var controller = new AbortController();
+  window.__mardocHtmlSelectionAbort = controller;
+
+  function findLine(node) {
+    var cur = node;
+    while (cur) {
+      if (cur.nodeType === 1 && cur.getAttribute) {
+        var attr = cur.getAttribute('data-mardoc-line');
+        if (attr) {
+          var n = parseInt(attr, 10);
+          if (!isNaN(n)) return n;
+        }
+      }
+      cur = cur.parentNode;
+    }
+    return null;
+  }
+
+  function postSelection() {
+    var sel = window.getSelection();
+    if (!sel || sel.isCollapsed) return;
+    var text = sel.toString();
+    if (!text || !text.trim()) return;
+
+    var anchorLine = findLine(sel.anchorNode);
+    var focusLine = findLine(sel.focusNode);
+    if (anchorLine === null || focusLine === null) return;
+
+    var startLine = Math.min(anchorLine, focusLine);
+    var endLine = Math.max(anchorLine, focusLine);
+
+    window.parent.postMessage({
+      type: 'mardoc-html-selection',
+      text: text,
+      startLine: startLine,
+      endLine: endLine
+    }, '*');
+  }
+
+  // Fire on mouseup (end of drag) and touchend (mobile) — not on
+  // selectionchange because it fires too often during drag.
+  document.addEventListener('mouseup', function() {
+    setTimeout(postSelection, 0);
+  }, { signal: controller.signal });
+  document.addEventListener('touchend', function() {
+    setTimeout(postSelection, 0);
+  }, { signal: controller.signal });
+})();
+`;
+}

--- a/src/lib/html-source-lines.ts
+++ b/src/lib/html-source-lines.ts
@@ -1,0 +1,233 @@
+/**
+ * Walks an HTML source string and injects a `data-mardoc-line="N"`
+ * attribute on every element's opening tag, where N is the 1-indexed
+ * line number the tag starts on in the source.
+ *
+ * Used by feature 033 (inline comments on HTML files). When the
+ * rendered HTML is loaded into the review iframe, a companion script
+ * walks up from the user's selection to the nearest ancestor with a
+ * `data-mardoc-line` attribute and postMessages the line number to
+ * the parent. That line number feeds the same comment-submission
+ * pipeline that markdown uses, so an inline comment on HTML lands
+ * on the correct source range.
+ *
+ * The injector is careful to preserve the source byte-for-byte
+ * except for the new attribute — whitespace, ordering, and
+ * existing attributes are untouched. It skips HTML comments,
+ * DOCTYPE declarations, and the bodies of `<script>` and `<style>`
+ * tags so that text that looks like HTML inside those regions is
+ * not mistaken for real elements.
+ */
+
+const ATTR_NAME = "data-mardoc-line";
+
+export function injectSourceLineAttributes(source: string): string {
+  if (!source) return "";
+
+  let out = "";
+  let i = 0;
+  let line = 1;
+  const len = source.length;
+
+  while (i < len) {
+    const ch = source[i];
+
+    // Track newlines in pass-through text
+    if (ch === "\n") {
+      out += ch;
+      line++;
+      i++;
+      continue;
+    }
+
+    // HTML comment: <!-- ... -->
+    if (startsWith(source, i, "<!--")) {
+      const end = source.indexOf("-->", i + 4);
+      if (end === -1) {
+        const rest = source.slice(i);
+        out += rest;
+        line += countNewlines(rest);
+        i = len;
+        break;
+      }
+      const chunk = source.slice(i, end + 3);
+      out += chunk;
+      line += countNewlines(chunk);
+      i = end + 3;
+      continue;
+    }
+
+    // DOCTYPE or processing instruction: <! ... > or <? ... >
+    if (
+      ch === "<" &&
+      i + 1 < len &&
+      (source[i + 1] === "!" || source[i + 1] === "?")
+    ) {
+      const end = source.indexOf(">", i);
+      if (end === -1) {
+        const rest = source.slice(i);
+        out += rest;
+        line += countNewlines(rest);
+        i = len;
+        break;
+      }
+      const chunk = source.slice(i, end + 1);
+      out += chunk;
+      line += countNewlines(chunk);
+      i = end + 1;
+      continue;
+    }
+
+    // Closing tag: </tagname>
+    if (ch === "<" && i + 1 < len && source[i + 1] === "/") {
+      const end = source.indexOf(">", i);
+      if (end === -1) {
+        const rest = source.slice(i);
+        out += rest;
+        line += countNewlines(rest);
+        i = len;
+        break;
+      }
+      const chunk = source.slice(i, end + 1);
+      out += chunk;
+      line += countNewlines(chunk);
+      i = end + 1;
+      continue;
+    }
+
+    // Opening tag: <tagname ...>
+    if (ch === "<" && i + 1 < len && isTagNameStart(source[i + 1])) {
+      const tagStartLine = line;
+      const tagStart = i;
+
+      // Read tag name
+      let j = i + 1;
+      while (j < len && isTagNameChar(source[j])) j++;
+      const tagName = source.slice(i + 1, j);
+
+      // Walk through attributes until the matching ">", respecting
+      // quoted attribute values (which may contain > or newlines)
+      let inQuote: '"' | "'" | null = null;
+      let end = -1;
+      while (j < len) {
+        const c = source[j];
+        if (inQuote) {
+          if (c === inQuote) inQuote = null;
+          if (c === "\n") line++;
+          j++;
+          continue;
+        }
+        if (c === '"' || c === "'") {
+          inQuote = c;
+          j++;
+          continue;
+        }
+        if (c === ">") {
+          end = j;
+          break;
+        }
+        if (c === "\n") line++;
+        j++;
+      }
+
+      if (end === -1) {
+        // Malformed — emit the rest and stop
+        out += source.slice(tagStart);
+        i = len;
+        break;
+      }
+
+      // The chunk from `<` up to and including `>`
+      const tagBody = source.slice(tagStart, end + 1);
+      const injected = addAttribute(tagBody, tagStartLine);
+      out += injected;
+      i = end + 1;
+
+      // Skip raw-text element bodies: <script> and <style> contents
+      // are not HTML and must not be rescanned
+      const lower = tagName.toLowerCase();
+      if (lower === "script" || lower === "style") {
+        const closing = `</${lower}`;
+        // Find the closing tag case-insensitively
+        const remaining = source.slice(i);
+        const lowerRemaining = remaining.toLowerCase();
+        const closeIdx = lowerRemaining.indexOf(closing);
+        if (closeIdx === -1) {
+          // Unterminated — dump the rest as raw text
+          out += remaining;
+          line += countNewlines(remaining);
+          i = len;
+          break;
+        }
+        const body = remaining.slice(0, closeIdx);
+        out += body;
+        line += countNewlines(body);
+        i += closeIdx;
+      }
+
+      continue;
+    }
+
+    // Default: pass-through character
+    out += ch;
+    i++;
+  }
+
+  return out;
+}
+
+/**
+ * Insert the `data-mardoc-line` attribute into a tag body (the
+ * full `<tagname ... >` string). If the tag already has the
+ * attribute, returns it unchanged. Otherwise inserts the attribute
+ * just before the closing `>` (or before a trailing `/` for a
+ * self-closing tag).
+ */
+function addAttribute(tagBody: string, lineNumber: number): string {
+  if (tagBody.includes(`${ATTR_NAME}=`)) return tagBody;
+
+  // tagBody looks like `<tagname...>`
+  // Strip the leading `<` and trailing `>` to work on the interior
+  const interior = tagBody.slice(1, -1);
+  const attr = `${ATTR_NAME}="${lineNumber}"`;
+
+  // Self-closing: `<br />` or `<br/>`
+  const selfClosingMatch = interior.match(/^(.*?)(\s*\/)$/s);
+  if (selfClosingMatch) {
+    const [, body, tail] = selfClosingMatch;
+    const spacer = body.endsWith(" ") || body.length === 0 ? "" : " ";
+    return `<${body}${spacer}${attr}${tail}>`;
+  }
+
+  // Normal opening tag: append before the closing `>`
+  const spacer = interior.endsWith(" ") || interior.length === 0 ? "" : " ";
+  return `<${interior}${spacer}${attr}>`;
+}
+
+function startsWith(source: string, offset: number, needle: string): boolean {
+  if (offset + needle.length > source.length) return false;
+  for (let k = 0; k < needle.length; k++) {
+    if (source[offset + k] !== needle[k]) return false;
+  }
+  return true;
+}
+
+function isTagNameStart(ch: string): boolean {
+  return (ch >= "a" && ch <= "z") || (ch >= "A" && ch <= "Z");
+}
+
+function isTagNameChar(ch: string): boolean {
+  return (
+    isTagNameStart(ch) ||
+    (ch >= "0" && ch <= "9") ||
+    ch === "-" ||
+    ch === "_" ||
+    ch === ":"
+  );
+}
+
+function countNewlines(s: string): number {
+  let n = 0;
+  for (let k = 0; k < s.length; k++) if (s[k] === "\n") n++;
+  return n;
+}

--- a/src/lib/html-source-lines.ts
+++ b/src/lib/html-source-lines.ts
@@ -192,7 +192,7 @@ function addAttribute(tagBody: string, lineNumber: number): string {
   const attr = `${ATTR_NAME}="${lineNumber}"`;
 
   // Self-closing: `<br />` or `<br/>`
-  const selfClosingMatch = interior.match(/^(.*?)(\s*\/)$/s);
+  const selfClosingMatch = interior.match(/^([\s\S]*?)(\s*\/)$/);
   if (selfClosingMatch) {
     const [, body, tail] = selfClosingMatch;
     const spacer = body.endsWith(" ") || body.length === 0 ? "" : " ";


### PR DESCRIPTION
## Summary

Implements feature 033 — the select-passage-and-comment flow now works on HTML files the same way it works on markdown. This closes the #1 HTML parity gap and makes the README's "markdown **and HTML**" claim load-bearing instead of aspirational.

Three new modules + wiring:

- **\`src/lib/html-source-lines.ts\`** — walks an HTML source string and injects \`data-mardoc-line=\"N\"\` on every element's opening tag, where N is the 1-indexed source line. Skips HTML comments, DOCTYPE, and \`<script>\`/\`<style>\` bodies. Preserves the source byte-for-byte.
- **\`src/lib/html-selection.ts\`** — \`resolveSelectionSourceLines(anchor, focus)\` walks selection endpoints up to the nearest tagged ancestor. \`buildIframeSelectionScript()\` returns a self-contained string that runs inside the sandboxed review iframe and postMessages \`{type: 'mardoc-html-selection', text, startLine, endLine}\` back to the parent on \`mouseup\`/\`touchend\`.
- **\`DiffViewer.tsx\`** — pipes head content through the injector before rendering, attaches the selection script, listens for the new message type, and flows the selection into the existing pending-comment pipeline.

The parent-side change is minimal: a new \`pendingSelectionRange\` state that \`submitSelectionComment\` uses when set (the HTML iframe path) and falls back to \`mapSelectionToLines\` when null (the markdown path). Existing comment submission, batching, resolution, and reply flows work unchanged.

## What the reviewer gets

Open an HTML file in a PR → click Rendered → highlight any passage → the existing \"Commenting on selected text\" bar appears at the top with the exact selection → type a comment → it queues in the review → submit batches them into a single GitHub inline review comment tied to the correct source lines.

## Test plan

- [x] \`html-source-lines.test.ts\` — 22 unit tests for the injector (single/multi/nested elements, void and self-closing tags, skip regions for comments/script/style, attribute-value edge cases, round-trip byte preservation)
- [x] \`html-selection-lines.test.ts\` — 12 unit tests for \`resolveSelectionSourceLines\` (element endpoints, text-node endpoints, nested, multi-line, end-to-end with the injector, degraded input)
- [x] \`html-iframe-script.test.ts\` — 4 integration tests for the shipped iframe script's postMessage contract (single-element post, multi-line range, untagged-ancestor no-op, collapsed-selection no-op)
- [x] \`readme-claims.test.ts\` — 4 new acceptance tests for the HTML review claim
- [x] Full suite: **602 passing, 5 expected-fail** (up from 560/3), no regressions
- [x] \`npm run build\` clean

## Out of scope (deferred follow-ons)

- **Comment pins rendered over the iframe** — existing comments currently appear in the side panel (they always did for HTML), not as visual pins on the rendered document. Adding pin overlays needs a second injected script that walks the DOM, paints highlights by \`data-mardoc-line\` match, and posts click events back. Tracked as a follow-up, not blocking this PR.
- **Word-level prose diff for HTML** — feature 034
- **WYSIWYG editing of HTML** — feature 035
- **Suggestion round-trip for HTML** — feature 036
- **PWA claim backing** — still deferred (3 \`it.fails\` in readme-claims.test.ts)

Feature doc: \`docs/features/033-html-inline-comments.md\` (merged earlier in a docs-only commit).

Also included in this branch: future feature docs for **037 AI page translation** and **038 cellphone mode viewer** — captured proactively per user direction so they're on the record.