### PR TITLE
test: e2e coverage for rendering features

### DIFF
--- a/e2e/rendering-features.spec.ts
+++ b/e2e/rendering-features.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * E2E tests for MarDoc's rendering features.
+ *
+ * Transforms for each feature (mermaid, GitHub alerts, footnotes, tables,
+ * syntax highlighting) are unit-tested in src/__tests__/. These e2e tests
+ * prove the transforms that reach the editor DOM are actually wired up —
+ * a broken extension pipeline or a missing Showdown plugin fails here.
+ *
+ * Covers:
+ *   - Mermaid code fences render as pre-rendered diagram images
+ *   - Tables render as <table> elements with column headers
+ *   - Inline code renders as <code>
+ *   - Code blocks render with lowlight syntax highlighting spans
+ *
+ * NOT covered here (intentional):
+ *   - GitHub alerts ([!NOTE] etc.) — rendered via dangerouslySetInnerHTML
+ *     in PRDetail.tsx, not via TipTap. TipTap strips the wrapper div
+ *     because markdown-alert isn't a registered node type. Transform
+ *     correctness lives in src/__tests__/github-alerts.test.ts (22 cases).
+ *   - Footnotes — same story: the <sup class="footnote-ref"> wrapper is
+ *     stripped by TipTap. Transform correctness in
+ *     src/__tests__/footnotes.test.ts.
+ */
+import { test, expect } from "@playwright/test";
+import { openMarkdownFile } from "./fixtures/helpers";
+
+test.describe("Rendering: mermaid diagrams", () => {
+  test("A mermaid code fence renders as a diagram image", async ({ page }) => {
+    await openMarkdownFile(page, /README\.md/);
+    // MarDoc pre-renders mermaid fences to an SVG data URL that is
+    // embedded as an <img alt="Mermaid diagram">. The README ships
+    // three such diagrams — at least one should be visible.
+    await expect(
+      page.locator('.ProseMirror img[alt="Mermaid diagram"]').first()
+    ).toBeVisible({ timeout: 5_000 });
+  });
+});
+
+test.describe("Rendering: tables", () => {
+  test("A markdown table renders as an HTML <table>", async ({ page }) => {
+    await openMarkdownFile(page, /README\.md/);
+    // Demo README has several tables — at minimum one with the "Syntax"
+    // column header. Table should be rendered, not raw markdown.
+    await expect(page.locator(".ProseMirror table").first()).toBeVisible({
+      timeout: 3_000,
+    });
+    // Spot-check a known column header is rendered as a th
+    await expect(
+      page.locator(".ProseMirror th", { hasText: "Syntax" })
+    ).toBeVisible();
+  });
+});
+
+test.describe("Rendering: code blocks and inline code", () => {
+  test("Fenced code blocks render with syntax highlighting", async ({ page }) => {
+    await openMarkdownFile(page, /README\.md/);
+    // lowlight wraps highlighted tokens in <span class="hljs-...">.
+    // We just assert at least one such span exists inside a .ProseMirror pre.
+    await expect(
+      page.locator('.ProseMirror pre code [class^="hljs-"]').first()
+    ).toBeVisible({ timeout: 3_000 });
+  });
+
+  test("Inline code renders as a <code> element", async ({ page }) => {
+    await openMarkdownFile(page, /README\.md/);
+    // The README has `**bold**` in an inline code span inside its
+    // syntax table.
+    await expect(page.locator(".ProseMirror code").first()).toBeVisible({
+      timeout: 3_000,
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary

Final of the 5 e2e test suites. Covers the rendering features that reach the TipTap editor DOM — mermaid diagrams, tables, and code blocks.

### What's tested

- **Mermaid diagrams** — code fences pre-render to an `<img alt="Mermaid diagram">`. The demo README ships three diagrams.
- **Tables** — markdown tables render as `<table>` with `<th>` column headers.
- **Inline code** — renders as `<code>`.
- **Fenced code blocks** — render with lowlight syntax highlighting (`.hljs-*` spans).

### Intentional exclusions (with reasoning)

- **GitHub alerts** (`[!NOTE]`, `[!WARNING]`, etc.) — rendered via `dangerouslySetInnerHTML` in `PRDetail.tsx`, **not** in the editor. TipTap strips the wrapper `<div class="markdown-alert-note">` during `setContent` because it isn't a registered node type, so the editor surface can't exercise them. Transform correctness lives in `src/__tests__/github-alerts.test.ts` (22 cases).
- **Footnotes** — same story: TipTap strips `<sup class="footnote-ref">` and `<section class="footnotes">`. Transform correctness in `src/__tests__/footnotes.test.ts`.

If you want e2e coverage for alerts/footnotes rendering, the right place is a PR-description fixture in a PR detail view test, not the editor. Happy to follow up if that's worth doing.

## Test plan

- [x] \`npx playwright test --project=desktop\` — 4/4 pass
- [x] \`npx playwright test --project=mobile\` — 4/4 pass
- [x] Combined run: 8/8 pass in 12.5s local
- [x] CI Test workflow green

## Rollup of the 5-suite expansion

With this merged, the e2e suite goes from 40 → ~80 tests covering:
- ✅ HTML commenting + image editing (pre-existing)
- ✅ PR review submission flows (PR #83)
- ✅ Markdown editor toolbar + view toggle + outline (PR #83)
- ✅ Keyboard shortcuts — help overlays, editor formatting, find bar (PR #84)
- ✅ Sidebar navigation — file switching, PRs tab, back button (PR #85)
- ✅ Rendering features — mermaid, tables, code blocks (this PR)