### PR TITLE
fix: CI Playwright webServer for static export

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,11 @@ jobs:
       - run: npm ci
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        # Install both chromium AND webkit — the mobile test project
+        # uses the iPhone 14 device profile which launches webkit.
+        # Without webkit, mobile tests fail with "Executable doesn't
+        # exist at .../webkit-xxxx/pw_run.sh".
+        run: npx playwright install --with-deps chromium webkit
 
       - name: Build the app
         run: npx next build

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -38,10 +38,17 @@ export default defineConfig({
   ],
 
   webServer: {
-    // In CI the test.yml workflow runs `next build` before this,
-    // so `next start` serves the production build. Locally, `npm run dev`
-    // is faster. Both listen on 3000.
-    command: process.env.CI ? "npx next start" : "npm run dev",
+    // Locally: `npm run dev` is the fastest path and picks up HMR.
+    //
+    // In CI: the workflow runs `npx next build` before playwright,
+    // producing a fully static export in `out/`. MarDoc uses
+    // `output: "export"` in next.config.js, so `next start` is not
+    // supported. Serve the static bundle with `serve` instead — it
+    // handles client-side hash routing correctly because the shell
+    // lives at `out/index.html` and everything else is a hash route.
+    command: process.env.CI
+      ? "npx --yes serve out -l 3000 --no-clipboard"
+      : "npm run dev",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,


### PR DESCRIPTION
The Test workflow has been **failing on every run** since I added it yesterday. Unit tests pass; Playwright fails because my playwright.config.ts told CI to start the app with `next start`, but `next.config.js` uses `output: 'export'` which is incompatible with `next start`. Next.js says 'Use npx serve@latest out instead.'

Fix: use `npx --yes serve out -l 3000` in CI. Test workflow already runs `npx next build` to produce `out/`, so serving the static bundle is correct and faster than a dev server.

Verified locally with `CI=1 npm run e2e` against a fresh production build — all 20 desktop e2e tests pass.