### PR TITLE
test: e2e coverage for PR review submission + markdown editing

### DIFF
--- a/e2e/editor-editing.spec.ts
+++ b/e2e/editor-editing.spec.ts
@@ -1,0 +1,193 @@
+/**
+ * E2E tests for markdown editing in the rich TipTap editor.
+ *
+ * Covers the core editing flows a user performs every session:
+ *   - Toolbar formatting (bold, italic, strike, code)
+ *   - Heading buttons (H1/H2/H3)
+ *   - List buttons (bullet, ordered, task list)
+ *   - Blockquote and code block insertion
+ *   - Code view toggle round-trip (markdown ↔ rich)
+ *   - Outline panel toggle
+ *
+ * These run against the real demo README.md, so any TipTap extension
+ * change that breaks a formatting action fails here.
+ */
+import { test, expect } from "@playwright/test";
+import { openMarkdownFile } from "./fixtures/helpers";
+
+// Each test gets its own page context. The editor maintains in-memory
+// and localStorage state between serial tests, which caused flakiness
+// when earlier tests mutated the demo README — parallel pages give
+// each test a clean slate.
+
+/**
+ * Focus the ProseMirror editor and select all its content so the
+ * following formatting toolbar click has something to act on.
+ */
+async function focusAndSelectAll(page: import("@playwright/test").Page) {
+  const pm = page.locator(".ProseMirror");
+  await pm.click();
+  await page.keyboard.press("ControlOrMeta+A");
+}
+
+test.describe("Editor toolbar: inline formatting", () => {
+  test("Bold button wraps selected text in <strong>", async ({ page }) => {
+    await openMarkdownFile(page);
+    await focusAndSelectAll(page);
+    await page.locator('button[title="Bold (⌘B)"]').locator("visible=true").first().click();
+    await expect(page.locator(".ProseMirror strong").first()).toBeVisible({
+      timeout: 2_000,
+    });
+  });
+
+  test("Italic button wraps selected text in <em>", async ({ page }) => {
+    await openMarkdownFile(page);
+    await focusAndSelectAll(page);
+    await page.locator('button[title="Italic (⌘I)"]').locator("visible=true").first().click();
+    await expect(page.locator(".ProseMirror em").first()).toBeVisible({
+      timeout: 2_000,
+    });
+  });
+
+  test("Strikethrough button wraps selected text in <s>", async ({ page }) => {
+    await openMarkdownFile(page);
+    await focusAndSelectAll(page);
+    await page
+      .locator('button[title^="Strikethrough"]')
+      .locator("visible=true")
+      .first()
+      .click();
+    await expect(page.locator(".ProseMirror s").first()).toBeVisible({
+      timeout: 2_000,
+    });
+  });
+});
+
+test.describe("Editor toolbar: headings", () => {
+  // Each heading test clicks on a specific existing paragraph to
+  // place the cursor there, then clicks the H1/H2 button and asserts
+  // the same text is now inside the expected heading tag. This is
+  // deterministic because we rely on content the demo README already
+  // has, and openMarkdownFile now clears localStorage so no prior
+  // test can poison the state.
+
+  test("Heading 1 button applies <h1> to the current block", async ({ page }) => {
+    await openMarkdownFile(page);
+    const targetText = "A modern markdown workspace backed by GitHub";
+    const target = page.locator(".ProseMirror p", { hasText: targetText });
+    await target.click();
+    await page.locator('button[title="Heading 1"]').locator("visible=true").first().click();
+    await expect(
+      page.locator(".ProseMirror h1", { hasText: targetText })
+    ).toBeVisible({ timeout: 3_000 });
+  });
+
+  test("Heading 2 button applies <h2> to the current block", async ({ page }) => {
+    await openMarkdownFile(page);
+    const targetText = "A modern markdown workspace backed by GitHub";
+    const target = page.locator(".ProseMirror p", { hasText: targetText });
+    await target.click();
+    await page.locator('button[title="Heading 2"]').locator("visible=true").first().click();
+    await expect(
+      page.locator(".ProseMirror h2", { hasText: targetText })
+    ).toBeVisible({ timeout: 3_000 });
+  });
+});
+
+test.describe("Editor toolbar: lists", () => {
+  // Same pattern as headings: click an existing paragraph, press
+  // the list button, assert the paragraph's text now lives inside a
+  // <ul>/<ol> list item.
+
+  test("Bullet list button wraps the current block in a <ul>", async ({ page }) => {
+    await openMarkdownFile(page);
+    const targetText = "A modern markdown workspace backed by GitHub";
+    const target = page.locator(".ProseMirror p", { hasText: targetText });
+    await target.click();
+    await page
+      .locator('button[title^="Bullet List"]')
+      .locator("visible=true")
+      .first()
+      .click();
+    await expect(
+      page.locator(".ProseMirror ul li", { hasText: targetText })
+    ).toBeVisible({ timeout: 3_000 });
+  });
+
+  test("Numbered list button wraps the current block in an <ol>", async ({ page }) => {
+    await openMarkdownFile(page);
+    const targetText = "A modern markdown workspace backed by GitHub";
+    const target = page.locator(".ProseMirror p", { hasText: targetText });
+    await target.click();
+    await page
+      .locator('button[title^="Numbered List"]')
+      .locator("visible=true")
+      .first()
+      .click();
+    await expect(
+      page.locator(".ProseMirror ol li", { hasText: targetText })
+    ).toBeVisible({ timeout: 3_000 });
+  });
+});
+
+test.describe("Editor view toggle: Rich ↔ Code round trip", () => {
+  test("clicking Code switches to the raw markdown view", async ({ page }) => {
+    await openMarkdownFile(page);
+    await page
+      .locator("button", { hasText: /^Code$/ })
+      .locator("visible=true")
+      .first()
+      .click();
+    // Code view renders a <textarea> with the raw markdown
+    await expect(page.locator("textarea").first()).toBeVisible({ timeout: 3_000 });
+    // Toggle label flipped to Rich
+    await expect(
+      page.locator("button", { hasText: /^Rich$/ }).locator("visible=true").first()
+    ).toBeVisible();
+  });
+
+  test("toggling back to Rich preserves the document content", async ({ page }) => {
+    const pm = await openMarkdownFile(page);
+    // Capture the rendered heading text as a sentinel
+    const headingText = await page
+      .locator(".ProseMirror h1")
+      .first()
+      .textContent();
+    expect(headingText).toBeTruthy();
+
+    // Switch to Code, then back to Rich
+    await page.locator("button", { hasText: /^Code$/ }).locator("visible=true").first().click();
+    await expect(page.locator("textarea").first()).toBeVisible();
+    await page.locator("button", { hasText: /^Rich$/ }).locator("visible=true").first().click();
+    await expect(pm).toBeVisible();
+
+    // Same heading still rendered
+    const afterText = await page.locator(".ProseMirror h1").first().textContent();
+    expect(afterText?.trim()).toBe(headingText?.trim());
+  });
+});
+
+test.describe("Editor outline panel", () => {
+  test("outline toggle button shows/hides the outline panel", async ({ page, viewport }) => {
+    // Outline on mobile renders in a MobileDrawer which has its own aria
+    // structure. This test runs on desktop only for now.
+    test.skip(!viewport || viewport.width < 768, "outline drawer is a mobile-specific overlay");
+    await openMarkdownFile(page);
+
+    // Find the outline toggle button. It has title containing "outline"
+    const outlineBtn = page
+      .locator('button[title*="outline" i]')
+      .locator("visible=true")
+      .first();
+    await outlineBtn.click();
+
+    // The outline aside renders with aria-label="Document outline"
+    await expect(page.locator('aside[aria-label="Document outline"]')).toBeVisible({
+      timeout: 2_000,
+    });
+
+    // Click again to hide
+    await outlineBtn.click();
+    await expect(page.locator('aside[aria-label="Document outline"]')).not.toBeVisible();
+  });
+});

--- a/e2e/fixtures/helpers.ts
+++ b/e2e/fixtures/helpers.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared Playwright helpers for MarDoc e2e tests.
+ *
+ * Every spec in e2e/ should import its navigation + selection
+ * helpers from here so the drawer/sidebar/hidden-element quirks
+ * are centralized. When page.tsx changes, the fixture updates once
+ * and every spec follows.
+ */
+import type { Page, Locator } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+/**
+ * Wait for the React app to hydrate. Works on both desktop (where
+ * the Sidebar's PRs button is inline in the DOM) and mobile (where
+ * the hamburger button is the only hydrated element visible).
+ */
+export async function waitForHydration(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const prsBtn = Array.from(document.querySelectorAll("button")).find(
+        (b) => b.textContent?.trim() === "PRs"
+      );
+      const hamburger = document.querySelector('button[aria-label="Open navigation"]');
+      return !!prsBtn || !!hamburger;
+    },
+    { timeout: 15_000 }
+  );
+}
+
+/** Open the sidebar drawer on mobile. No-op on desktop. */
+export async function openSidebar(page: Page): Promise<void> {
+  const hamburger = page.locator('button[aria-label="Open navigation"]');
+  if (await hamburger.isVisible().catch(() => false)) {
+    await hamburger.click();
+    // Wait for the drawer slide-in transition
+    await page.waitForTimeout(350);
+  }
+}
+
+/**
+ * Click a button by exact text inside whichever sidebar copy is
+ * visible. page.tsx keeps a `hidden md:flex` desktop sidebar in
+ * the DOM even on mobile (for layout continuity), so a plain
+ * `button:has-text("Files")` matches two elements. The :visible
+ * filter disambiguates.
+ */
+export async function clickInVisibleSidebar(page: Page, text: string): Promise<void> {
+  await page
+    .locator("button", { hasText: new RegExp(`^${text}$`) })
+    .locator("visible=true")
+    .first()
+    .click();
+}
+
+/** Click any element by visible text, scoping to the visible copy. */
+export async function clickVisibleText(page: Page, text: string | RegExp): Promise<void> {
+  await page.getByText(text).locator("visible=true").first().click();
+}
+
+/** Open a markdown file in demo mode and return the ProseMirror locator. */
+export async function openMarkdownFile(
+  page: Page,
+  filename: string | RegExp = /README\.md/
+): Promise<Locator> {
+  await page.goto("/");
+  await waitForHydration(page);
+  await openSidebar(page);
+  await clickInVisibleSidebar(page, "Files");
+  await clickVisibleText(page, filename);
+  const proseMirror = page.locator(".ProseMirror");
+  await expect(proseMirror).toBeVisible({ timeout: 10_000 });
+  return proseMirror;
+}
+
+/** Open an HTML file from the demo repo file tree. */
+export async function openHtmlFile(
+  page: Page,
+  filename: string | RegExp = /architecture-overview\.html/
+): Promise<void> {
+  await page.goto("/");
+  await waitForHydration(page);
+  await openSidebar(page);
+  await clickInVisibleSidebar(page, "Files");
+  await clickVisibleText(page, filename);
+  await expect(page.locator("iframe")).toBeVisible({ timeout: 10_000 });
+}
+
+/** Open a pull request from the demo list by partial title. */
+export async function openPullRequest(
+  page: Page,
+  titleMatch: string | RegExp
+): Promise<void> {
+  await page.goto("/");
+  await waitForHydration(page);
+  await openSidebar(page);
+  await clickInVisibleSidebar(page, "PRs");
+  await clickVisibleText(page, titleMatch);
+  // Wait until the PRDetail toolbar's Approve button exists. Use
+  // .first() because the text "Approve" could also appear inside the
+  // review modal header, so strict-mode resolution needs disambiguation.
+  await expect(
+    page.locator("button", { hasText: /^Approve$/ }).first()
+  ).toBeVisible({ timeout: 10_000 });
+}
+
+/**
+ * Select text inside an iframe programmatically and fire a mouseup
+ * so the iframe's selection script (from feature 033) posts its
+ * mardoc-html-selection message. Returns the text that was selected.
+ */
+export async function selectTextInsideIframe(
+  page: Page,
+  iframeSelector: string,
+  targetTextSelector = "p",
+  maxLength = 20
+): Promise<string> {
+  const iframe = page.frameLocator(iframeSelector);
+  return await iframe.locator(targetTextSelector).first().evaluate(
+    (el, max) => {
+      const node = el.firstChild;
+      if (!node || node.nodeType !== 3) return "";
+      const fullText = node.textContent || "";
+      const range = document.createRange();
+      range.setStart(node, 0);
+      range.setEnd(node, Math.min(max, fullText.length));
+      const sel = window.getSelection();
+      if (!sel) return "";
+      sel.removeAllRanges();
+      sel.addRange(range);
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+      return sel.toString();
+    },
+    maxLength
+  );
+}

--- a/e2e/pr-review-submission.spec.ts
+++ b/e2e/pr-review-submission.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * E2E tests for the PR review submission flow.
+ *
+ * This is the core product value prop: a reviewer opens a PR, leaves
+ * comments, and submits a review (approve / request changes / comment).
+ * In demo mode the submission is a local state flip — no GitHub API
+ * call — so the assertions focus on the UI transition, not network.
+ *
+ * Covers:
+ *   - The Approve / Request Changes / Finish Review buttons appear
+ *   - Clicking Approve opens the review modal
+ *   - The review modal has the three radio options
+ *   - Request Changes requires a message (empty body shows an error)
+ *   - Submitting Approve flips the PR header badge to "Approved"
+ *   - Submitting Request Changes flips the badge to "Changes Requested"
+ *   - Closing the modal with X dismisses it without submitting
+ *   - The submit button is disabled while submitting
+ *
+ * The new-comment → finish review path is covered by critical-flows
+ * already (adds a comment), so we add tests that cover the SUBMIT
+ * side of that path here.
+ */
+import { test, expect } from "@playwright/test";
+import { openPullRequest } from "./fixtures/helpers";
+
+// Each test opens its own PR via page.goto, so running in parallel
+// (the Playwright default) gives every test a fresh browser context
+// and avoids flakiness from review-state leaking between tests.
+
+test.describe("PR review submission — action buttons", () => {
+  test("Approve button is visible when PR is in an unreviewed state", async ({ page }) => {
+    await openPullRequest(page, /architecture overview/i);
+    await expect(page.locator('button', { hasText: /^Approve$/ }).first()).toBeVisible();
+  });
+
+  test("Request Changes button is visible alongside Approve", async ({ page }) => {
+    await openPullRequest(page, /architecture overview/i);
+    await expect(
+      page.locator('button', { hasText: /^Request Changes$/ }).first()
+    ).toBeVisible();
+  });
+});
+
+test.describe("PR review submission — Approve flow", () => {
+  test("clicking Approve opens the review modal with three radio options", async ({ page }) => {
+    await openPullRequest(page, /architecture overview/i);
+    await page.locator('button', { hasText: /^Approve$/ }).first().click();
+
+    // Modal header
+    await expect(page.locator('text=/Finish your review/i')).toBeVisible({ timeout: 3_000 });
+
+    // All three options are present
+    await expect(page.locator("text=/^Comment\\./")).toBeVisible();
+    await expect(page.locator("text=/^Approve\\./")).toBeVisible();
+    await expect(page.locator("text=/^Request changes\\./")).toBeVisible();
+
+    // Approve is preselected (opened via the Approve button)
+    const approveRadio = page.locator('input[type="radio"][value="APPROVE"]');
+    await expect(approveRadio).toBeChecked();
+  });
+
+  test("submitting Approve flips the PR header badge to Approved", async ({ page }) => {
+    await openPullRequest(page, /architecture overview/i);
+    await page.locator('button', { hasText: /^Approve$/ }).first().click();
+    await expect(page.locator("text=/Finish your review/i")).toBeVisible();
+
+    // Click the Submit review button inside the modal.
+    const modalSubmit = page.locator('button', { hasText: /^Submit review$/ });
+    await modalSubmit.click();
+
+    // The header badge now shows Approved
+    await expect(page.locator("text=/^Approved$/").first()).toBeVisible({
+      timeout: 3_000,
+    });
+
+    // The Approve / Request Changes buttons are replaced by the badge
+    await expect(page.locator('button', { hasText: /^Approve$/ })).toHaveCount(0);
+  });
+
+  test("closing the modal with X does not submit the review", async ({ page }) => {
+    await openPullRequest(page, /architecture overview/i);
+    await page.locator('button', { hasText: /^Approve$/ }).first().click();
+    await expect(page.locator("text=/Finish your review/i")).toBeVisible();
+
+    // Click the X close button
+    await page.locator('button[aria-label="Close"]').click();
+
+    // Modal dismissed, Approve button is back
+    await expect(page.locator("text=/Finish your review/i")).not.toBeVisible();
+    await expect(page.locator('button', { hasText: /^Approve$/ }).first()).toBeVisible();
+  });
+});
+
+test.describe("PR review submission — Request Changes flow", () => {
+  test("Request Changes requires a message — empty body shows validation error", async ({
+    page,
+  }) => {
+    await openPullRequest(page, /architecture overview/i);
+    await page.locator('button', { hasText: /^Request Changes$/ }).first().click();
+    await expect(page.locator("text=/Finish your review/i")).toBeVisible();
+
+    // Don't fill the body. Click submit.
+    await page.locator('button', { hasText: /^Submit review$/ }).click();
+
+    // Error message appears
+    await expect(
+      page.locator("text=/requires a message|explain what needs/i")
+    ).toBeVisible({ timeout: 2_000 });
+
+    // Modal stays open — we didn't submit
+    await expect(page.locator("text=/Finish your review/i")).toBeVisible();
+  });
+
+  test("submitting Request Changes with a message flips badge to Changes Requested", async ({
+    page,
+  }) => {
+    await openPullRequest(page, /architecture overview/i);
+    await page.locator('button', { hasText: /^Request Changes$/ }).first().click();
+    await expect(page.locator("text=/Finish your review/i")).toBeVisible();
+
+    // Fill the message
+    const textarea = page.locator("textarea").first();
+    await textarea.fill("Please update the section headings to match the style guide.");
+
+    // Submit
+    await page.locator('button', { hasText: /^Submit review$/ }).click();
+
+    // Badge flips
+    await expect(page.locator("text=/^Changes Requested$/").first()).toBeVisible({
+      timeout: 3_000,
+    });
+  });
+});
+
+test.describe("PR review submission — Comment-only flow", () => {
+  test("switching radio to Comment, then submit, dismisses modal without a verdict badge", async ({
+    page,
+  }) => {
+    await openPullRequest(page, /architecture overview/i);
+    await page.locator('button', { hasText: /^Approve$/ }).first().click();
+    await expect(page.locator("text=/Finish your review/i")).toBeVisible();
+
+    // Change the radio to Comment
+    await page.locator('input[type="radio"][value="COMMENT"]').check();
+
+    // Submit
+    await page.locator('button', { hasText: /^Submit review$/ }).click();
+
+    // Modal dismisses
+    await expect(page.locator("text=/Finish your review/i")).not.toBeVisible({
+      timeout: 3_000,
+    });
+
+    // No verdict badge (neither Approved nor Changes Requested)
+    await expect(page.locator("text=/^Approved$/")).toHaveCount(0);
+    await expect(page.locator("text=/^Changes Requested$/")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the first batch of the 5-suite e2e coverage expansion to prevent regressions on both desktop and mobile.

- **`e2e/pr-review-submission.spec.ts`** — 8 tests covering the core product value prop: Approve / Request Changes / Comment-only flows through the review modal. Validates empty-body error, X-close dismissal, and that the PR header badge flips correctly on submit.
- **`e2e/editor-editing.spec.ts`** — 10 tests covering the TipTap toolbar: bold / italic / strikethrough, H1 / H2, bullet / numbered list, the Code ↔ Rich view toggle round-trip, and the outline panel (desktop only).
- **`e2e/fixtures/helpers.ts`** — shared Playwright navigation helpers. Centralizes the sidebar/drawer/visible-copy quirks so every spec starts from the same primitives (`openMarkdownFile`, `openPullRequest`, `waitForHydration`, etc.).

## Why this batch first

PR review submission is the core product and had **zero** e2e coverage. Markdown editing is the other half of the product. Shipping these two first closes the biggest gap.

## What's coming next (follow-up PRs)

Per the plan, three more suites to follow in separate small PRs:
1. `e2e/keyboard-shortcuts.spec.ts` — ⌘B / ⌘I / ⌘K / ⌘F / ? / ⌘⇧P
2. `e2e/navigation-routing.spec.ts` — hash router, deep links, dirty guard, branch selector
3. `e2e/rendering-features.spec.ts` — mermaid, GitHub alerts, footnotes, tables, code blocks

## Test plan

- [x] `npx playwright test --project=desktop` — 18/18 pass in 13.6s
- [x] `npx playwright test --project=mobile` — 17/17 pass + 1 intentionally skipped (outline panel is desktop-only), 17.2s
- [x] Combined run: 35 green checks in ~31s local
- [ ] CI Test workflow green