### PR TITLE
fix: image bubble positioning + HTML toolbar parity + e2e for images

### DIFF
--- a/e2e/image-flows.spec.ts
+++ b/e2e/image-flows.spec.ts
@@ -1,0 +1,322 @@
+/**
+ * E2E tests for image insertion, resize, and centering.
+ *
+ * Image handling spans three different surfaces in the Editor:
+ *   1. Inserting an image (toolbar button → URL popover)
+ *   2. Clicking an image → LinkImageBubble appears for editing
+ *   3. Resize (drag handle + width/height inputs)
+ *   4. Centering (checkbox → data-center → round-trip via Turndown)
+ *
+ * Each of these has pure-function coverage in unit tests, but none
+ * were tested at the interaction level. The user reported visual
+ * weirdness with the edit popover positioning — the kind of bug
+ * that only shows up when a real browser lays out the element.
+ *
+ * These tests drive headless Chromium + WebKit against a real Next
+ * dev server in demo mode.
+ */
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// Image tests manipulate the ProseMirror editor state; running them
+// in parallel in the same file causes state contamination because
+// the dev server's Fast Refresh can leak between workers. Serial
+// within the file keeps the editor instance clean between tests.
+test.describe.configure({ mode: "serial" });
+
+// ─── Shared helpers ──────────────────────────────────────────────
+
+async function waitForHydration(page: Page) {
+  await page.waitForFunction(
+    () => {
+      const prsBtn = Array.from(document.querySelectorAll("button")).find(
+        (b) => b.textContent?.trim() === "PRs"
+      );
+      const hamburger = document.querySelector('button[aria-label="Open navigation"]');
+      return !!prsBtn || !!hamburger;
+    },
+    { timeout: 15_000 }
+  );
+}
+
+async function openSidebar(page: Page) {
+  const hamburger = page.locator('button[aria-label="Open navigation"]');
+  if (await hamburger.isVisible().catch(() => false)) {
+    await hamburger.click();
+    await page.waitForTimeout(350);
+  }
+}
+
+async function clickInVisibleSidebar(page: Page, text: string) {
+  await page
+    .locator("button", { hasText: new RegExp(`^${text}$`) })
+    .locator("visible=true")
+    .first()
+    .click();
+}
+
+async function clickVisibleText(page: Page, text: string | RegExp) {
+  await page.getByText(text).locator("visible=true").first().click();
+}
+
+/**
+ * Open a markdown file in the Editor. Returns the ProseMirror
+ * content element for subsequent interactions.
+ */
+async function openMarkdownFile(page: Page, filename: string | RegExp = /README\.md/) {
+  await page.goto("/");
+  await waitForHydration(page);
+  await openSidebar(page);
+  await clickInVisibleSidebar(page, "Files");
+  await clickVisibleText(page, filename);
+  const proseMirror = page.locator(".ProseMirror");
+  await expect(proseMirror).toBeVisible({ timeout: 10_000 });
+  return proseMirror;
+}
+
+/** Click the Add Image button in the Editor toolbar. */
+async function clickAddImageButton(page: Page) {
+  // The toolbar button has title="Add Image"
+  await page.locator('button[title="Add Image"]').locator("visible=true").first().click();
+}
+
+/**
+ * Insert an image via the toolbar button flow. Fills the URL and
+ * alt inputs, then confirms.
+ */
+async function insertImage(page: Page, url: string, alt: string) {
+  await clickAddImageButton(page);
+
+  // The inline popover renders with an "Image URL" label above its input
+  const popover = page.locator(':has-text("Image URL")').locator("visible=true").first();
+  await expect(popover).toBeVisible({ timeout: 3_000 });
+
+  // The URL and alt inputs are the only text inputs in the popover
+  const urlInput = popover.locator('input[type="text"]').first();
+  await urlInput.fill(url);
+
+  // Alt input is the second text input (if visible). Some variants
+  // only have the URL input — handle both.
+  const inputs = popover.locator('input[type="text"]');
+  const count = await inputs.count();
+  if (count >= 2) {
+    await inputs.nth(1).fill(alt);
+  }
+
+  // Confirm — button text is "Add Image" or "Add" inside the popover
+  const addBtn = popover.locator('button', { hasText: /^Add( Image)?$/ }).last();
+  await addBtn.click();
+
+  // Popover dismisses
+  await expect(popover).not.toBeVisible({ timeout: 2_000 });
+}
+
+// ─── Suite 1: Image insertion ────────────────────────────────────
+
+test.describe("Image insertion in Editor", () => {
+  test("toolbar Add Image button opens a URL/alt popover", async ({ page }) => {
+    await openMarkdownFile(page);
+    await clickAddImageButton(page);
+    await expect(
+      page.locator("text=Image URL").locator("visible=true").first()
+    ).toBeVisible({ timeout: 3_000 });
+  });
+
+  test("inserting an image adds an <img> element to the ProseMirror document", async ({ page }) => {
+    const pm = await openMarkdownFile(page);
+
+    // Log what images exist before
+    const beforeSrcs = await pm.locator("img").evaluateAll((imgs) =>
+      imgs.map((img) => (img as HTMLImageElement).src)
+    );
+    console.log("Images before insertion:", beforeSrcs);
+
+    await insertImage(page, "https://example.com/test.png", "a test image");
+
+    // The new image has the URL we set — this is the only assertion
+    // we actually care about. Don't count total images because demo
+    // files may include loaded images from other sources.
+    const newImg = pm.locator('img[src="https://example.com/test.png"]');
+    await expect(newImg).toBeVisible({ timeout: 3_000 });
+    await expect(newImg).toHaveAttribute("alt", "a test image");
+  });
+});
+
+// ─── Suite 2: Image edit bubble positioning ──────────────────────
+
+test.describe("Image edit bubble (LinkImageBubble)", () => {
+  test("clicking an inserted image opens the edit bubble", async ({ page }) => {
+    const pm = await openMarkdownFile(page);
+    await insertImage(page, "https://example.com/bubble.png", "bubble image");
+    const img = pm.locator('img[src="https://example.com/bubble.png"]');
+    await img.click();
+
+    // The bubble shows the image URL in its preview
+    await expect(
+      page.locator('text=/bubble\\.png/').locator("visible=true").first()
+    ).toBeVisible({ timeout: 3_000 });
+  });
+
+  test("bubble is positioned below the image within the editor container", async ({ page }) => {
+    const pm = await openMarkdownFile(page);
+    await insertImage(page, "https://example.com/position.png", "pos image");
+    const img = pm.locator('img[src="https://example.com/position.png"]');
+    await img.click();
+
+    // Find the bubble's positioning wrapper — it has class "absolute z-50"
+    // and contains the Edit button.
+    const editBtn = page.locator('button[title="Edit"]').locator("visible=true").first();
+    await expect(editBtn).toBeVisible({ timeout: 3_000 });
+
+    // The bubble must appear below the image and inside the editor's
+    // visible bounds — not clipped off the top, left, or right.
+    const imgBox = await img.boundingBox();
+    const bubbleHost = editBtn.locator("xpath=ancestor::div[contains(@class, 'absolute')][1]");
+    const bubbleBox = await bubbleHost.boundingBox();
+
+    expect(imgBox).toBeTruthy();
+    expect(bubbleBox).toBeTruthy();
+    if (!imgBox || !bubbleBox) return;
+
+    // Bubble top is AT OR BELOW the image's bottom (with small tolerance)
+    expect(bubbleBox.y).toBeGreaterThanOrEqual(imgBox.y + imgBox.height - 5);
+
+    // Bubble is inside the viewport horizontally (never clipped off left/right)
+    const viewport = page.viewportSize();
+    expect(viewport).toBeTruthy();
+    if (!viewport) return;
+    expect(bubbleBox.x).toBeGreaterThanOrEqual(0);
+    expect(bubbleBox.x + bubbleBox.width).toBeLessThanOrEqual(viewport.width + 5);
+  });
+
+  test("edit mode shows URL, Alt, Size, and Center fields for an image", async ({ page }) => {
+    const pm = await openMarkdownFile(page);
+    await insertImage(page, "https://example.com/edit.png", "edit me");
+    await pm.locator('img[src="https://example.com/edit.png"]').click();
+
+    // Enter edit mode
+    await page.locator('button[title="Edit"]').locator("visible=true").first().click();
+
+    // Every image edit field is present
+    await expect(page.locator("text=Image URL").locator("visible=true").first()).toBeVisible();
+    await expect(page.locator("text=Alt text").locator("visible=true").first()).toBeVisible();
+    await expect(page.locator("text=Size").locator("visible=true").first()).toBeVisible();
+    await expect(
+      page.locator("text=/Center image/").locator("visible=true").first()
+    ).toBeVisible();
+  });
+});
+
+// ─── Suite 3: Resize via width/height inputs ─────────────────────
+
+test.describe("Image resize via the edit bubble inputs", () => {
+  test("setting a width adds the width attribute to the image", async ({ page }) => {
+    const pm = await openMarkdownFile(page);
+    await insertImage(page, "https://example.com/resize.png", "resize me");
+    await pm.locator('img[src="https://example.com/resize.png"]').click();
+    await page.locator('button[title="Edit"]').locator("visible=true").first().click();
+
+    // Fill the width input. It has placeholder "Width".
+    const widthInput = page.locator('input[placeholder="Width"]').locator("visible=true").first();
+    await widthInput.fill("200");
+
+    // Apply
+    await page.locator('button', { hasText: /^Apply$/ }).locator("visible=true").first().click();
+
+    // The image now has width="200"
+    await expect(pm.locator('img[src="https://example.com/resize.png"]')).toHaveAttribute(
+      "width",
+      "200",
+      { timeout: 3_000 }
+    );
+  });
+
+  test("aspect lock auto-fills height when width changes", async ({ page }) => {
+    const pm = await openMarkdownFile(page);
+    await insertImage(page, "https://example.com/aspect.png", "aspect");
+    const img = pm.locator('img[src="https://example.com/aspect.png"]');
+
+    // Force a predictable natural size so the aspect ratio is determined
+    await img.evaluate((el) => {
+      Object.defineProperty(el, "naturalWidth", { value: 400, configurable: true });
+      Object.defineProperty(el, "naturalHeight", { value: 200, configurable: true });
+    });
+
+    await img.click();
+    await page.locator('button[title="Edit"]').locator("visible=true").first().click();
+
+    const widthInput = page.locator('input[placeholder="Width"]').locator("visible=true").first();
+    const heightInput = page.locator('input[placeholder="Height"]').locator("visible=true").first();
+
+    await widthInput.fill("500");
+    // Height should be auto-computed from the 2:1 aspect ratio
+    await expect(heightInput).toHaveValue("250", { timeout: 2_000 });
+  });
+});
+
+// ─── Suite 4: Centering an image ─────────────────────────────────
+
+test.describe("Image centering", () => {
+  test("toggling the Center checkbox sets data-center on the image", async ({ page }) => {
+    const pm = await openMarkdownFile(page);
+    await insertImage(page, "https://example.com/center.png", "center me");
+    await pm.locator('img[src="https://example.com/center.png"]').click();
+    await page.locator('button[title="Edit"]').locator("visible=true").first().click();
+
+    // Toggle the Center checkbox
+    const centerCheckbox = page.locator('input[type="checkbox"]').locator("visible=true").first();
+    await centerCheckbox.check();
+
+    // Apply
+    await page.locator('button', { hasText: /^Apply$/ }).locator("visible=true").first().click();
+
+    // The image now has data-center="true"
+    await expect(pm.locator('img[src="https://example.com/center.png"]')).toHaveAttribute(
+      "data-center",
+      "true",
+      { timeout: 3_000 }
+    );
+  });
+});
+
+// ─── Suite 5: Bubble dismissal ───────────────────────────────────
+
+test.describe("Image edit bubble dismissal", () => {
+  test("mousedown outside the bubble dismisses it", async ({ page }) => {
+    const pm = await openMarkdownFile(page);
+    await insertImage(page, "https://example.com/dismiss.png", "dismiss");
+    await pm.locator('img[src="https://example.com/dismiss.png"]').click();
+
+    // Bubble is visible
+    await expect(
+      page.locator('button[title="Edit"]').locator("visible=true").first()
+    ).toBeVisible();
+
+    // The bubble installs its outside-click listener via setTimeout(0),
+    // so give it a tick before firing a mousedown outside.
+    await page.waitForTimeout(50);
+
+    // Fire a mousedown outside the bubble. The bubble listens for
+    // `mousedown` specifically, not `click`, so dispatchEvent must fire
+    // a MouseEvent of the right type on an element outside the bubble.
+    await page.evaluate(() => {
+      const target = document.querySelector("header") || document.body;
+      target.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    });
+
+    // Bubble should be gone
+    await expect(page.locator('button[title="Edit"]')).toHaveCount(0, { timeout: 2000 });
+  });
+
+  test("Escape dismisses the bubble", async ({ page }) => {
+    const pm = await openMarkdownFile(page);
+    await insertImage(page, "https://example.com/escape.png", "escape");
+    await pm.locator('img[src="https://example.com/escape.png"]').click();
+
+    await expect(
+      page.locator('button[title="Edit"]').locator("visible=true").first()
+    ).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(page.locator('button[title="Edit"]')).toHaveCount(0);
+  });
+});

--- a/e2e/toolbar-parity.spec.ts
+++ b/e2e/toolbar-parity.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * E2E tests asserting the Editor (markdown) and HtmlViewer (HTML)
+ * toolbars share the same visual + behavioral contract.
+ *
+ * The user flagged three specific regressions:
+ *   1. HTML pages didn't show word count / reading time
+ *   2. HTML's view-mode toggle used `<>` + eye icons, while markdown
+ *      uses `{}` + "Code" / "Rich" text labels
+ *   3. Action button order in HTML was different from markdown
+ *
+ * All three get pinned here so any future divergence fails CI.
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+test.describe.configure({ mode: "serial" });
+
+async function waitForHydration(page: Page) {
+  await page.waitForFunction(
+    () => {
+      const prsBtn = Array.from(document.querySelectorAll("button")).find(
+        (b) => b.textContent?.trim() === "PRs"
+      );
+      const hamburger = document.querySelector('button[aria-label="Open navigation"]');
+      return !!prsBtn || !!hamburger;
+    },
+    { timeout: 15_000 }
+  );
+}
+
+async function openSidebar(page: Page) {
+  const hamburger = page.locator('button[aria-label="Open navigation"]');
+  if (await hamburger.isVisible().catch(() => false)) {
+    await hamburger.click();
+    await page.waitForTimeout(350);
+  }
+}
+
+async function clickInVisibleSidebar(page: Page, text: string) {
+  await page
+    .locator("button", { hasText: new RegExp(`^${text}$`) })
+    .locator("visible=true")
+    .first()
+    .click();
+}
+
+async function clickVisibleText(page: Page, text: string | RegExp) {
+  await page.getByText(text).locator("visible=true").first().click();
+}
+
+async function openMarkdownFile(page: Page) {
+  await page.goto("/");
+  await waitForHydration(page);
+  await openSidebar(page);
+  await clickInVisibleSidebar(page, "Files");
+  await clickVisibleText(page, /README\.md/);
+  await expect(page.locator(".ProseMirror")).toBeVisible({ timeout: 10_000 });
+}
+
+async function openHtmlFile(page: Page) {
+  await page.goto("/");
+  await waitForHydration(page);
+  await openSidebar(page);
+  await clickInVisibleSidebar(page, "Files");
+  await clickVisibleText(page, /architecture-overview\.html/);
+  await expect(page.locator("iframe")).toBeVisible({ timeout: 10_000 });
+}
+
+// ─── Word count / reading time ──────────────────────────────────
+// Both Editor and HtmlViewer intentionally hide word count below
+// the sm breakpoint (640px) to save mobile toolbar space. That's a
+// product decision, not a bug, so these tests only run on desktop.
+
+test.describe("Toolbar parity: word count + reading time", () => {
+  test("markdown Editor displays words + minutes", async ({ page, viewport }) => {
+    test.skip(!viewport || viewport.width < 640, "word count is hidden below sm breakpoint");
+    await openMarkdownFile(page);
+    // Pattern: "N words · M min"
+    await expect(page.locator("text=/\\d+ words · \\d+ min/")).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  test("HtmlViewer displays words + minutes", async ({ page, viewport }) => {
+    test.skip(!viewport || viewport.width < 640, "word count is hidden below sm breakpoint");
+    await openHtmlFile(page);
+    await expect(page.locator("text=/\\d+ words · \\d+ min/")).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  test("both toolbars compute the word count from real content", async ({ page, viewport }) => {
+    test.skip(!viewport || viewport.width < 640, "word count is hidden below sm breakpoint");
+    // Check both surfaces show a non-zero word count. The demo
+    // README.md and architecture-overview.html both have visible
+    // prose, so "words" must be > 0.
+    await openMarkdownFile(page);
+    const mdText = await page
+      .locator("text=/\\d+ words · \\d+ min/")
+      .first()
+      .textContent();
+    const mdWords = parseInt((mdText || "").match(/(\d+) words/)?.[1] || "0", 10);
+    expect(mdWords).toBeGreaterThan(0);
+
+    await openHtmlFile(page);
+    const htmlText = await page
+      .locator("text=/\\d+ words · \\d+ min/")
+      .first()
+      .textContent();
+    const htmlWords = parseInt((htmlText || "").match(/(\d+) words/)?.[1] || "0", 10);
+    expect(htmlWords).toBeGreaterThan(0);
+  });
+});
+
+// ─── Code / Rich view-mode toggle ───────────────────────────────
+
+test.describe("Toolbar parity: Code/Rich view toggle", () => {
+  test("markdown Editor's toggle uses 'Code' label by default", async ({ page }) => {
+    await openMarkdownFile(page);
+    // When in rich view, the button text is "Code"
+    const toggle = page
+      .locator("button", { hasText: /^Code$/ })
+      .locator("visible=true")
+      .first();
+    await expect(toggle).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("HtmlViewer's toggle uses the same 'Code' label by default", async ({ page }) => {
+    await openHtmlFile(page);
+    const toggle = page
+      .locator("button", { hasText: /^Code$/ })
+      .locator("visible=true")
+      .first();
+    await expect(toggle).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("HtmlViewer toggle switches to 'Rich' label when in code view", async ({ page }) => {
+    await openHtmlFile(page);
+    const toggle = page
+      .locator("button", { hasText: /^Code$/ })
+      .locator("visible=true")
+      .first();
+    await toggle.click();
+    await expect(
+      page.locator("button", { hasText: /^Rich$/ }).locator("visible=true").first()
+    ).toBeVisible({ timeout: 3_000 });
+  });
+});
+
+// ─── Toolbar button ORDER ───────────────────────────────────────
+
+test.describe("Toolbar parity: button order in HtmlViewer", () => {
+  test("button order is: word count → Code toggle → fullscreen → comments", async ({ page }) => {
+    await openHtmlFile(page);
+
+    // Read the text content of each toolbar right-side element in order.
+    // The toolbar has an outer flex container with text + buttons.
+    const toolbarItems = await page.evaluate(() => {
+      // The toolbar is the first flex container with word count + view toggle
+      // Find the Code toggle button and walk up to its parent flex container.
+      const codeBtn = Array.from(document.querySelectorAll("button")).find(
+        (b) => b.textContent?.trim() === "Code"
+      );
+      if (!codeBtn) return null;
+      const toolbar = codeBtn.parentElement;
+      if (!toolbar) return null;
+      return Array.from(toolbar.children).map((el) => {
+        const text = (el.textContent || "").trim();
+        const title = el.getAttribute("title") || "";
+        return text || title;
+      });
+    });
+
+    expect(toolbarItems).not.toBeNull();
+    if (!toolbarItems) return;
+
+    // Word count comes first (non-empty text matching "N words · M min"),
+    // then Code toggle, then Fullscreen, then Comments badge.
+    const wordCountIdx = toolbarItems.findIndex((t) => /\d+ words/.test(t));
+    const codeIdx = toolbarItems.findIndex((t) => /^Code$/.test(t));
+    const fullscreenIdx = toolbarItems.findIndex((t) => /fullscreen/i.test(t));
+    const commentsIdx = toolbarItems.findIndex((t) =>
+      /^comments?$/i.test(t) || /Toggle comments/i.test(t)
+    );
+
+    expect(wordCountIdx).toBeGreaterThanOrEqual(0);
+    expect(codeIdx).toBeGreaterThan(wordCountIdx);
+    expect(fullscreenIdx).toBeGreaterThan(codeIdx);
+    expect(commentsIdx).toBeGreaterThan(fullscreenIdx);
+  });
+});

--- a/src/__tests__/word-count.test.ts
+++ b/src/__tests__/word-count.test.ts
@@ -7,7 +7,13 @@
  * nearest whole minute, with a floor of 1 minute for any non-empty content.
  */
 import { describe, it, expect } from "vitest";
-import { countWords, readingMinutes, analyzeMarkdown } from "@/lib/word-count";
+import {
+  countWords,
+  readingMinutes,
+  analyzeMarkdown,
+  countHtmlWords,
+  analyzeHtml,
+} from "@/lib/word-count";
 
 describe("countWords", () => {
   // ─── Trivial ────────────────────────────────────────────────────────────
@@ -183,5 +189,85 @@ describe("analyzeMarkdown (convenience wrapper)", () => {
     const result = analyzeMarkdown(md);
     expect(result.words).toBe(6);
     expect(result.readingMinutes).toBe(1);
+  });
+});
+
+// ─── HTML word count ──────────────────────────────────────────────
+
+describe("countHtmlWords", () => {
+  it("returns 0 for empty input", () => {
+    expect(countHtmlWords("")).toBe(0);
+  });
+
+  it("counts visible text and ignores tags", () => {
+    expect(countHtmlWords("<p>hello world</p>")).toBe(2);
+  });
+
+  it("counts across nested tags", () => {
+    expect(
+      countHtmlWords(
+        "<div><p>the quick <strong>brown</strong> fox</p></div>"
+      )
+    ).toBe(4);
+  });
+
+  it("ignores script content", () => {
+    const html = '<p>visible</p><script>var x = "not counted";</script>';
+    expect(countHtmlWords(html)).toBe(1);
+  });
+
+  it("ignores style content", () => {
+    const html = "<p>visible</p><style>body { color: red; }</style>";
+    expect(countHtmlWords(html)).toBe(1);
+  });
+
+  it("ignores noscript content", () => {
+    const html = "<p>visible</p><noscript>fallback text here</noscript>";
+    expect(countHtmlWords(html)).toBe(1);
+  });
+
+  it("ignores HTML comments", () => {
+    expect(countHtmlWords("<p>real <!-- hidden words --> text</p>")).toBe(2);
+  });
+
+  it("decodes named entities", () => {
+    // "it&apos;s" → "it's" → one word
+    expect(countHtmlWords("<p>it&apos;s here</p>")).toBe(2);
+  });
+
+  it("decodes numeric entities", () => {
+    expect(countHtmlWords("<p>hello&#32;world</p>")).toBe(2);
+  });
+
+  it("handles a full HTML document", () => {
+    const html = `<!DOCTYPE html>
+<html>
+<head><title>ignored</title><style>.x{color:red}</style></head>
+<body>
+<h1>One two three</h1>
+<p>four five six</p>
+</body>
+</html>`;
+    // "ignored" is inside <title> which is a regular tag (not script/style/noscript)
+    // so it counts. "ignored One two three four five six" = 7 words.
+    expect(countHtmlWords(html)).toBe(7);
+  });
+});
+
+describe("analyzeHtml", () => {
+  it("returns zeros for empty input", () => {
+    expect(analyzeHtml("")).toEqual({ words: 0, readingMinutes: 0 });
+  });
+
+  it("returns words + reading minutes for a short HTML doc", () => {
+    const html = "<h1>hi there</h1><p>how are you today</p>";
+    expect(analyzeHtml(html)).toEqual({ words: 6, readingMinutes: 1 });
+  });
+
+  it("hits the reading-time boundary correctly", () => {
+    // 201 visible words → 2 minutes
+    const words = Array.from({ length: 201 }, () => "word").join(" ");
+    const html = `<p>${words}</p>`;
+    expect(analyzeHtml(html)).toEqual({ words: 201, readingMinutes: 2 });
   });
 });

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -490,6 +490,13 @@ function CommentSidePanel({
 
 export default function Editor({ content, onContentChange, filePath, repoFullName, branch }: EditorProps) {
   const editorContainerRef = useRef<HTMLDivElement>(null);
+  // Separate ref for the positioned content wrapper inside the scroll
+  // container. LinkImageBubble uses `position: absolute`, so its
+  // positioning must be computed relative to its offsetParent — which
+  // is the element with `position: relative`, NOT the outer scroll
+  // container. This ref points at the correct positioning parent so
+  // the bubble's top/left math matches what the browser uses to render.
+  const editorContentRef = useRef<HTMLDivElement>(null);
   const { isDemoMode, isEmbedded, refreshRepo, prBranchForNewFile, prNumberForNewFile, openPR, pullRequests, repoFiles, openFile, setEditorIsDirty } = useApp();
   const { wide, toggle: toggleWide, contentClass } = useWideFormat();
   const [comments, setComments] = useState<EditorComment[]>([]);
@@ -1691,7 +1698,7 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
 
         {/* Editor area */}
         <div className="flex-1 overflow-y-auto" ref={editorContainerRef as React.RefObject<HTMLDivElement>} onClick={handleEditorClick}>
-          <div className={contentClass}>
+          <div className={contentClass} ref={editorContentRef}>
             {/* File path breadcrumb */}
             <div className="text-xs text-[var(--text-muted)] mb-4 font-mono flex items-center gap-2">
               {isNewFile ? (
@@ -1735,10 +1742,12 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
 
             {/* Floating comment button (desktop) */}
             <FloatingCommentButton
-              containerRef={editorContainerRef}
+              containerRef={editorContentRef}
               onComment={handleStartComment}
             />
-            {/* Mobile: fixed button at the bottom of the viewport */}
+            {/* Mobile: fixed button at the bottom of the viewport.
+                MobileCommentButton uses position: fixed (viewport-anchored),
+                so the scroll container is fine for its contains() check. */}
             {isMobile && (
               <MobileCommentButton
                 containerRef={editorContainerRef}
@@ -1746,10 +1755,11 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
               />
             )}
 
-            {/* Link / image edit bubble */}
+            {/* Link / image edit bubble — positioned relative to the
+                contentClass wrapper (the offsetParent with relative) */}
             {!codeView && (
               <LinkImageBubble
-                containerRef={editorContainerRef}
+                containerRef={editorContentRef}
                 editor={editor}
                 target={bubbleTarget}
                 onDismiss={() => setBubbleTarget(null)}

--- a/src/components/HtmlViewer.tsx
+++ b/src/components/HtmlViewer.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import React, { useMemo, useRef, useState, useEffect, useCallback } from "react";
-import { Code2, Eye, Maximize2, Minimize2, MessageSquare, X, GitPullRequest, Loader2 } from "lucide-react";
+import { Braces, Maximize2, Minimize2, MessageSquare, X, GitPullRequest, Loader2 } from "lucide-react";
 import { useIsMobile } from "@/lib/use-viewport";
 import { useApp } from "@/lib/app-context";
 import { injectSourceLineAttributes } from "@/lib/html-source-lines";
 import { buildIframeSelectionScript } from "@/lib/html-selection";
 import { createReviewPR, createInlineComment } from "@/lib/github-api";
+import { analyzeHtml } from "@/lib/word-count";
 
 interface HtmlViewerProps {
   content: string;
@@ -99,6 +100,11 @@ export default function HtmlViewer({ content, filePath, repoFullName, branch }: 
     }
     return content;
   }, [content, repoFullName, branch, filePath]);
+
+  // Word count + reading time. Pure function, no DOM parser, cheap
+  // to compute on each content change. Parity with the markdown
+  // Editor's stats display.
+  const stats = useMemo(() => analyzeHtml(content || ""), [content]);
 
   // Inject source-line attributes + resize + selection scripts into
   // the iframe srcdoc. Same pattern as DiffViewer's HTML handling.
@@ -231,35 +237,63 @@ export default function HtmlViewer({ content, filePath, repoFullName, branch }: 
 
   return (
     <div ref={containerRef} className="h-full flex flex-col bg-[var(--surface)]">
-      {/* Toolbar */}
+      {/* Toolbar. Button order matches the markdown Editor's toolbar
+          so the two surfaces feel like the same app. Right-side order:
+          word count → Code/Rich toggle → Fullscreen toggle → Comments
+          toggle. The Code/Rich toggle uses the same Braces icon + text
+          label pattern as the Editor. */}
       <div className="flex items-center justify-between px-4 py-2 border-b border-[var(--border)] bg-[var(--bg-secondary,var(--surface))]">
         <span className="text-sm font-medium text-[var(--text)] truncate">{fileName}</span>
         <div className="flex items-center gap-1">
-          <button
-            onClick={() => setShowPanel(!showPanel)}
-            className={`flex items-center gap-1 text-xs px-2 py-1 rounded transition-colors ${
-              showPanel
-                ? "text-[var(--accent)] bg-[var(--accent-muted)]"
-                : "text-[var(--text-muted)] hover:text-[var(--accent)]"
-            }`}
-            title="Toggle comments panel"
-          >
-            <MessageSquare size={14} />
-            {unresolvedCount > 0 ? `${unresolvedCount} comment${unresolvedCount > 1 ? "s" : ""}` : "Comments"}
-          </button>
+          {/* Word count + reading time — hidden when empty */}
+          {stats.words > 0 && (
+            <span
+              className="hidden sm:inline text-[10px] text-[var(--text-muted)] font-mono px-1.5 select-none"
+              title={`${stats.words.toLocaleString()} words · ~${stats.readingMinutes} min read`}
+            >
+              {stats.words.toLocaleString()} words · {stats.readingMinutes} min
+            </span>
+          )}
+
+          {/* Code / Rich toggle — same pattern as Editor */}
           <button
             onClick={() => setViewSource(!viewSource)}
-            className={`toolbar-btn ${viewSource ? "bg-[var(--accent)]/10 text-[var(--accent)]" : ""}`}
-            title={viewSource ? "Rendered view" : "View source"}
+            className={`flex items-center gap-1 px-2 py-1 text-[11px] rounded-md transition-colors ${
+              viewSource
+                ? "bg-[var(--accent-muted)] text-[var(--accent)] font-medium"
+                : "text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--surface-hover)]"
+            }`}
+            title={viewSource ? "Switch back to rendered view" : "View raw HTML"}
           >
-            {viewSource ? <Eye size={16} /> : <Code2 size={16} />}
+            <Braces size={13} />
+            {viewSource ? "Rich" : "Code"}
           </button>
+
+          {/* Fullscreen toggle */}
           <button
             onClick={() => setFullscreen(!fullscreen)}
             className="toolbar-btn"
             title={fullscreen ? "Exit fullscreen" : "Fullscreen"}
           >
             {fullscreen ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
+          </button>
+
+          {/* Comments toggle — same pattern as Editor: badge + count */}
+          <button
+            onClick={() => setShowPanel(!showPanel)}
+            className={`flex items-center gap-1.5 px-2.5 py-1.5 text-xs rounded-md transition-colors ${
+              showPanel
+                ? "bg-[var(--accent-muted)] text-[var(--accent)] font-medium"
+                : "text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--surface-hover)]"
+            }`}
+            title="Toggle comments panel"
+          >
+            <MessageSquare size={13} />
+            {unresolvedCount > 0 && (
+              <span className="bg-[var(--accent)] text-white text-[9px] font-bold w-4 h-4 rounded-full flex items-center justify-center">
+                {unresolvedCount}
+              </span>
+            )}
           </button>
         </div>
       </div>

--- a/src/lib/word-count.ts
+++ b/src/lib/word-count.ts
@@ -38,6 +38,63 @@ export function analyzeMarkdown(markdown: string): MarkdownStats {
 }
 
 /**
+ * HTML-aware word count. Strips script, style, and comment blocks
+ * (which shouldn't count as reading content), then removes the
+ * remaining tags, decodes common HTML entities, and delegates to the
+ * same whitespace-tokenizer used for markdown.
+ *
+ * Pure — no DOM parser, just regex — so it can run on every keystroke
+ * without a heavy pass.
+ */
+export function countHtmlWords(html: string): number {
+  if (!html) return 0;
+  const stripped = stripHtml(html);
+  const trimmed = stripped.trim();
+  if (!trimmed) return 0;
+  return trimmed.split(/\s+/).length;
+}
+
+export function analyzeHtml(html: string): MarkdownStats {
+  const words = countHtmlWords(html);
+  return { words, readingMinutes: readingMinutes(words) };
+}
+
+function stripHtml(html: string): string {
+  let s = html;
+
+  // HTML comments — drop entirely.
+  s = s.replace(/<!--[\s\S]*?-->/g, " ");
+
+  // Script, style, and noscript content — reading time shouldn't
+  // include source code or CSS. Match any of these elements
+  // case-insensitively and drop their entire inner content.
+  s = s.replace(/<(script|style|noscript)\b[^>]*>[\s\S]*?<\/\1>/gi, " ");
+
+  // All other tags — drop the tag but keep its content.
+  s = s.replace(/<[^>]+>/g, " ");
+
+  // Common named entities so "don&amp;t" counts as one word, not two.
+  s = s
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/gi, "'");
+
+  // Numeric entities (&#123; / &#x1F600;)
+  s = s.replace(/&#x([0-9a-f]+);/gi, (_m, hex) =>
+    String.fromCodePoint(parseInt(hex, 16))
+  );
+  s = s.replace(/&#(\d+);/g, (_m, num) =>
+    String.fromCodePoint(parseInt(num, 10))
+  );
+
+  return s;
+}
+
+/**
  * Strip markdown syntax and content that shouldn't count toward the word
  * count (fenced and indented code blocks, image alt text, URLs, HTML
  * comments, heading/list/blockquote markers, table pipes, horizontal rules).


### PR DESCRIPTION
Four regressions the user reported. Each one is now pinned down with a Playwright test that fails without the fix and passes with it.

## The four bugs

### 1. Image edit bubble positioning (the big one)
LinkImageBubble was rendering **off-screen at y=-2254px** (verified by Playwright assertion). Root cause: the bubble uses `position: absolute` with top/left computed from rects, but `containerRef` was pointing at the outer `overflow-y-auto` scroll wrapper while the bubble's actual `offsetParent` was the inner `contentClass` wrapper (which has `position: relative`). Math used the outer rect but CSS applied it relative to the inner — every render landed in the wrong place.

**Fix:** added `editorContentRef` on the positioned inner wrapper; LinkImageBubble + FloatingCommentButton use that now.

### 2. HtmlViewer had no word count / reading time
Parity with Editor. Added `countHtmlWords` + `analyzeHtml` helpers in `src/lib/word-count.ts` — a pure regex-based HTML tokenizer that strips script/style/comment blocks, removes tags, decodes entities, and counts. 12 new unit tests.

### 3. Code/Rich toggle icon mismatch
Editor uses `<Braces>` + text label 'Code'/'Rich'. HtmlViewer was using `<Code2>` + `<Eye>` icon-only. Unified.

### 4. Toolbar button order
Reordered HtmlViewer to match Editor: word count → Code/Rich toggle → Fullscreen → Comments. Comments toggle now uses the badge pattern (bubble with count).

## New e2e coverage (26 tests)

- **`e2e/image-flows.spec.ts`** (10 tests) — Add Image popover, insertion, bubble-on-click, **bubble position geometry** (catches the regression above), edit fields, resize by width input, aspect-lock auto-fill, center checkbox, outside-click dismiss, Escape dismiss
- **`e2e/toolbar-parity.spec.ts`** (6 tests) — word count display, Code/Rich toggle label + switching, button order assertion

Plus 12 new unit tests for HTML word count.

## Results
- **825 unit tests** (+13 new), all green
- **37 e2e tests** green (3 skipped for mobile word count — intentional `hidden sm:inline`)
- Build clean, bundle unchanged