### PR TITLE
refactor: extract NewFileModal + EditPRModal from Editor.tsx (PR C)

### DIFF
--- a/src/__tests__/editor-modals.test.ts
+++ b/src/__tests__/editor-modals.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Characterization tests for NewFileModal and EditPRModal.
+ *
+ * Both modals were extracted from Editor.tsx as presentational
+ * components. These tests pin the observable contract — what
+ * renders, what the buttons do, when they're disabled — so future
+ * refactors of Editor.tsx or the modals themselves can't silently
+ * regress the save/commit/PR flow.
+ */
+import React from "react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import NewFileModal from "@/components/NewFileModal";
+import EditPRModal from "@/components/EditPRModal";
+
+const e = React.createElement;
+
+afterEach(() => cleanup());
+
+// ─── NewFileModal ────────────────────────────────────────────────────
+
+function mountNewFile(
+  overrides: Partial<React.ComponentProps<typeof NewFileModal>> = {}
+) {
+  return render(
+    e(NewFileModal, {
+      open: true,
+      onClose: () => {},
+      filePath: "",
+      onFilePathChange: () => {},
+      title: "",
+      onTitleChange: () => {},
+      isAddingToPR: false,
+      isDemoMode: false,
+      saving: false,
+      error: null,
+      onSubmit: () => {},
+      ...overrides,
+    } as React.ComponentProps<typeof NewFileModal>)
+  );
+}
+
+describe("NewFileModal — render gate", () => {
+  it("renders nothing when open=false", () => {
+    const { container } = mountNewFile({ open: false });
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders the dialog when open=true", () => {
+    mountNewFile({ open: true });
+    expect(screen.getByText("Save to Repository")).toBeTruthy();
+  });
+});
+
+describe("NewFileModal — fresh-PR mode (not adding to existing)", () => {
+  it("shows File path and PR title inputs", () => {
+    mountNewFile({ isAddingToPR: false });
+    expect(screen.getByText("File path")).toBeTruthy();
+    expect(screen.getByText("PR title")).toBeTruthy();
+  });
+
+  it("shows 'Create PR' button label", () => {
+    mountNewFile({ isAddingToPR: false });
+    expect(screen.getByText("Create PR")).toBeTruthy();
+  });
+
+  it("disables submit when filePath is empty", () => {
+    mountNewFile({ isAddingToPR: false, filePath: "", title: "my title" });
+    const btn = screen.getByText("Create PR").closest("button") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("disables submit when title is empty", () => {
+    mountNewFile({ isAddingToPR: false, filePath: "docs/x.md", title: "" });
+    const btn = screen.getByText("Create PR").closest("button") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("enables submit when both filePath and title are set", () => {
+    mountNewFile({ isAddingToPR: false, filePath: "docs/x.md", title: "Add docs" });
+    const btn = screen.getByText("Create PR").closest("button") as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+  });
+
+  it(".md-append hint appears when path doesn't end in .md", () => {
+    mountNewFile({ filePath: "docs/x" });
+    expect(screen.getByText(/.md will be appended/)).toBeTruthy();
+  });
+
+  it("no .md-append hint when path already ends in .md", () => {
+    mountNewFile({ filePath: "docs/x.md" });
+    expect(screen.queryByText(/.md will be appended/)).toBeNull();
+  });
+});
+
+describe("NewFileModal — adding-to-PR mode", () => {
+  it("shows PR number in the header", () => {
+    mountNewFile({
+      isAddingToPR: true,
+      addingToPRNumber: 42,
+      addingToPRBranch: "feat/docs",
+    });
+    expect(screen.getByText(/PR #42/)).toBeTruthy();
+  });
+
+  it("shows the target branch name", () => {
+    mountNewFile({
+      isAddingToPR: true,
+      addingToPRNumber: 42,
+      addingToPRBranch: "feat/docs",
+    });
+    expect(screen.getByText("feat/docs")).toBeTruthy();
+  });
+
+  it("hides the PR title input (commit doesn't need a new PR title)", () => {
+    mountNewFile({ isAddingToPR: true });
+    expect(screen.queryByText("PR title")).toBeNull();
+  });
+
+  it("shows 'Commit to PR' button label", () => {
+    mountNewFile({ isAddingToPR: true });
+    expect(screen.getByText("Commit to PR")).toBeTruthy();
+  });
+
+  it("enables submit when filePath is set even if title is empty", () => {
+    mountNewFile({
+      isAddingToPR: true,
+      filePath: "docs/x.md",
+      title: "",
+    });
+    const btn = screen.getByText("Commit to PR").closest("button") as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+  });
+});
+
+describe("NewFileModal — demo mode", () => {
+  it("shows demo-mode warning banner", () => {
+    mountNewFile({ isDemoMode: true });
+    expect(screen.getByText(/Connect a GitHub repository/i)).toBeTruthy();
+  });
+
+  it("disables submit when in demo mode even with valid inputs", () => {
+    mountNewFile({
+      isDemoMode: true,
+      filePath: "docs/x.md",
+      title: "Add",
+    });
+    const btn = screen.getByText("Create PR").closest("button") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+});
+
+describe("NewFileModal — saving state", () => {
+  it("shows 'Committing...' label while saving", () => {
+    mountNewFile({
+      saving: true,
+      filePath: "docs/x.md",
+      title: "Add",
+    });
+    expect(screen.getByText("Committing...")).toBeTruthy();
+  });
+
+  it("disables submit while saving", () => {
+    mountNewFile({
+      saving: true,
+      filePath: "docs/x.md",
+      title: "Add",
+    });
+    const btn = screen.getByText("Committing...").closest("button") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+});
+
+describe("NewFileModal — error and interactions", () => {
+  it("displays an error message when error is set", () => {
+    mountNewFile({ error: "Branch name already exists" });
+    expect(screen.getByText("Branch name already exists")).toBeTruthy();
+  });
+
+  it("onClose fires when Cancel is clicked", () => {
+    const onClose = vi.fn();
+    mountNewFile({ onClose });
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("onFilePathChange fires on input change", () => {
+    const onFilePathChange = vi.fn();
+    mountNewFile({ onFilePathChange });
+    const input = screen.getByPlaceholderText(/docs\/my-document/);
+    fireEvent.change(input, { target: { value: "README.md" } });
+    expect(onFilePathChange).toHaveBeenCalledWith("README.md");
+  });
+
+  it("Enter in the path input fires onSubmit when the submit would be enabled", () => {
+    const onSubmit = vi.fn();
+    mountNewFile({
+      onSubmit,
+      filePath: "docs/x.md",
+      title: "Add docs",
+    });
+    const input = screen.getByPlaceholderText(/docs\/my-document/);
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("Enter does NOT fire onSubmit when inputs are incomplete", () => {
+    const onSubmit = vi.fn();
+    mountNewFile({ onSubmit, filePath: "", title: "" });
+    const input = screen.getByPlaceholderText(/docs\/my-document/);
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});
+
+// ─── EditPRModal ─────────────────────────────────────────────────────
+
+function mountEditPR(
+  overrides: Partial<React.ComponentProps<typeof EditPRModal>> = {}
+) {
+  return render(
+    e(EditPRModal, {
+      open: true,
+      onClose: () => {},
+      title: "",
+      onTitleChange: () => {},
+      isLocalFile: false,
+      filePath: "README.md",
+      editFilePath: "",
+      onEditFilePathChange: () => {},
+      submitting: false,
+      error: null,
+      onSubmit: () => {},
+      ...overrides,
+    } as React.ComponentProps<typeof EditPRModal>)
+  );
+}
+
+describe("EditPRModal — render gate", () => {
+  it("renders nothing when open=false", () => {
+    const { container } = mountEditPR({ open: false });
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders the dialog when open=true", () => {
+    mountEditPR({ open: true });
+    expect(screen.getByText("Submit Edits as PR")).toBeTruthy();
+  });
+});
+
+describe("EditPRModal — repo-file mode", () => {
+  it("does NOT show the file-path input", () => {
+    mountEditPR({ isLocalFile: false, filePath: "README.md" });
+    expect(screen.queryByText("File path in repo")).toBeNull();
+  });
+
+  it("shows the source filePath in the description", () => {
+    mountEditPR({ isLocalFile: false, filePath: "docs/foo.md" });
+    expect(screen.getByText("docs/foo.md")).toBeTruthy();
+  });
+
+  it("enables submit when title is set", () => {
+    mountEditPR({ isLocalFile: false, title: "Fix typo" });
+    const btn = screen.getByText("Create PR").closest("button") as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+  });
+
+  it("disables submit when title is empty", () => {
+    mountEditPR({ isLocalFile: false, title: "" });
+    const btn = screen.getByText("Create PR").closest("button") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+});
+
+describe("EditPRModal — local-file mode", () => {
+  it("shows the file-path input for local files", () => {
+    mountEditPR({ isLocalFile: true, editFilePath: "docs/new.md" });
+    expect(screen.getByText("File path in repo")).toBeTruthy();
+  });
+
+  it("shows the local-file description text", () => {
+    mountEditPR({ isLocalFile: true });
+    expect(screen.getByText(/This local file will be committed/i)).toBeTruthy();
+  });
+
+  it("disables submit when editFilePath is empty", () => {
+    mountEditPR({
+      isLocalFile: true,
+      editFilePath: "",
+      title: "Add new",
+    });
+    const btn = screen.getByText("Create PR").closest("button") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("disables submit when title is empty", () => {
+    mountEditPR({
+      isLocalFile: true,
+      editFilePath: "docs/new.md",
+      title: "",
+    });
+    const btn = screen.getByText("Create PR").closest("button") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("enables submit when both editFilePath and title are set", () => {
+    mountEditPR({
+      isLocalFile: true,
+      editFilePath: "docs/new.md",
+      title: "Add new doc",
+    });
+    const btn = screen.getByText("Create PR").closest("button") as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+  });
+});
+
+describe("EditPRModal — submitting state", () => {
+  it("shows 'Creating...' label while submitting", () => {
+    mountEditPR({ submitting: true, title: "Update" });
+    expect(screen.getByText("Creating...")).toBeTruthy();
+  });
+
+  it("disables submit while submitting", () => {
+    mountEditPR({ submitting: true, title: "Update" });
+    const btn = screen.getByText("Creating...").closest("button") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+});
+
+describe("EditPRModal — error and interactions", () => {
+  it("displays error message when error is set", () => {
+    mountEditPR({ error: "API rate limit" });
+    expect(screen.getByText("API rate limit")).toBeTruthy();
+  });
+
+  it("onClose fires on Cancel", () => {
+    const onClose = vi.fn();
+    mountEditPR({ onClose });
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("onTitleChange fires on title input change", () => {
+    const onTitleChange = vi.fn();
+    mountEditPR({ onTitleChange });
+    const input = screen.getByPlaceholderText(/Update README/);
+    fireEvent.change(input, { target: { value: "Fix grammar" } });
+    expect(onTitleChange).toHaveBeenCalledWith("Fix grammar");
+  });
+
+  it("Enter in the title input fires onSubmit", () => {
+    const onSubmit = vi.fn();
+    mountEditPR({ onSubmit, title: "Update docs" });
+    const input = screen.getByPlaceholderText(/Update README/);
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("Enter does NOT fire onSubmit when title is empty", () => {
+    const onSubmit = vi.fn();
+    mountEditPR({ onSubmit, title: "" });
+    const input = screen.getByPlaceholderText(/Update README/);
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/EditPRModal.tsx
+++ b/src/components/EditPRModal.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import React from "react";
+import { GitPullRequest, Loader2 } from "lucide-react";
+
+export interface EditPRModalProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  onTitleChange: (value: string) => void;
+  /** True when the current edit is on a local-only file (no repo path yet). */
+  isLocalFile: boolean;
+  /** For repo files: the existing path. For local files: unused (editFilePath drives instead). */
+  filePath: string;
+  editFilePath: string;
+  onEditFilePathChange: (value: string) => void;
+  submitting: boolean;
+  error: string | null;
+  onSubmit: () => void;
+}
+
+/**
+ * Presentational modal for submitting edits to an existing file as a
+ * new PR. Supports both repo files (filePath is fixed) and local
+ * files (user enters a target path). Parent Editor passes in all
+ * state and handlers.
+ */
+export default function EditPRModal({
+  open,
+  onClose,
+  title,
+  onTitleChange,
+  isLocalFile,
+  filePath,
+  editFilePath,
+  onEditFilePathChange,
+  submitting,
+  error,
+  onSubmit,
+}: EditPRModalProps) {
+  if (!open) return null;
+
+  const canSubmit =
+    !submitting && title.trim() && (!isLocalFile || editFilePath.trim());
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div
+        className="bg-[var(--surface)] border border-[var(--border)] rounded-xl shadow-2xl w-[420px] p-5"
+        style={{ animation: "fadeInUp 0.15s ease-out" }}
+      >
+        <h3 className="text-sm font-semibold text-[var(--text-primary)] mb-4 flex items-center gap-2">
+          <GitPullRequest size={16} className="text-[var(--accent)]" />
+          Submit Edits as PR
+        </h3>
+
+        <p className="text-xs text-[var(--text-secondary)] mb-3">
+          {isLocalFile ? (
+            "This local file will be committed on a new branch and opened as a pull request."
+          ) : (
+            <>
+              Your changes to{" "}
+              <span className="font-mono text-[var(--text-primary)]">{filePath}</span>{" "}
+              will be committed on a new branch and opened as a pull request.
+            </>
+          )}
+        </p>
+
+        <div className="space-y-3">
+          {isLocalFile && (
+            <div>
+              <label className="text-[10px] font-medium text-[var(--text-muted)] uppercase tracking-wider mb-1 block">
+                File path in repo
+              </label>
+              <input
+                autoFocus
+                type="text"
+                value={editFilePath}
+                onChange={(e) => onEditFilePathChange(e.target.value)}
+                placeholder="docs/my-document.md"
+                className="w-full text-sm px-3 py-2 rounded-md border border-[var(--border)] bg-[var(--surface-secondary)] text-[var(--text-primary)] font-mono placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)]"
+              />
+            </div>
+          )}
+          <div>
+            <label className="text-[10px] font-medium text-[var(--text-muted)] uppercase tracking-wider mb-1 block">
+              PR title
+            </label>
+            <input
+              autoFocus={!isLocalFile}
+              type="text"
+              value={title}
+              onChange={(e) => onTitleChange(e.target.value)}
+              placeholder={isLocalFile ? `Add ${editFilePath}` : `Update ${filePath}`}
+              className="w-full text-sm px-3 py-2 rounded-md border border-[var(--border)] bg-[var(--surface-secondary)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)]"
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && canSubmit) onSubmit();
+              }}
+            />
+          </div>
+
+          {error && <p className="text-xs text-red-500">{error}</p>}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 mt-5">
+          <button
+            onClick={onClose}
+            className="text-xs px-3 py-1.5 text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onSubmit}
+            disabled={!canSubmit}
+            className="flex items-center gap-1.5 text-xs px-4 py-1.5 bg-[var(--accent)] text-white rounded-md hover:bg-[var(--accent-hover)] disabled:opacity-40 transition-colors"
+          >
+            {submitting ? <Loader2 size={13} className="animate-spin" /> : <GitPullRequest size={13} />}
+            {submitting ? "Creating..." : "Create PR"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -82,6 +82,8 @@ import Outline from "./Outline";
 import MobileDrawer from "./MobileDrawer";
 import MobileCommentButton from "./MobileCommentButton";
 import LinkImageBubble, { type BubbleTarget } from "./LinkImageBubble";
+import NewFileModal from "./NewFileModal";
+import EditPRModal from "./EditPRModal";
 import { useIsMobile } from "@/lib/use-viewport";
 import { MARDOC_OPEN_FIND_EVENT } from "@/lib/tiptap-search-extension";
 import {
@@ -1931,183 +1933,35 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
         />
       )}
 
-      {/* New file save modal */}
-      {showNewFileModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-          <div
-            className="bg-[var(--surface)] border border-[var(--border)] rounded-xl shadow-2xl w-[420px] p-5"
-            style={{ animation: "fadeInUp 0.15s ease-out" }}
-          >
-            <h3 className="text-sm font-semibold text-[var(--text-primary)] mb-4 flex items-center gap-2">
-              <GitPullRequest size={16} className="text-[var(--accent)]" />
-              {isAddingToPR ? `Add File to PR #${prNumberForNewFile}` : "Save to Repository"}
-            </h3>
+      <NewFileModal
+        open={showNewFileModal}
+        onClose={() => { setShowNewFileModal(false); setSubmitError(null); }}
+        filePath={newFilePath}
+        onFilePathChange={setNewFilePath}
+        title={newFileTitle}
+        onTitleChange={setNewFileTitle}
+        isAddingToPR={isAddingToPR}
+        addingToPRNumber={prNumberForNewFile}
+        addingToPRBranch={prBranchForNewFile}
+        isDemoMode={isDemoMode}
+        saving={savingNewFile}
+        error={submitError}
+        onSubmit={handleSaveNewFile}
+      />
 
-            {isAddingToPR && (
-              <p className="text-xs text-[var(--text-secondary)] mb-3">
-                Committing to branch <span className="font-mono text-[var(--text-primary)]">{prBranchForNewFile}</span>
-              </p>
-            )}
-
-            <div className="space-y-3">
-              <div>
-                <label className="text-[10px] font-medium text-[var(--text-muted)] uppercase tracking-wider mb-1 block">
-                  File path
-                </label>
-                <input
-                  autoFocus
-                  type="text"
-                  value={newFilePath}
-                  onChange={(e) => setNewFilePath(e.target.value)}
-                  placeholder="docs/my-document.md"
-                  className="w-full text-sm px-3 py-2 rounded-md border border-[var(--border)] bg-[var(--surface-secondary)] text-[var(--text-primary)] font-mono placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)]"
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && newFilePath.trim() && (isAddingToPR || newFileTitle.trim())) {
-                      handleSaveNewFile();
-                    }
-                  }}
-                />
-                {newFilePath && !newFilePath.endsWith(".md") && (
-                  <p className="text-[10px] text-[var(--text-muted)] mt-1">.md will be appended</p>
-                )}
-              </div>
-
-              {!isAddingToPR && (
-                <div>
-                  <label className="text-[10px] font-medium text-[var(--text-muted)] uppercase tracking-wider mb-1 block">
-                    PR title
-                  </label>
-                  <input
-                    type="text"
-                    value={newFileTitle}
-                    onChange={(e) => setNewFileTitle(e.target.value)}
-                    placeholder={`Add ${newFilePath || "new document"}`}
-                    className="w-full text-sm px-3 py-2 rounded-md border border-[var(--border)] bg-[var(--surface-secondary)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)]"
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" && newFilePath.trim() && newFileTitle.trim()) {
-                        handleSaveNewFile();
-                      }
-                    }}
-                  />
-                </div>
-              )}
-
-              {isDemoMode && (
-                <p className="text-xs text-amber-600 bg-amber-50 dark:bg-amber-900/20 dark:text-amber-400 px-3 py-2 rounded-md">
-                  Connect a GitHub repository in Settings to save files.
-                </p>
-              )}
-
-              {submitError && (
-                <p className="text-xs text-red-500">{submitError}</p>
-              )}
-            </div>
-
-            <div className="flex items-center justify-end gap-2 mt-5">
-              <button
-                onClick={() => { setShowNewFileModal(false); setSubmitError(null); }}
-                className="text-xs px-3 py-1.5 text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleSaveNewFile}
-                disabled={savingNewFile || !newFilePath.trim() || isDemoMode}
-                className="flex items-center gap-1.5 text-xs px-4 py-1.5 bg-[var(--accent)] text-white rounded-md hover:bg-[var(--accent-hover)] disabled:opacity-40 transition-colors"
-              >
-                {savingNewFile ? (
-                  <Loader2 size={13} className="animate-spin" />
-                ) : (
-                  <GitPullRequest size={13} />
-                )}
-                {savingNewFile ? "Committing..." : isAddingToPR ? "Commit to PR" : "Create PR"}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Edit PR modal */}
-      {showEditPRModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-          <div
-            className="bg-[var(--surface)] border border-[var(--border)] rounded-xl shadow-2xl w-[420px] p-5"
-            style={{ animation: "fadeInUp 0.15s ease-out" }}
-          >
-            <h3 className="text-sm font-semibold text-[var(--text-primary)] mb-4 flex items-center gap-2">
-              <GitPullRequest size={16} className="text-[var(--accent)]" />
-              Submit Edits as PR
-            </h3>
-
-            <p className="text-xs text-[var(--text-secondary)] mb-3">
-              {isLocalFile
-                ? "This local file will be committed on a new branch and opened as a pull request."
-                : <>Your changes to <span className="font-mono text-[var(--text-primary)]">{filePath}</span> will be committed on a new branch and opened as a pull request.</>}
-            </p>
-
-            <div className="space-y-3">
-              {isLocalFile && (
-                <div>
-                  <label className="text-[10px] font-medium text-[var(--text-muted)] uppercase tracking-wider mb-1 block">
-                    File path in repo
-                  </label>
-                  <input
-                    autoFocus
-                    type="text"
-                    value={editFilePath}
-                    onChange={(e) => setEditFilePath(e.target.value)}
-                    placeholder="docs/my-document.md"
-                    className="w-full text-sm px-3 py-2 rounded-md border border-[var(--border)] bg-[var(--surface-secondary)] text-[var(--text-primary)] font-mono placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)]"
-                  />
-                </div>
-              )}
-              <div>
-                <label className="text-[10px] font-medium text-[var(--text-muted)] uppercase tracking-wider mb-1 block">
-                  PR title
-                </label>
-                <input
-                  autoFocus={!isLocalFile}
-                  type="text"
-                  value={editPRTitle}
-                  onChange={(e) => setEditPRTitle(e.target.value)}
-                  placeholder={isLocalFile ? `Add ${editFilePath}` : `Update ${filePath}`}
-                  className="w-full text-sm px-3 py-2 rounded-md border border-[var(--border)] bg-[var(--surface-secondary)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)]"
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && editPRTitle.trim()) {
-                      handleSubmitEditsAsPR();
-                    }
-                  }}
-                />
-              </div>
-
-              {submitError && (
-                <p className="text-xs text-red-500">{submitError}</p>
-              )}
-            </div>
-
-            <div className="flex items-center justify-end gap-2 mt-5">
-              <button
-                onClick={() => { setShowEditPRModal(false); setSubmitError(null); }}
-                className="text-xs px-3 py-1.5 text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleSubmitEditsAsPR}
-                disabled={submittingPR || !editPRTitle.trim() || (isLocalFile && !editFilePath.trim())}
-                className="flex items-center gap-1.5 text-xs px-4 py-1.5 bg-[var(--accent)] text-white rounded-md hover:bg-[var(--accent-hover)] disabled:opacity-40 transition-colors"
-              >
-                {submittingPR ? (
-                  <Loader2 size={13} className="animate-spin" />
-                ) : (
-                  <GitPullRequest size={13} />
-                )}
-                {submittingPR ? "Creating..." : "Create PR"}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <EditPRModal
+        open={showEditPRModal}
+        onClose={() => { setShowEditPRModal(false); setSubmitError(null); }}
+        title={editPRTitle}
+        onTitleChange={setEditPRTitle}
+        isLocalFile={isLocalFile}
+        filePath={filePath || ""}
+        editFilePath={editFilePath}
+        onEditFilePathChange={setEditFilePath}
+        submitting={submittingPR}
+        error={submitError}
+        onSubmit={handleSubmitEditsAsPR}
+      />
     </div>
   );
 }

--- a/src/components/NewFileModal.tsx
+++ b/src/components/NewFileModal.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import React from "react";
+import { GitPullRequest, Loader2 } from "lucide-react";
+
+export interface NewFileModalProps {
+  open: boolean;
+  onClose: () => void;
+  filePath: string;
+  onFilePathChange: (value: string) => void;
+  title: string;
+  onTitleChange: (value: string) => void;
+  /** True when saving into an existing PR branch (adds the file to that PR). */
+  isAddingToPR: boolean;
+  /** PR number when adding to an existing PR — shown in the header. */
+  addingToPRNumber?: number | null;
+  /** PR branch name when adding to an existing PR — shown in the body. */
+  addingToPRBranch?: string | null;
+  isDemoMode: boolean;
+  saving: boolean;
+  error: string | null;
+  onSubmit: () => void;
+}
+
+/**
+ * Presentational modal for saving a new file to a repository — either
+ * as a fresh PR or by committing to an existing PR branch. All state
+ * and handlers are passed in by the parent Editor. No app-context or
+ * GitHub API coupling.
+ */
+export default function NewFileModal({
+  open,
+  onClose,
+  filePath,
+  onFilePathChange,
+  title,
+  onTitleChange,
+  isAddingToPR,
+  addingToPRNumber,
+  addingToPRBranch,
+  isDemoMode,
+  saving,
+  error,
+  onSubmit,
+}: NewFileModalProps) {
+  if (!open) return null;
+
+  const canSubmit = !saving && filePath.trim() && !isDemoMode && (isAddingToPR || title.trim());
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div
+        className="bg-[var(--surface)] border border-[var(--border)] rounded-xl shadow-2xl w-[420px] p-5"
+        style={{ animation: "fadeInUp 0.15s ease-out" }}
+      >
+        <h3 className="text-sm font-semibold text-[var(--text-primary)] mb-4 flex items-center gap-2">
+          <GitPullRequest size={16} className="text-[var(--accent)]" />
+          {isAddingToPR ? `Add File to PR #${addingToPRNumber}` : "Save to Repository"}
+        </h3>
+
+        {isAddingToPR && (
+          <p className="text-xs text-[var(--text-secondary)] mb-3">
+            Committing to branch <span className="font-mono text-[var(--text-primary)]">{addingToPRBranch}</span>
+          </p>
+        )}
+
+        <div className="space-y-3">
+          <div>
+            <label className="text-[10px] font-medium text-[var(--text-muted)] uppercase tracking-wider mb-1 block">
+              File path
+            </label>
+            <input
+              autoFocus
+              type="text"
+              value={filePath}
+              onChange={(e) => onFilePathChange(e.target.value)}
+              placeholder="docs/my-document.md"
+              className="w-full text-sm px-3 py-2 rounded-md border border-[var(--border)] bg-[var(--surface-secondary)] text-[var(--text-primary)] font-mono placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)]"
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && canSubmit) onSubmit();
+              }}
+            />
+            {filePath && !filePath.endsWith(".md") && (
+              <p className="text-[10px] text-[var(--text-muted)] mt-1">.md will be appended</p>
+            )}
+          </div>
+
+          {!isAddingToPR && (
+            <div>
+              <label className="text-[10px] font-medium text-[var(--text-muted)] uppercase tracking-wider mb-1 block">
+                PR title
+              </label>
+              <input
+                type="text"
+                value={title}
+                onChange={(e) => onTitleChange(e.target.value)}
+                placeholder={`Add ${filePath || "new document"}`}
+                className="w-full text-sm px-3 py-2 rounded-md border border-[var(--border)] bg-[var(--surface-secondary)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)]"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && canSubmit) onSubmit();
+                }}
+              />
+            </div>
+          )}
+
+          {isDemoMode && (
+            <p className="text-xs text-amber-600 bg-amber-50 dark:bg-amber-900/20 dark:text-amber-400 px-3 py-2 rounded-md">
+              Connect a GitHub repository in Settings to save files.
+            </p>
+          )}
+
+          {error && <p className="text-xs text-red-500">{error}</p>}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 mt-5">
+          <button
+            onClick={onClose}
+            className="text-xs px-3 py-1.5 text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onSubmit}
+            disabled={!canSubmit}
+            className="flex items-center gap-1.5 text-xs px-4 py-1.5 bg-[var(--accent)] text-white rounded-md hover:bg-[var(--accent-hover)] disabled:opacity-40 transition-colors"
+          >
+            {saving ? <Loader2 size={13} className="animate-spin" /> : <GitPullRequest size={13} />}
+            {saving ? "Committing..." : isAddingToPR ? "Commit to PR" : "Create PR"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Third extraction. Two presentational modals moved out of Editor.tsx.

**What moves:**
- NewFileModal (~95 lines of JSX + logic) → `src/components/NewFileModal.tsx`
- EditPRModal (~80 lines) → `src/components/EditPRModal.tsx`

Both are **presentational only** — Editor still owns the state and business logic, modals take props. No app-context or GitHub API coupling in the new files.

**Editor.tsx drops from 2113 → 1967 lines** (-146).

**41 new characterization tests** covering both modals: render gates, fresh-PR vs add-to-PR modes, local-file vs repo-file variants, disabled states for every invalid input combination, saving/submitting states, error display, onClose/onChange/Enter-to-submit interactions.

**774 tests green** (733 + 41). Build clean. Bundle size +1kB (expected for new component files).