### PR TITLE
feat: mobile 'Comment on selection' button (feature 038)

### DIFF
--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -51,6 +51,7 @@ import { injectSourceLineAttributes } from "@/lib/html-source-lines";
 import { buildIframeSelectionScript } from "@/lib/html-selection";
 import { useIsMobile } from "@/lib/use-viewport";
 import BottomSheet from "./BottomSheet";
+import MobileCommentButton from "./MobileCommentButton";
 import { extractCommentSuggestions, mergeSuggestions } from "@/lib/suggestion-extract";
 import { parseSuggestionBody } from "@/lib/suggestion-body";
 
@@ -169,9 +170,11 @@ function FloatingToolbar({
 
   if (!pos || !text) return null;
 
+  // Hidden on mobile — the native iOS/Android selection callout
+  // covers this toolbar. MobileCommentButton replaces it.
   return (
     <div
-      className="absolute z-40"
+      className="absolute z-40 hidden md:block"
       style={{ top: `${pos.top}px`, left: `${pos.left}px`, transform: "translateX(-50%)" }}
     >
       <button
@@ -1871,6 +1874,16 @@ export default function DiffViewer({
             }}
           />
         </BottomSheet>
+      )}
+
+      {/* Mobile: fixed "Comment on selection" button at the bottom of
+          the viewport. Replaces the FloatingToolbar which is hidden on
+          mobile because the native OS selection callout covers it. */}
+      {isMobile && (
+        <MobileCommentButton
+          containerRef={contentRef}
+          onComment={handleSelectionComment}
+        />
       )}
     </div>
   );

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -80,6 +80,7 @@ import RichFindReplaceBar from "./RichFindReplaceBar";
 import type { Match as FindMatch } from "@/lib/find-replace";
 import Outline from "./Outline";
 import MobileDrawer from "./MobileDrawer";
+import MobileCommentButton from "./MobileCommentButton";
 import { useIsMobile } from "@/lib/use-viewport";
 import { MARDOC_OPEN_FIND_EVENT } from "@/lib/tiptap-search-extension";
 import {
@@ -275,9 +276,10 @@ function FloatingCommentButton({
 
   if (!pos || !text) return null;
 
+  // Hidden on mobile — MobileCommentButton replaces it.
   return (
     <div
-      className="absolute z-50"
+      className="absolute z-50 hidden md:block"
       style={{ top: pos.top, left: pos.left }}
     >
       <button
@@ -2164,11 +2166,18 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
               )}
             </div>
 
-            {/* Floating comment button */}
+            {/* Floating comment button (desktop) */}
             <FloatingCommentButton
               containerRef={editorContainerRef}
               onComment={handleStartComment}
             />
+            {/* Mobile: fixed button at the bottom of the viewport */}
+            {isMobile && (
+              <MobileCommentButton
+                containerRef={editorContainerRef}
+                onComment={handleStartComment}
+              />
+            )}
 
             {/* Link / image edit bubble */}
             {!codeView && (

--- a/src/components/MobileCommentButton.tsx
+++ b/src/components/MobileCommentButton.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { MessageSquarePlus } from "lucide-react";
+
+interface MobileCommentButtonProps {
+  containerRef: React.RefObject<HTMLElement | null>;
+  onComment: (text: string) => void;
+}
+
+/**
+ * A fixed-position "Comment on selection" button that sits at the
+ * bottom of the viewport on mobile. Replaces the FloatingToolbar
+ * (which fights with the native iOS/Android selection callout) with
+ * a button that works WITH the OS selection UI: the user selects
+ * text, sees the native Cut/Copy/Paste callout, and taps this button
+ * below it to open the comment flow.
+ *
+ * Only visible when there's a valid selection (3+ characters) inside
+ * the container. Uses `selectionchange` to track state without
+ * fighting the native selection handles.
+ *
+ * Hidden on desktop (md:hidden) — the FloatingToolbar handles that.
+ */
+export default function MobileCommentButton({
+  containerRef,
+  onComment,
+}: MobileCommentButtonProps) {
+  const [hasSelection, setHasSelection] = useState(false);
+  const selectionText = useRef("");
+
+  const check = useCallback(() => {
+    const sel = window.getSelection();
+    if (!sel || sel.isCollapsed) {
+      setHasSelection(false);
+      selectionText.current = "";
+      return;
+    }
+    const text = sel.toString().trim();
+    if (text.length < 3) {
+      setHasSelection(false);
+      return;
+    }
+    const container = containerRef.current;
+    if (!container) {
+      setHasSelection(false);
+      return;
+    }
+    try {
+      const range = sel.getRangeAt(0);
+      if (!container.contains(range.commonAncestorContainer)) {
+        setHasSelection(false);
+        return;
+      }
+    } catch {
+      setHasSelection(false);
+      return;
+    }
+    selectionText.current = text;
+    setHasSelection(true);
+  }, [containerRef]);
+
+  useEffect(() => {
+    document.addEventListener("selectionchange", check);
+    return () => document.removeEventListener("selectionchange", check);
+  }, [check]);
+
+  if (!hasSelection) return null;
+
+  return (
+    <button
+      onClick={() => {
+        const text = selectionText.current;
+        if (text) {
+          onComment(text);
+          window.getSelection()?.removeAllRanges();
+          setHasSelection(false);
+        }
+      }}
+      className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 md:hidden flex items-center gap-2 px-5 py-3.5 bg-[var(--accent)] text-white text-sm font-medium rounded-full"
+      style={{
+        boxShadow: "0 8px 24px -4px rgba(0,0,0,0.4), 0 0 0 1px rgba(0,0,0,0.1)",
+        animation: "fadeInUp 0.2s ease-out",
+      }}
+    >
+      <MessageSquarePlus size={16} />
+      Comment on selection
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

On mobile, the native iOS/Android text selection callout (Cut/Copy/Paste) covers the FloatingToolbar, making it untappable. This replaces it with a fixed-position pill button at the bottom of the viewport that works WITH the OS selection UI.

**Flow:** select text → see the OS callout → tap "Comment on selection" at the bottom → opens the comment input.

- `MobileCommentButton.tsx` — shared by DiffViewer + Editor, tracks selection via `selectionchange`, 44px+ touch target, `md:hidden`
- FloatingToolbar (DiffViewer) and FloatingCommentButton (Editor) get `hidden md:block` — desktop-only now

## Test plan
- [x] 626 tests / build clean
- [ ] iPhone: select text in a rendered doc → "Comment on selection" pill appears at the bottom → tap → comment input opens
- [ ] iPhone: deselect → pill disappears
- [ ] Desktop: FloatingToolbar still appears above the selection as before