### PR TITLE
fix: rate-limit circuit breaker for GitHub API calls

### DIFF
--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  markRateLimited,
+  isRateLimited,
+  clearRateLimit,
+  updateFromHeaders,
+  isRateLimitError,
+  extractResetFromError,
+  getRateLimitInfo,
+} from "@/lib/rate-limit";
+
+beforeEach(() => {
+  clearRateLimit();
+});
+
+describe("rate-limit circuit breaker", () => {
+  it("is not rate-limited by default", () => {
+    expect(isRateLimited()).toBe(false);
+  });
+
+  it("pauses for 60s when markRateLimited is called without a reset timestamp", () => {
+    markRateLimited();
+    expect(isRateLimited()).toBe(true);
+  });
+
+  it("pauses until a specific epoch when markRateLimited is given a reset timestamp", () => {
+    const futureEpochSec = Math.floor(Date.now() / 1000) + 3600;
+    markRateLimited(futureEpochSec);
+    expect(isRateLimited()).toBe(true);
+    expect(getRateLimitInfo().resetsAt).toBe(futureEpochSec * 1000);
+  });
+
+  it("unpauses after the reset time passes", () => {
+    const pastEpochSec = Math.floor(Date.now() / 1000) - 10;
+    markRateLimited(pastEpochSec);
+    expect(isRateLimited()).toBe(false);
+  });
+
+  it("clearRateLimit resets everything", () => {
+    markRateLimited();
+    expect(isRateLimited()).toBe(true);
+    clearRateLimit();
+    expect(isRateLimited()).toBe(false);
+    expect(getRateLimitInfo().remaining).toBeNull();
+  });
+});
+
+describe("updateFromHeaders", () => {
+  it("tracks remaining and limit from response headers", () => {
+    updateFromHeaders({
+      "x-ratelimit-remaining": "4999",
+      "x-ratelimit-limit": "5000",
+      "x-ratelimit-reset": "9999999999",
+    });
+    const info = getRateLimitInfo();
+    expect(info.remaining).toBe(4999);
+    expect(info.limit).toBe(5000);
+    expect(info.isLimited).toBe(false);
+  });
+
+  it("triggers the circuit breaker when remaining hits 0", () => {
+    const resetEpoch = Math.floor(Date.now() / 1000) + 3600;
+    updateFromHeaders({
+      "x-ratelimit-remaining": "0",
+      "x-ratelimit-limit": "5000",
+      "x-ratelimit-reset": String(resetEpoch),
+    });
+    expect(isRateLimited()).toBe(true);
+    expect(getRateLimitInfo().resetsAt).toBe(resetEpoch * 1000);
+  });
+
+  it("does not trigger when remaining is above 0", () => {
+    updateFromHeaders({
+      "x-ratelimit-remaining": "1",
+      "x-ratelimit-limit": "5000",
+      "x-ratelimit-reset": "9999999999",
+    });
+    expect(isRateLimited()).toBe(false);
+  });
+});
+
+describe("isRateLimitError", () => {
+  it("detects a 429 status", () => {
+    expect(isRateLimitError({ status: 429, message: "Too many requests" })).toBe(true);
+  });
+
+  it("detects a 403 with rate limit message", () => {
+    expect(
+      isRateLimitError({
+        status: 403,
+        message: "API rate limit exceeded for user ID 123",
+      })
+    ).toBe(true);
+  });
+
+  it("does NOT flag a 403 without rate limit in the message", () => {
+    expect(
+      isRateLimitError({ status: 403, message: "Resource not accessible" })
+    ).toBe(false);
+  });
+
+  it("does NOT flag a 401", () => {
+    expect(isRateLimitError({ status: 401, message: "Bad credentials" })).toBe(false);
+  });
+
+  it("handles null/undefined gracefully", () => {
+    expect(isRateLimitError(null)).toBe(false);
+    expect(isRateLimitError(undefined)).toBe(false);
+  });
+});
+
+describe("extractResetFromError", () => {
+  it("extracts the reset epoch from an error with response headers", () => {
+    expect(
+      extractResetFromError({
+        status: 403,
+        message: "rate limit",
+        response: { headers: { "x-ratelimit-reset": "1700000000" } },
+      })
+    ).toBe(1700000000);
+  });
+
+  it("returns undefined for errors without headers", () => {
+    expect(extractResetFromError({ status: 403 })).toBeUndefined();
+  });
+});

--- a/src/components/PRDetail.tsx
+++ b/src/components/PRDetail.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import { PullRequest, PRComment, PendingSuggestion } from "@/types";
 import { useApp } from "@/lib/app-context";
+import { isRateLimited, isRateLimitError, markRateLimited, extractResetFromError } from "@/lib/rate-limit";
 import {
   createPRComment,
   replyToReviewComment,
@@ -76,11 +77,14 @@ export default function PRDetail({ pr, onBack }: PRDetailProps) {
   // to @/lib/comment-merge and covered by comment-merge.test.ts.
   const refreshFromGitHub = useCallback(async () => {
     if (isDemoMode || !currentRepo || !pr.number) return;
+    if (isRateLimited()) return;
     try {
       const fresh = await fetchPRComments(currentRepo, pr.number);
       setComments((prev) => mergeFreshComments(prev, fresh));
-    } catch {
-      // Silently skip — the next poll or retry will catch up.
+    } catch (err) {
+      if (isRateLimitError(err)) {
+        markRateLimited(extractResetFromError(err));
+      }
     }
   }, [isDemoMode, currentRepo, pr.number]);
 
@@ -91,7 +95,7 @@ export default function PRDetail({ pr, onBack }: PRDetailProps) {
   const scheduleRefreshHedge = useCallback(() => {
     for (const delay of [1500, 4000, 8000]) {
       setTimeout(() => {
-        void refreshFromGitHub();
+        if (!isRateLimited()) void refreshFromGitHub();
       }, delay);
     }
   }, [refreshFromGitHub]);

--- a/src/lib/app-context.tsx
+++ b/src/lib/app-context.tsx
@@ -328,7 +328,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
           setPRList((prev) =>
             prev.map((p) => ({ ...p, mdFileCount: counts.get(p.number) ?? 0 }))
           );
-        });
+        }).catch(() => {});
       }
     } catch (err: any) {
       console.error("Failed to load PRs:", err);

--- a/src/lib/github-api.ts
+++ b/src/lib/github-api.ts
@@ -5,11 +5,35 @@ import { RepoFile, PullRequest, PRFile, PRComment } from "@/types";
 import { isDocumentFile } from "@/lib/file-types";
 import { utf8ToBase64, base64ToUtf8 } from "@/lib/base64-utf8";
 import { isLineResolutionError, runInlineFallback } from "@/lib/review-fallback";
+import {
+  updateFromHeaders,
+  isRateLimitError,
+  markRateLimited,
+  extractResetFromError,
+} from "@/lib/rate-limit";
 
 let octokitInstance: Octokit | null = null;
 
 export function initOctokit(token: string) {
   octokitInstance = new Octokit({ auth: token });
+
+  // Track rate-limit headers on every response so the circuit
+  // breaker can proactively pause before we get a hard 403.
+  octokitInstance.hook.after("request", (_response, options) => {
+    const headers = (options as any)?.request?.headers ?? ((_response as any)?.headers);
+    if (headers) updateFromHeaders(headers);
+  });
+
+  // When an API call fails with a rate-limit error, mark the
+  // breaker so the 30s poll and propagation hedge stop firing.
+  octokitInstance.hook.error("request", (error) => {
+    if (isRateLimitError(error)) {
+      const reset = extractResetFromError(error);
+      markRateLimited(reset);
+    }
+    throw error;
+  });
+
   return octokitInstance;
 }
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,102 @@
+/**
+ * Rate-limit circuit breaker for GitHub API calls.
+ *
+ * The GitHub REST API returns a 403 with "rate limit exceeded" when
+ * the token's hourly quota is spent (5,000 for authenticated users).
+ * Responses also include `x-ratelimit-remaining` and
+ * `x-ratelimit-reset` headers so callers can proactively avoid
+ * wasting requests.
+ *
+ * This module tracks the rate-limit state globally. When a 403/429
+ * is detected (either from the error or from the headers), it sets
+ * a `pausedUntil` timestamp and every caller that checks
+ * `isRateLimited()` before firing will skip the request. The 30s
+ * comment poll in PRDetail.tsx and the propagation hedge are the
+ * main consumers — they were burning 4+ requests per minute into
+ * the limit with no backoff.
+ */
+
+let pausedUntil = 0;
+let remaining: number | null = null;
+let limit: number | null = null;
+
+export function markRateLimited(resetEpochSec?: number) {
+  if (resetEpochSec && resetEpochSec > 0) {
+    pausedUntil = resetEpochSec * 1000;
+  } else {
+    pausedUntil = Date.now() + 60_000;
+  }
+}
+
+export function isRateLimited(): boolean {
+  if (Date.now() < pausedUntil) return true;
+  if (pausedUntil > 0 && Date.now() >= pausedUntil) {
+    pausedUntil = 0;
+    remaining = null;
+  }
+  return false;
+}
+
+export function rateLimitResetsAt(): number {
+  return pausedUntil;
+}
+
+export function clearRateLimit() {
+  pausedUntil = 0;
+  remaining = null;
+  limit = null;
+}
+
+export function getRateLimitInfo(): {
+  remaining: number | null;
+  limit: number | null;
+  resetsAt: number;
+  isLimited: boolean;
+} {
+  return {
+    remaining,
+    limit,
+    resetsAt: pausedUntil,
+    isLimited: isRateLimited(),
+  };
+}
+
+/**
+ * Called after every successful Octokit response to track the
+ * remaining quota. When remaining hits 0, proactively pauses
+ * before the server starts returning 403s — this is the "soft
+ * circuit breaker" that keeps the poll from wasting the last
+ * few requests.
+ */
+export function updateFromHeaders(headers: Record<string, string | undefined>) {
+  const rem = headers["x-ratelimit-remaining"];
+  const lim = headers["x-ratelimit-limit"];
+  const reset = headers["x-ratelimit-reset"];
+
+  if (rem !== undefined) remaining = parseInt(rem, 10);
+  if (lim !== undefined) limit = parseInt(lim, 10);
+
+  if (remaining !== null && remaining <= 0 && reset) {
+    markRateLimited(parseInt(reset, 10));
+  }
+}
+
+export function isRateLimitError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const e = error as { status?: number; message?: string; response?: { headers?: Record<string, string> } };
+  if (e.status === 429) return true;
+  if (e.status === 403 && typeof e.message === "string" && e.message.toLowerCase().includes("rate limit")) return true;
+  return false;
+}
+
+/**
+ * Extract the reset timestamp from a rate-limit error response.
+ * Returns undefined if the error doesn't include one.
+ */
+export function extractResetFromError(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const e = error as { response?: { headers?: Record<string, string> } };
+  const reset = e.response?.headers?.["x-ratelimit-reset"];
+  if (reset) return parseInt(reset, 10);
+  return undefined;
+}


### PR DESCRIPTION
## Summary

Fixes the API quota burn that rate-limited the user yesterday. The 30s comment poll and propagation hedge were firing 4+ requests/minute with no backoff — when rate-limited, they silently failed and retried forever.

**New module:** `src/lib/rate-limit.ts` — global circuit breaker that tracks `x-ratelimit-remaining`/`reset` headers. When the quota is spent, `isRateLimited()` returns true and all poll/hedge callers skip their requests until the reset time passes.

**Wiring:**
- Octokit init hooks read rate-limit headers from every response and mark the breaker on 403/429
- PRDetail's `refreshFromGitHub` checks `isRateLimited()` before each call
- PRDetail's `scheduleRefreshHedge` skips delayed calls when rate-limited
- `fetchPRMarkdownCounts` fire-and-forget now has a `.catch()`

15 new tests for the rate-limit module. 641 total green, build clean.

Addresses feature 024 (GitHub API Error Handling and Resilience).