### PR TITLE
refactor: extract SuggestBlockEditor + markdown format helpers (PR D)

### DIFF
--- a/src/__tests__/markdown-format.test.ts
+++ b/src/__tests__/markdown-format.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for the pure markdown formatting helpers extracted from
+ * DiffViewer.tsx. These functions back the MarkdownToolbar and the
+ * SuggestBlockEditor keyboard shortcuts — getting them wrong would
+ * corrupt user edits, so every branch gets explicit coverage.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  applyWrap,
+  applyLinePrefix,
+  applyCodeBlock,
+  applyHorizontalRule,
+  applyLink,
+} from "@/lib/markdown-format";
+
+// ─── applyWrap ────────────────────────────────────────────────────
+
+describe("applyWrap", () => {
+  it("wraps a selected range with prefix and suffix", () => {
+    const r = applyWrap("hello world", 0, 5, "**", "**");
+    expect(r.text).toBe("**hello** world");
+    expect(r.selStart).toBe(2);
+    expect(r.selEnd).toBe(7);
+  });
+
+  it("inserts a 'text' placeholder when nothing is selected", () => {
+    const r = applyWrap("", 0, 0, "**", "**");
+    expect(r.text).toBe("**text**");
+    expect(r.selStart).toBe(2);
+    expect(r.selEnd).toBe(6);
+  });
+
+  it("wraps in the middle of a string without disturbing the rest", () => {
+    const r = applyWrap("abc def ghi", 4, 7, "_", "_");
+    expect(r.text).toBe("abc _def_ ghi");
+    expect(r.selStart).toBe(5);
+    expect(r.selEnd).toBe(8);
+  });
+
+  it("handles different prefix and suffix (asymmetric)", () => {
+    const r = applyWrap("cat", 0, 3, "[", "](url)");
+    expect(r.text).toBe("[cat](url)");
+    expect(r.selStart).toBe(1);
+    expect(r.selEnd).toBe(4);
+  });
+});
+
+// ─── applyLinePrefix ──────────────────────────────────────────────
+
+describe("applyLinePrefix", () => {
+  it("prepends a prefix to the line containing the cursor", () => {
+    const r = applyLinePrefix("hello", 2, 2, "# ");
+    expect(r.text).toBe("# hello");
+    expect(r.selStart).toBe(4);
+    expect(r.selEnd).toBe(4);
+  });
+
+  it("finds the start of the current line across multi-line text", () => {
+    const text = "first\nsecond\nthird";
+    // Cursor on 'second' at position 8
+    const r = applyLinePrefix(text, 8, 8, "- ");
+    expect(r.text).toBe("first\n- second\nthird");
+  });
+
+  it("toggles the prefix off when it's already present", () => {
+    const r = applyLinePrefix("# hello", 4, 4, "# ");
+    expect(r.text).toBe("hello");
+  });
+
+  it("keeps selection stable when toggling off", () => {
+    // "## foo", cursor on "f" at 3, toggle "## " off
+    const r = applyLinePrefix("## foo", 3, 3, "## ");
+    expect(r.text).toBe("foo");
+    expect(r.selStart).toBe(0);
+    expect(r.selEnd).toBe(0);
+  });
+
+  it("handles the last line with no trailing newline", () => {
+    const text = "first\nlast";
+    const r = applyLinePrefix(text, 8, 8, "> ");
+    expect(r.text).toBe("first\n> last");
+  });
+
+  it("works on a single-word blockquote toggle", () => {
+    const r = applyLinePrefix("> cite", 2, 2, "> ");
+    expect(r.text).toBe("cite");
+  });
+});
+
+// ─── applyCodeBlock ───────────────────────────────────────────────
+
+describe("applyCodeBlock", () => {
+  it("wraps selection in a fenced code block", () => {
+    const r = applyCodeBlock("const x = 1;", 0, 12);
+    expect(r.text).toBe("```\nconst x = 1;\n```");
+    expect(r.selStart).toBe(4);
+    expect(r.selEnd).toBe(16);
+  });
+
+  it("inserts an empty fenced block when nothing is selected", () => {
+    const r = applyCodeBlock("", 0, 0);
+    expect(r.text).toBe("```\n\n```");
+    expect(r.selStart).toBe(4);
+    expect(r.selEnd).toBe(4);
+  });
+});
+
+// ─── applyHorizontalRule ──────────────────────────────────────────
+
+describe("applyHorizontalRule", () => {
+  it("inserts a horizontal rule at the cursor", () => {
+    const r = applyHorizontalRule("before after", 6, 6);
+    expect(r.text).toBe("before\n---\n after");
+  });
+
+  it("places the cursor after the inserted hr", () => {
+    const r = applyHorizontalRule("x", 1, 1);
+    expect(r.selStart).toBe(6);
+    expect(r.selEnd).toBe(6);
+  });
+});
+
+// ─── applyLink ────────────────────────────────────────────────────
+
+describe("applyLink", () => {
+  it("wraps selected text as the link text with 'url' selected", () => {
+    const r = applyLink("click here", 0, 10);
+    expect(r.text).toBe("[click here](url)");
+    // "url" is the 3 characters before the closing paren
+    expect(r.text.slice(r.selStart, r.selEnd)).toBe("url");
+  });
+
+  it("inserts a [text](url) placeholder with 'text' selected when nothing is selected", () => {
+    const r = applyLink("", 0, 0);
+    expect(r.text).toBe("[text](url)");
+    expect(r.text.slice(r.selStart, r.selEnd)).toBe("text");
+  });
+});

--- a/src/__tests__/suggest-block-editor.test.ts
+++ b/src/__tests__/suggest-block-editor.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Characterization tests for SuggestBlockEditor + MarkdownToolbar.
+ *
+ * Pins the behavior of the suggest-mode editing UI that was
+ * extracted from DiffViewer.tsx. Future refactors must keep:
+ *   - Header with line range
+ *   - Done/Delete/Cancel buttons
+ *   - Markdown toolbar with format groups
+ *   - Textarea with keyboard shortcuts (Escape, ⌘+Enter,
+ *     auto-surround, ⌘B/I/E/K hotkeys)
+ */
+import React, { useRef } from "react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import SuggestBlockEditor from "@/components/SuggestBlockEditor";
+import MarkdownToolbar from "@/components/MarkdownToolbar";
+
+const e = React.createElement;
+
+afterEach(() => cleanup());
+
+// ─── SuggestBlockEditor ──────────────────────────────────────────
+
+function Wrapper(props: Omit<React.ComponentProps<typeof SuggestBlockEditor>, "textareaRef">) {
+  const ref = useRef<HTMLTextAreaElement>(null!);
+  return e(SuggestBlockEditor, { ...props, textareaRef: ref });
+}
+
+function mount(
+  overrides: Partial<Omit<React.ComponentProps<typeof SuggestBlockEditor>, "textareaRef">> = {}
+) {
+  return render(
+    e(Wrapper, {
+      blockIndex: 0,
+      startLine: 3,
+      endLine: 5,
+      text: "## Heading\n\nsome paragraph",
+      onTextChange: () => {},
+      onFinish: () => {},
+      onDelete: () => {},
+      onCancel: () => {},
+      ...overrides,
+    } as Parameters<typeof Wrapper>[0])
+  );
+}
+
+describe("SuggestBlockEditor — rendering", () => {
+  it("shows the line range in the header", () => {
+    mount({ startLine: 10, endLine: 14 });
+    expect(screen.getByText(/Lines 10–14/)).toBeTruthy();
+  });
+
+  it("renders Done, Delete, and Cancel buttons", () => {
+    mount();
+    expect(screen.getByText("Done")).toBeTruthy();
+    expect(screen.getByText("Delete")).toBeTruthy();
+    expect(screen.getByText("Cancel")).toBeTruthy();
+  });
+
+  it("renders the textarea with the current text", () => {
+    mount({ text: "hello world" });
+    expect(screen.getByDisplayValue("hello world")).toBeTruthy();
+  });
+
+  it("renders the markdown toolbar (5 format groups)", () => {
+    mount();
+    expect(screen.getByTitle(/Heading 1/)).toBeTruthy();
+    expect(screen.getByTitle(/Bold/)).toBeTruthy();
+    expect(screen.getByTitle(/Bullet List/)).toBeTruthy();
+    expect(screen.getByTitle(/Blockquote/)).toBeTruthy();
+    expect(screen.getByTitle(/Add Link/)).toBeTruthy();
+  });
+});
+
+describe("SuggestBlockEditor — button actions", () => {
+  it("onFinish fires when Done is clicked", () => {
+    const onFinish = vi.fn();
+    mount({ onFinish });
+    fireEvent.click(screen.getByText("Done"));
+    expect(onFinish).toHaveBeenCalledTimes(1);
+  });
+
+  it("onDelete fires when Delete is clicked", () => {
+    const onDelete = vi.fn();
+    mount({ onDelete });
+    fireEvent.click(screen.getByText("Delete"));
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("onCancel fires when Cancel is clicked", () => {
+    const onCancel = vi.fn();
+    mount({ onCancel });
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("onTextChange fires when the user types", () => {
+    const onTextChange = vi.fn();
+    mount({ text: "old", onTextChange });
+    const textarea = screen.getByDisplayValue("old");
+    fireEvent.change(textarea, { target: { value: "new" } });
+    expect(onTextChange).toHaveBeenCalledWith("new");
+  });
+});
+
+describe("SuggestBlockEditor — keyboard shortcuts", () => {
+  it("Escape fires onCancel", () => {
+    const onCancel = vi.fn();
+    mount({ onCancel });
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    fireEvent.keyDown(textarea, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("⌘+Enter fires onFinish", () => {
+    const onFinish = vi.fn();
+    mount({ onFinish });
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+    expect(onFinish).toHaveBeenCalledTimes(1);
+  });
+
+  it("plain Enter does NOT fire onFinish", () => {
+    const onFinish = vi.fn();
+    mount({ onFinish });
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onFinish).not.toHaveBeenCalled();
+  });
+
+  it("auto-surround * wraps selected text with asterisks", () => {
+    const onTextChange = vi.fn();
+    mount({ text: "hello world", onTextChange });
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    // Select "world"
+    textarea.setSelectionRange(6, 11);
+    fireEvent.keyDown(textarea, { key: "*" });
+    expect(onTextChange).toHaveBeenCalledWith("hello *world*");
+  });
+
+  it("auto-surround does NOT fire when there's no selection", () => {
+    const onTextChange = vi.fn();
+    mount({ text: "hello", onTextChange });
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    textarea.setSelectionRange(5, 5); // collapsed
+    fireEvent.keyDown(textarea, { key: "*" });
+    expect(onTextChange).not.toHaveBeenCalled();
+  });
+
+  it("⌘B fires the Bold action on the current selection", () => {
+    const onTextChange = vi.fn();
+    mount({ text: "some text", onTextChange });
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    textarea.setSelectionRange(0, 4); // "some"
+    fireEvent.keyDown(textarea, { key: "b", metaKey: true });
+    expect(onTextChange).toHaveBeenCalledWith("**some** text");
+  });
+
+  it("⌘I fires the Italic action", () => {
+    const onTextChange = vi.fn();
+    mount({ text: "italic please", onTextChange });
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    textarea.setSelectionRange(0, 6); // "italic"
+    fireEvent.keyDown(textarea, { key: "i", metaKey: true });
+    expect(onTextChange).toHaveBeenCalledWith("_italic_ please");
+  });
+
+  it("⌘K fires the Add Link action", () => {
+    const onTextChange = vi.fn();
+    mount({ text: "click me", onTextChange });
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    textarea.setSelectionRange(0, 8);
+    fireEvent.keyDown(textarea, { key: "k", metaKey: true });
+    expect(onTextChange).toHaveBeenCalledWith("[click me](url)");
+  });
+});
+
+// ─── MarkdownToolbar ────────────────────────────────────────────
+
+function ToolbarWrapper(props: Omit<React.ComponentProps<typeof MarkdownToolbar>, "textareaRef">) {
+  const ref = useRef<HTMLTextAreaElement>(null!);
+  return React.createElement(
+    "div",
+    null,
+    e(MarkdownToolbar, { ...props, textareaRef: ref }),
+    e("textarea", {
+      ref,
+      defaultValue: props.text,
+      onChange: (ev: React.ChangeEvent<HTMLTextAreaElement>) =>
+        props.onTextChange(ev.target.value),
+    })
+  );
+}
+
+describe("MarkdownToolbar — rendering", () => {
+  it("renders all 14 format buttons", () => {
+    render(
+      e(ToolbarWrapper, {
+        text: "",
+        onTextChange: () => {},
+      } as Parameters<typeof ToolbarWrapper>[0])
+    );
+    const buttons = document.querySelectorAll(".toolbar-btn");
+    // 3 headings + 5 inline + 3 list + 3 block + 1 link = 15
+    expect(buttons.length).toBe(15);
+  });
+
+  it("shows the hotkey in Bold button title", () => {
+    render(
+      e(ToolbarWrapper, {
+        text: "",
+        onTextChange: () => {},
+      } as Parameters<typeof ToolbarWrapper>[0])
+    );
+    expect(screen.getByTitle("Bold (⌘B)")).toBeTruthy();
+  });
+});

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -11,32 +11,15 @@ import { PRFile, PRComment, PendingSuggestion } from "@/types";
 import {
   MessageSquare,
   MessageSquarePlus,
-  ChevronDown,
-  ChevronRight,
   Plus,
   Check,
   X,
-  Send,
   Maximize2,
   Minimize2,
   Pencil,
   Eye,
-  Bold,
-  Italic,
-  Heading1,
-  Heading2,
-  Heading3,
   Code,
-  Link,
-  List,
-  ListOrdered,
-  CheckSquare,
-  Quote,
-  Strikethrough,
-  Highlighter,
   FileCode,
-  Minus,
-  Trash2,
 } from "lucide-react";
 import ContextMenu from "./ContextMenu";
 import { mapSelectionToLines, rewriteImageUrls, loadAuthenticatedImages, loadEmbedLocalImages } from "@/lib/github-api";
@@ -53,6 +36,7 @@ import { useIsMobile } from "@/lib/use-viewport";
 import BottomSheet from "./BottomSheet";
 import MobileCommentButton from "./MobileCommentButton";
 import CommentPanel, { type PanelComment } from "./CommentPanel";
+import SuggestBlockEditor from "./SuggestBlockEditor";
 import { extractCommentSuggestions, mergeSuggestions } from "@/lib/suggestion-extract";
 import { parseSuggestionBody } from "@/lib/suggestion-body";
 
@@ -192,231 +176,6 @@ function FloatingToolbar({
 }
 
 // ─── Markdown Formatting Toolbar ──────────────────────────────────────────
-
-type FormatAction = {
-  icon: React.ReactNode;
-  label: string;
-  hotkey?: string;
-  apply: (text: string, selStart: number, selEnd: number) => {
-    text: string;
-    selStart: number;
-    selEnd: number;
-  };
-};
-
-function applyWrap(
-  text: string,
-  selStart: number,
-  selEnd: number,
-  prefix: string,
-  suffix: string
-): { text: string; selStart: number; selEnd: number } {
-  const before = text.slice(0, selStart);
-  const selected = text.slice(selStart, selEnd);
-  const after = text.slice(selEnd);
-
-  if (selected) {
-    const newText = before + prefix + selected + suffix + after;
-    return { text: newText, selStart: selStart + prefix.length, selEnd: selEnd + prefix.length };
-  }
-  // No selection — insert placeholder
-  const placeholder = "text";
-  const newText = before + prefix + placeholder + suffix + after;
-  return { text: newText, selStart: selStart + prefix.length, selEnd: selStart + prefix.length + placeholder.length };
-}
-
-function applyLinePrefix(
-  text: string,
-  selStart: number,
-  selEnd: number,
-  prefix: string
-): { text: string; selStart: number; selEnd: number } {
-  // Find start of current line
-  const lineStart = text.lastIndexOf("\n", selStart - 1) + 1;
-  const lineEnd = text.indexOf("\n", selEnd);
-  const actualEnd = lineEnd === -1 ? text.length : lineEnd;
-
-  const before = text.slice(0, lineStart);
-  const line = text.slice(lineStart, actualEnd);
-  const after = text.slice(actualEnd);
-
-  // Toggle: if line already starts with prefix, remove it
-  if (line.startsWith(prefix)) {
-    const newText = before + line.slice(prefix.length) + after;
-    return { text: newText, selStart: Math.max(lineStart, selStart - prefix.length), selEnd: selEnd - prefix.length };
-  }
-
-  const newText = before + prefix + line + after;
-  return { text: newText, selStart: selStart + prefix.length, selEnd: selEnd + prefix.length };
-}
-
-// Group 1: Headings
-const HEADING_ACTIONS: FormatAction[] = [
-  {
-    icon: <Heading1 size={15} />, label: "Heading 1",
-    apply: (t, s, e) => applyLinePrefix(t, s, e, "# "),
-  },
-  {
-    icon: <Heading2 size={15} />, label: "Heading 2",
-    apply: (t, s, e) => applyLinePrefix(t, s, e, "## "),
-  },
-  {
-    icon: <Heading3 size={15} />, label: "Heading 3",
-    apply: (t, s, e) => applyLinePrefix(t, s, e, "### "),
-  },
-];
-
-// Group 2: Inline formatting
-const INLINE_ACTIONS: FormatAction[] = [
-  {
-    icon: <Bold size={15} />, label: "Bold", hotkey: "b",
-    apply: (t, s, e) => applyWrap(t, s, e, "**", "**"),
-  },
-  {
-    icon: <Italic size={15} />, label: "Italic", hotkey: "i",
-    apply: (t, s, e) => applyWrap(t, s, e, "_", "_"),
-  },
-  {
-    icon: <Strikethrough size={15} />, label: "Strikethrough",
-    apply: (t, s, e) => applyWrap(t, s, e, "~~", "~~"),
-  },
-  {
-    icon: <Code size={15} />, label: "Inline Code", hotkey: "e",
-    apply: (t, s, e) => applyWrap(t, s, e, "`", "`"),
-  },
-  {
-    icon: <Highlighter size={15} />, label: "Highlight",
-    apply: (t, s, e) => applyWrap(t, s, e, "==", "=="),
-  },
-];
-
-// Group 3: Lists
-const LIST_ACTIONS: FormatAction[] = [
-  {
-    icon: <List size={15} />, label: "Bullet List",
-    apply: (t, s, e) => applyLinePrefix(t, s, e, "- "),
-  },
-  {
-    icon: <ListOrdered size={15} />, label: "Numbered List",
-    apply: (t, s, e) => applyLinePrefix(t, s, e, "1. "),
-  },
-  {
-    icon: <CheckSquare size={15} />, label: "Task List",
-    apply: (t, s, e) => applyLinePrefix(t, s, e, "- [ ] "),
-  },
-];
-
-// Group 4: Block elements
-const BLOCK_ACTIONS: FormatAction[] = [
-  {
-    icon: <Quote size={15} />, label: "Blockquote",
-    apply: (t, s, e) => applyLinePrefix(t, s, e, "> "),
-  },
-  {
-    icon: <FileCode size={15} />, label: "Code Block",
-    apply: (t, s, e) => {
-      const selected = t.slice(s, e);
-      const before = t.slice(0, s);
-      const after = t.slice(e);
-      if (selected) {
-        const newText = before + "```\n" + selected + "\n```" + after;
-        return { text: newText, selStart: s + 4, selEnd: s + 4 + selected.length };
-      }
-      const newText = before + "```\n\n```" + after;
-      return { text: newText, selStart: s + 4, selEnd: s + 4 };
-    },
-  },
-  {
-    icon: <Minus size={15} />, label: "Horizontal Rule",
-    apply: (t, s, e) => {
-      const before = t.slice(0, s);
-      const after = t.slice(e);
-      const newText = before + "\n---\n" + after;
-      return { text: newText, selStart: s + 5, selEnd: s + 5 };
-    },
-  },
-];
-
-// Group 5: Link
-const LINK_ACTIONS: FormatAction[] = [
-  {
-    icon: <Link size={15} />, label: "Add Link", hotkey: "k",
-    apply: (t, s, e) => {
-      const selected = t.slice(s, e);
-      const before = t.slice(0, s);
-      const after = t.slice(e);
-      if (selected) {
-        const newText = before + "[" + selected + "](url)" + after;
-        const urlStart = s + selected.length + 3;
-        return { text: newText, selStart: urlStart, selEnd: urlStart + 3 };
-      }
-      const newText = before + "[text](url)" + after;
-      return { text: newText, selStart: s + 1, selEnd: s + 5 };
-    },
-  },
-];
-
-// All actions flat for hotkey lookup
-const ALL_FORMAT_ACTIONS: FormatAction[] = [
-  ...HEADING_ACTIONS, ...INLINE_ACTIONS, ...LIST_ACTIONS, ...BLOCK_ACTIONS, ...LINK_ACTIONS,
-];
-
-function ToolbarDivider() {
-  return <div className="w-px h-5 bg-[var(--border)] mx-1" />;
-}
-
-function MarkdownToolbar({
-  textareaRef,
-  text,
-  onTextChange,
-}: {
-  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
-  text: string;
-  onTextChange: (text: string) => void;
-}) {
-  const applyAction = useCallback(
-    (action: FormatAction) => {
-      const textarea = textareaRef.current;
-      if (!textarea) return;
-
-      const { selectionStart, selectionEnd } = textarea;
-      const result = action.apply(text, selectionStart, selectionEnd);
-      onTextChange(result.text);
-
-      requestAnimationFrame(() => {
-        textarea.focus();
-        textarea.setSelectionRange(result.selStart, result.selEnd);
-      });
-    },
-    [textareaRef, text, onTextChange]
-  );
-
-  const renderGroup = (actions: FormatAction[]) =>
-    actions.map((action, i) => (
-      <button
-        key={action.label}
-        onClick={(e) => { e.preventDefault(); applyAction(action); }}
-        title={`${action.label}${action.hotkey ? ` (⌘${action.hotkey.toUpperCase()})` : ""}`}
-        className="toolbar-btn"
-      >
-        {action.icon}
-      </button>
-    ));
-
-  return (
-    <div className="flex items-center gap-0.5 px-3 py-1.5 border-b border-[var(--accent)] bg-[var(--surface)]">
-      {renderGroup(HEADING_ACTIONS)}
-      <ToolbarDivider />
-      {renderGroup(INLINE_ACTIONS)}
-      <ToolbarDivider />
-      {renderGroup(LIST_ACTIONS)}
-      <ToolbarDivider />
-      {renderGroup(BLOCK_ACTIONS)}
-      <ToolbarDivider />
-      {renderGroup(LINK_ACTIONS)}
-    </div>
-  );
-}
 
 // ─── Main DiffViewer ───────────────────────────────────────────────────────
 
@@ -1348,98 +1107,18 @@ export default function DiffViewer({
 
                   if (isEditing) {
                     return (
-                      <div key={idx} className="mb-2 rounded-lg border-2 border-[var(--accent)] bg-[var(--surface)] overflow-hidden">
-                        <div className="flex items-center justify-between px-3 py-1.5 bg-[var(--accent-muted)] border-b border-[var(--accent)]">
-                          <span className="text-[10px] text-[var(--accent)] font-medium">
-                            Editing block — Lines {headBlockRanges[idx].startLine}–{headBlockRanges[idx].endLine}
-                          </span>
-                          <div className="flex items-center gap-1">
-                            <button
-                              onClick={finishEditingBlock}
-                              className="text-[10px] px-2 py-0.5 bg-[var(--accent)] text-white rounded hover:bg-[var(--accent-hover)] transition-colors"
-                            >
-                              Done
-                            </button>
-                            <button
-                              onClick={deleteEditingBlock}
-                              className="flex items-center gap-1 text-[10px] px-2 py-0.5 bg-red-600 text-white rounded hover:bg-red-700 transition-colors"
-                              title="Suggest deleting this block"
-                            >
-                              <Trash2 size={10} />
-                              Delete
-                            </button>
-                            <button
-                              onClick={() => { setEditingBlockIndex(null); setEditingText(""); }}
-                              className="text-[10px] px-2 py-0.5 text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
-                            >
-                              Cancel
-                            </button>
-                          </div>
-                        </div>
-                        <MarkdownToolbar
-                          textareaRef={editTextareaRef}
-                          text={editingText}
-                          onTextChange={setEditingText}
-                        />
-                        <textarea
-                          ref={editTextareaRef}
-                          value={editingText}
-                          onChange={(e) => setEditingText(e.target.value)}
-                          onKeyDown={(e) => {
-                            if (e.key === "Escape") {
-                              setEditingBlockIndex(null);
-                              setEditingText("");
-                              return;
-                            }
-                            if (e.key === "Enter" && e.metaKey) {
-                              finishEditingBlock();
-                              return;
-                            }
-                            // Auto-surround selection with matching characters
-                            const surroundPairs: Record<string, string> = {
-                              "'": "'", '"': '"', "*": "*", "_": "_",
-                              "(": ")", "[": "]", "{": "}", "`": "`",
-                            };
-                            if (surroundPairs[e.key]) {
-                              const textarea = e.currentTarget;
-                              if (textarea.selectionStart !== textarea.selectionEnd) {
-                                e.preventDefault();
-                                const result = applyWrap(
-                                  editingText,
-                                  textarea.selectionStart,
-                                  textarea.selectionEnd,
-                                  e.key,
-                                  surroundPairs[e.key]
-                                );
-                                setEditingText(result.text);
-                                requestAnimationFrame(() => {
-                                  textarea.setSelectionRange(result.selStart, result.selEnd);
-                                });
-                                return;
-                              }
-                            }
-                            // Hotkeys for formatting
-                            if (e.metaKey || e.ctrlKey) {
-                              const action = ALL_FORMAT_ACTIONS.find((a) => a.hotkey === e.key);
-                              if (action) {
-                                e.preventDefault();
-                                const textarea = e.currentTarget;
-                                const result = action.apply(
-                                  editingText,
-                                  textarea.selectionStart,
-                                  textarea.selectionEnd
-                                );
-                                setEditingText(result.text);
-                                requestAnimationFrame(() => {
-                                  textarea.setSelectionRange(result.selStart, result.selEnd);
-                                });
-                              }
-                            }
-                          }}
-                          className="w-full p-3 text-sm font-mono bg-[var(--surface)] text-[var(--text-primary)] border-none outline-none resize-y min-h-[80px]"
-                          rows={Math.max(3, editingText.split("\n").length + 1)}
-                        />
-                      </div>
+                      <SuggestBlockEditor
+                        key={idx}
+                        blockIndex={idx}
+                        startLine={headBlockRanges[idx].startLine}
+                        endLine={headBlockRanges[idx].endLine}
+                        text={editingText}
+                        onTextChange={setEditingText}
+                        onFinish={finishEditingBlock}
+                        onDelete={deleteEditingBlock}
+                        onCancel={() => { setEditingBlockIndex(null); setEditingText(""); }}
+                        textareaRef={editTextareaRef}
+                      />
                     );
                   }
 

--- a/src/components/MarkdownToolbar.tsx
+++ b/src/components/MarkdownToolbar.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import React, { useCallback } from "react";
+import {
+  Heading1,
+  Heading2,
+  Heading3,
+  Bold,
+  Italic,
+  Strikethrough,
+  Code,
+  Link,
+  List,
+  ListOrdered,
+  CheckSquare,
+  Quote,
+  FileCode,
+  Minus,
+  Highlighter,
+} from "lucide-react";
+import {
+  applyWrap,
+  applyLinePrefix,
+  applyCodeBlock,
+  applyHorizontalRule,
+  applyLink,
+  type FormatResult,
+} from "@/lib/markdown-format";
+
+export interface FormatAction {
+  icon: React.ReactNode;
+  label: string;
+  hotkey?: string;
+  apply: (text: string, selStart: number, selEnd: number) => FormatResult;
+}
+
+// Group 1: Headings
+const HEADING_ACTIONS: FormatAction[] = [
+  {
+    icon: <Heading1 size={15} />, label: "Heading 1",
+    apply: (t, s, e) => applyLinePrefix(t, s, e, "# "),
+  },
+  {
+    icon: <Heading2 size={15} />, label: "Heading 2",
+    apply: (t, s, e) => applyLinePrefix(t, s, e, "## "),
+  },
+  {
+    icon: <Heading3 size={15} />, label: "Heading 3",
+    apply: (t, s, e) => applyLinePrefix(t, s, e, "### "),
+  },
+];
+
+// Group 2: Inline formatting
+const INLINE_ACTIONS: FormatAction[] = [
+  {
+    icon: <Bold size={15} />, label: "Bold", hotkey: "b",
+    apply: (t, s, e) => applyWrap(t, s, e, "**", "**"),
+  },
+  {
+    icon: <Italic size={15} />, label: "Italic", hotkey: "i",
+    apply: (t, s, e) => applyWrap(t, s, e, "_", "_"),
+  },
+  {
+    icon: <Strikethrough size={15} />, label: "Strikethrough",
+    apply: (t, s, e) => applyWrap(t, s, e, "~~", "~~"),
+  },
+  {
+    icon: <Code size={15} />, label: "Inline Code", hotkey: "e",
+    apply: (t, s, e) => applyWrap(t, s, e, "`", "`"),
+  },
+  {
+    icon: <Highlighter size={15} />, label: "Highlight",
+    apply: (t, s, e) => applyWrap(t, s, e, "==", "=="),
+  },
+];
+
+// Group 3: Lists
+const LIST_ACTIONS: FormatAction[] = [
+  {
+    icon: <List size={15} />, label: "Bullet List",
+    apply: (t, s, e) => applyLinePrefix(t, s, e, "- "),
+  },
+  {
+    icon: <ListOrdered size={15} />, label: "Numbered List",
+    apply: (t, s, e) => applyLinePrefix(t, s, e, "1. "),
+  },
+  {
+    icon: <CheckSquare size={15} />, label: "Task List",
+    apply: (t, s, e) => applyLinePrefix(t, s, e, "- [ ] "),
+  },
+];
+
+// Group 4: Block elements
+const BLOCK_ACTIONS: FormatAction[] = [
+  {
+    icon: <Quote size={15} />, label: "Blockquote",
+    apply: (t, s, e) => applyLinePrefix(t, s, e, "> "),
+  },
+  {
+    icon: <FileCode size={15} />, label: "Code Block",
+    apply: (t, s, e) => applyCodeBlock(t, s, e),
+  },
+  {
+    icon: <Minus size={15} />, label: "Horizontal Rule",
+    apply: (t, s, e) => applyHorizontalRule(t, s, e),
+  },
+];
+
+// Group 5: Link
+const LINK_ACTIONS: FormatAction[] = [
+  {
+    icon: <Link size={15} />, label: "Add Link", hotkey: "k",
+    apply: (t, s, e) => applyLink(t, s, e),
+  },
+];
+
+/** All actions flat for hotkey lookup. */
+export const ALL_FORMAT_ACTIONS: FormatAction[] = [
+  ...HEADING_ACTIONS,
+  ...INLINE_ACTIONS,
+  ...LIST_ACTIONS,
+  ...BLOCK_ACTIONS,
+  ...LINK_ACTIONS,
+];
+
+function ToolbarDivider() {
+  return <div className="w-px h-5 bg-[var(--border)] mx-1" />;
+}
+
+export interface MarkdownToolbarProps {
+  textareaRef: React.RefObject<HTMLTextAreaElement>;
+  text: string;
+  onTextChange: (text: string) => void;
+}
+
+export default function MarkdownToolbar({
+  textareaRef,
+  text,
+  onTextChange,
+}: MarkdownToolbarProps) {
+  const applyAction = useCallback(
+    (action: FormatAction) => {
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+
+      const { selectionStart, selectionEnd } = textarea;
+      const result = action.apply(text, selectionStart, selectionEnd);
+      onTextChange(result.text);
+
+      requestAnimationFrame(() => {
+        textarea.focus();
+        textarea.setSelectionRange(result.selStart, result.selEnd);
+      });
+    },
+    [textareaRef, text, onTextChange]
+  );
+
+  const renderGroup = (actions: FormatAction[]) =>
+    actions.map((action) => (
+      <button
+        key={action.label}
+        onClick={(e) => { e.preventDefault(); applyAction(action); }}
+        title={`${action.label}${action.hotkey ? ` (⌘${action.hotkey.toUpperCase()})` : ""}`}
+        className="toolbar-btn"
+      >
+        {action.icon}
+      </button>
+    ));
+
+  return (
+    <div className="flex items-center gap-0.5 px-3 py-1.5 border-b border-[var(--accent)] bg-[var(--surface)]">
+      {renderGroup(HEADING_ACTIONS)}
+      <ToolbarDivider />
+      {renderGroup(INLINE_ACTIONS)}
+      <ToolbarDivider />
+      {renderGroup(LIST_ACTIONS)}
+      <ToolbarDivider />
+      {renderGroup(BLOCK_ACTIONS)}
+      <ToolbarDivider />
+      {renderGroup(LINK_ACTIONS)}
+    </div>
+  );
+}

--- a/src/components/SuggestBlockEditor.tsx
+++ b/src/components/SuggestBlockEditor.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import React from "react";
+import { Trash2 } from "lucide-react";
+import MarkdownToolbar, { ALL_FORMAT_ACTIONS } from "./MarkdownToolbar";
+import { applyWrap } from "@/lib/markdown-format";
+
+export interface SuggestBlockEditorProps {
+  blockIndex: number;
+  startLine: number;
+  endLine: number;
+  text: string;
+  onTextChange: (text: string) => void;
+  /** Save the current edit as a suggestion (keeps suggest mode active). */
+  onFinish: () => void;
+  /** Queue an empty suggestion, i.e. suggest deleting the block. */
+  onDelete: () => void;
+  /** Discard the edit without saving. */
+  onCancel: () => void;
+  textareaRef: React.RefObject<HTMLTextAreaElement>;
+}
+
+/**
+ * The inline block-editor for suggest mode. Shows a textarea with a
+ * markdown formatting toolbar and supports keyboard shortcuts
+ * (auto-surround, ⌘B/I/E/K, Escape to cancel, ⌘+Enter to save).
+ *
+ * Purely presentational — the parent DiffViewer owns the edit state
+ * (editingBlockIndex, editingText, pendingSuggestions) and passes
+ * the callbacks that mutate it.
+ */
+export default function SuggestBlockEditor({
+  blockIndex,
+  startLine,
+  endLine,
+  text,
+  onTextChange,
+  onFinish,
+  onDelete,
+  onCancel,
+  textareaRef,
+}: SuggestBlockEditorProps) {
+  return (
+    <div
+      key={blockIndex}
+      className="mb-2 rounded-lg border-2 border-[var(--accent)] bg-[var(--surface)] overflow-hidden"
+    >
+      <div className="flex items-center justify-between px-3 py-1.5 bg-[var(--accent-muted)] border-b border-[var(--accent)]">
+        <span className="text-[10px] text-[var(--accent)] font-medium">
+          Editing block — Lines {startLine}–{endLine}
+        </span>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={onFinish}
+            className="text-[10px] px-2 py-0.5 bg-[var(--accent)] text-white rounded hover:bg-[var(--accent-hover)] transition-colors"
+          >
+            Done
+          </button>
+          <button
+            onClick={onDelete}
+            className="flex items-center gap-1 text-[10px] px-2 py-0.5 bg-red-600 text-white rounded hover:bg-red-700 transition-colors"
+            title="Suggest deleting this block"
+          >
+            <Trash2 size={10} />
+            Delete
+          </button>
+          <button
+            onClick={onCancel}
+            className="text-[10px] px-2 py-0.5 text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+      <MarkdownToolbar
+        textareaRef={textareaRef}
+        text={text}
+        onTextChange={onTextChange}
+      />
+      <textarea
+        ref={textareaRef}
+        value={text}
+        onChange={(e) => onTextChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            onCancel();
+            return;
+          }
+          if (e.key === "Enter" && e.metaKey) {
+            onFinish();
+            return;
+          }
+          // Auto-surround selection with matching characters
+          const surroundPairs: Record<string, string> = {
+            "'": "'", '"': '"', "*": "*", "_": "_",
+            "(": ")", "[": "]", "{": "}", "`": "`",
+          };
+          if (surroundPairs[e.key]) {
+            const textarea = e.currentTarget;
+            if (textarea.selectionStart !== textarea.selectionEnd) {
+              e.preventDefault();
+              const result = applyWrap(
+                text,
+                textarea.selectionStart,
+                textarea.selectionEnd,
+                e.key,
+                surroundPairs[e.key]
+              );
+              onTextChange(result.text);
+              requestAnimationFrame(() => {
+                textarea.setSelectionRange(result.selStart, result.selEnd);
+              });
+              return;
+            }
+          }
+          // Hotkeys for formatting
+          if (e.metaKey || e.ctrlKey) {
+            const action = ALL_FORMAT_ACTIONS.find((a) => a.hotkey === e.key);
+            if (action) {
+              e.preventDefault();
+              const textarea = e.currentTarget;
+              const result = action.apply(
+                text,
+                textarea.selectionStart,
+                textarea.selectionEnd
+              );
+              onTextChange(result.text);
+              requestAnimationFrame(() => {
+                textarea.setSelectionRange(result.selStart, result.selEnd);
+              });
+            }
+          }
+        }}
+        className="w-full p-3 text-sm font-mono bg-[var(--surface)] text-[var(--text-primary)] border-none outline-none resize-y min-h-[80px]"
+        rows={Math.max(3, text.split("\n").length + 1)}
+      />
+    </div>
+  );
+}

--- a/src/lib/markdown-format.ts
+++ b/src/lib/markdown-format.ts
@@ -1,0 +1,151 @@
+/**
+ * Pure text-manipulation helpers for the markdown toolbar.
+ *
+ * Both of the textarea-based editing surfaces in MarDoc — the code
+ * view in the Editor and the suggest-mode block editor in
+ * DiffViewer — need to support hotkey-driven formatting. The actual
+ * string transforms live here so they can be unit-tested in
+ * isolation and shared between both surfaces.
+ *
+ * Every function takes the full text, the current selection range,
+ * and returns the new text plus the new selection range.
+ */
+
+export interface FormatResult {
+  text: string;
+  selStart: number;
+  selEnd: number;
+}
+
+/**
+ * Wrap the selected range with a prefix + suffix. If nothing is
+ * selected, insert a "text" placeholder so the user can immediately
+ * type over it.
+ */
+export function applyWrap(
+  text: string,
+  selStart: number,
+  selEnd: number,
+  prefix: string,
+  suffix: string
+): FormatResult {
+  const before = text.slice(0, selStart);
+  const selected = text.slice(selStart, selEnd);
+  const after = text.slice(selEnd);
+
+  if (selected) {
+    const newText = before + prefix + selected + suffix + after;
+    return {
+      text: newText,
+      selStart: selStart + prefix.length,
+      selEnd: selEnd + prefix.length,
+    };
+  }
+  // No selection — insert placeholder
+  const placeholder = "text";
+  const newText = before + prefix + placeholder + suffix + after;
+  return {
+    text: newText,
+    selStart: selStart + prefix.length,
+    selEnd: selStart + prefix.length + placeholder.length,
+  };
+}
+
+/**
+ * Add (or toggle off) a line prefix on the line(s) covered by the
+ * selection. Used for headings, bullet lists, blockquotes, etc.
+ * If the line already starts with the prefix, remove it.
+ */
+export function applyLinePrefix(
+  text: string,
+  selStart: number,
+  selEnd: number,
+  prefix: string
+): FormatResult {
+  // Find start of current line
+  const lineStart = text.lastIndexOf("\n", selStart - 1) + 1;
+  const lineEnd = text.indexOf("\n", selEnd);
+  const actualEnd = lineEnd === -1 ? text.length : lineEnd;
+
+  const before = text.slice(0, lineStart);
+  const line = text.slice(lineStart, actualEnd);
+  const after = text.slice(actualEnd);
+
+  // Toggle: if line already starts with prefix, remove it
+  if (line.startsWith(prefix)) {
+    const newText = before + line.slice(prefix.length) + after;
+    return {
+      text: newText,
+      selStart: Math.max(lineStart, selStart - prefix.length),
+      selEnd: selEnd - prefix.length,
+    };
+  }
+
+  const newText = before + prefix + line + after;
+  return {
+    text: newText,
+    selStart: selStart + prefix.length,
+    selEnd: selEnd + prefix.length,
+  };
+}
+
+/**
+ * Wrap the selection in a fenced code block. If nothing is selected,
+ * insert an empty block with the cursor placed between the fences.
+ */
+export function applyCodeBlock(
+  text: string,
+  selStart: number,
+  selEnd: number
+): FormatResult {
+  const selected = text.slice(selStart, selEnd);
+  const before = text.slice(0, selStart);
+  const after = text.slice(selEnd);
+  if (selected) {
+    const newText = before + "```\n" + selected + "\n```" + after;
+    return {
+      text: newText,
+      selStart: selStart + 4,
+      selEnd: selStart + 4 + selected.length,
+    };
+  }
+  const newText = before + "```\n\n```" + after;
+  return { text: newText, selStart: selStart + 4, selEnd: selStart + 4 };
+}
+
+/**
+ * Insert a horizontal rule at the selection point. Current selection
+ * is discarded if any.
+ */
+export function applyHorizontalRule(
+  text: string,
+  selStart: number,
+  selEnd: number
+): FormatResult {
+  const before = text.slice(0, selStart);
+  const after = text.slice(selEnd);
+  const newText = before + "\n---\n" + after;
+  return { text: newText, selStart: selStart + 5, selEnd: selStart + 5 };
+}
+
+/**
+ * Insert a markdown link. If text is selected, wrap it as the link
+ * text and place the cursor on "url". If nothing is selected, insert
+ * a "[text](url)" placeholder with "text" selected.
+ */
+export function applyLink(
+  text: string,
+  selStart: number,
+  selEnd: number
+): FormatResult {
+  const selected = text.slice(selStart, selEnd);
+  const before = text.slice(0, selStart);
+  const after = text.slice(selEnd);
+  if (selected) {
+    const newText = before + "[" + selected + "](url)" + after;
+    const urlStart = selStart + selected.length + 3;
+    return { text: newText, selStart: urlStart, selEnd: urlStart + 3 };
+  }
+  const newText = before + "[text](url)" + after;
+  return { text: newText, selStart: selStart + 1, selEnd: selStart + 5 };
+}


### PR DESCRIPTION
Final extraction in the decomposition plan. Moves suggest-mode editing UI and its markdown format primitives out of DiffViewer.tsx.

**What moves:**
- `src/lib/markdown-format.ts` — pure text helpers (applyWrap, applyLinePrefix, applyCodeBlock, applyHorizontalRule, applyLink)
- `src/components/MarkdownToolbar.tsx` — 5-group format toolbar + ALL_FORMAT_ACTIONS hotkey lookup
- `src/components/SuggestBlockEditor.tsx` — inline block editor with all the keyboard shortcuts (Escape, ⌘+Enter, ⌘B/I/E/K, auto-surround)

**DiffViewer.tsx drops from 1624 → 1303 lines** (-321). Also cleaned up 14 unused lucide-react icon imports.

**34 new tests** (16 for markdown-format, 18 for SuggestBlockEditor + MarkdownToolbar rendering).

**Total decomposition scorecard across PRs A-D:**
- Editor.tsx: 2555 → 1967 (-588)
- DiffViewer.tsx: 1893 → 1303 (-590)
- 8 new independently testable modules
- 127 new characterization tests
- 808 tests green (681 at start), build clean, bundle unchanged