### PR TITLE
fix: PR description collapse toggle now actually collapses

### DIFF
--- a/e2e/pr-review-submission.spec.ts
+++ b/e2e/pr-review-submission.spec.ts
@@ -132,6 +132,47 @@ test.describe("PR review submission — Request Changes flow", () => {
   });
 });
 
+test.describe("PR detail — description collapse toggle", () => {
+  // The "Description" button in the PR header used to be a broken
+  // <details> element with no children. This test guards against the
+  // regression by proving that clicking the button actually hides the
+  // description body.
+
+  test("description body is expanded by default on a PR with a description", async ({
+    page,
+  }) => {
+    await openPullRequest(page, /architecture overview/i);
+    await expect(page.locator("#pr-description-body")).toBeVisible({
+      timeout: 3_000,
+    });
+    // And the toggle button reflects the expanded state
+    await expect(
+      page.locator('button[aria-controls="pr-description-body"]')
+    ).toHaveAttribute("aria-expanded", "true");
+  });
+
+  test("clicking the Description button collapses and re-expands the body", async ({
+    page,
+  }) => {
+    await openPullRequest(page, /architecture overview/i);
+    const toggle = page.locator('button[aria-controls="pr-description-body"]');
+    const body = page.locator("#pr-description-body");
+
+    // Start expanded
+    await expect(body).toBeVisible();
+
+    // Collapse
+    await toggle.click();
+    await expect(body).toHaveCount(0);
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    // Re-expand
+    await toggle.click();
+    await expect(body).toBeVisible();
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+  });
+});
+
 test.describe("PR review submission — Comment-only flow", () => {
   test("switching radio to Comment, then submit, dismisses modal without a verdict badge", async ({
     page,

--- a/src/components/PRDetail.tsx
+++ b/src/components/PRDetail.tsx
@@ -10,6 +10,8 @@ import {
   FileText,
   Loader2,
   X,
+  ChevronDown,
+  ChevronRight,
 } from "lucide-react";
 import { PullRequest, PRComment, PendingSuggestion } from "@/types";
 import { useApp } from "@/lib/app-context";
@@ -56,6 +58,7 @@ export default function PRDetail({ pr, onBack }: PRDetailProps) {
   } = useApp();
 
   const [comments, setComments] = useState<PRComment[]>(prComments);
+  const [descriptionOpen, setDescriptionOpen] = useState(true);
   const [reviewStatus, setReviewStatus] = useState<
     "pending" | "approved" | "changes-requested" | null
   >(null);
@@ -469,13 +472,6 @@ export default function PRDetail({ pr, onBack }: PRDetailProps) {
                       {pr.baseBranch}
                     </span>
                   </span>
-                  {pr.description && (
-                    <details className="inline">
-                      <summary className="text-[var(--text-muted)] cursor-pointer hover:text-[var(--text-secondary)] transition-colors">
-                        Description
-                      </summary>
-                    </details>
-                  )}
                 </div>
               </div>
             </div>
@@ -536,16 +532,38 @@ export default function PRDetail({ pr, onBack }: PRDetailProps) {
             </div>
           </div>
 
-          {/* Expanded description */}
+          {/* Description section — toggle + body. Lives on its own
+              row below the header meta so the full-width click target
+              is safe on mobile (the review actions on the right don't
+              overlap it). */}
           {pr.description && (
-            <div
-              className="mt-2 text-sm text-[var(--text-secondary)] prose prose-sm dark:prose-invert max-w-none max-h-40 overflow-y-auto border-t border-[var(--border)] pt-2"
-              dangerouslySetInnerHTML={{
-                __html: transformGitHubAlerts(
-                  descriptionConverter.makeHtml(transformFootnotes(pr.description))
-                ),
-              }}
-            />
+            <div className="mt-2 border-t border-[var(--border)] pt-2">
+              <button
+                type="button"
+                onClick={() => setDescriptionOpen((v) => !v)}
+                aria-expanded={descriptionOpen}
+                aria-controls="pr-description-body"
+                className="flex items-center gap-1 text-xs text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors cursor-pointer py-0.5"
+              >
+                {descriptionOpen ? (
+                  <ChevronDown size={12} />
+                ) : (
+                  <ChevronRight size={12} />
+                )}
+                Description
+              </button>
+              {descriptionOpen && (
+                <div
+                  id="pr-description-body"
+                  className="mt-1 text-sm text-[var(--text-secondary)] prose prose-sm dark:prose-invert max-w-none max-h-40 overflow-y-auto"
+                  dangerouslySetInnerHTML={{
+                    __html: transformGitHubAlerts(
+                      descriptionConverter.makeHtml(transformFootnotes(pr.description))
+                    ),
+                  }}
+                />
+              )}
+            </div>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary

The \"Description\" label in the PR header used to be a `<details>` element wrapping just a `<summary>` with no children — so clicking it did nothing visible. The actual description block was rendered as a separate always-visible `<div>` below.

This wires the label to real React state and makes the description body conditionally render:

- Adds a \`descriptionOpen\` state, default expanded (no surprise for reviewers)
- Replaces the empty `<details>` with a real `<button>` that has `aria-expanded` + `aria-controls` pointing at the description body
- Moves the toggle onto its own line above the description body. Previously the button was inline in the header meta row where the right-side Approve button was visually overlapping it on mobile viewports — a pre-existing layout squeeze that this refactor dodges entirely.
- Adds two Playwright tests in \`pr-review-submission.spec.ts\` to guard against regression:
  1. Description body is expanded by default on a PR with a description
  2. Clicking the Description button collapses and re-expands the body

## Test plan

- [x] \`npx playwright test e2e/pr-review-submission.spec.ts\` — 20/20 pass on both desktop and mobile in 16.9s
- [x] CI Test workflow green

Note: intermittent flakes in \`image-flows.spec.ts\` showed up during full-suite runs but pass consistently in isolation and on main — not introduced by this change.

## Screenshots

Before: Description label existed but did nothing; description body always took ~160px of vertical space.
After: Chevron toggle on its own row; clicking it hides the body entirely.