### PR TITLE
feat: Fraunces wordmark + warm orange accent for PR file counts

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,6 +15,12 @@
   --accent: #2383e2;
   --accent-hover: #1b6ec2;
   --accent-muted: #e8f0fe;
+  /* Warm accent — paired with --accent for "needs your attention"
+     highlights like PR file counts, review badges. Orange in both
+     themes (the prototype uses Dracula orange #ffb86c in dark;
+     light mode needs a warm orange that reads against #ffffff). */
+  --accent-warm: #ea580c;
+  --accent-warm-muted: #ffedd5;
   --inline-code: #d63384;
   --diff-add: #dafbe1;
   --diff-add-text: #1a7f37;
@@ -33,6 +39,8 @@
   --accent: #bd93f9;
   --accent-hover: #caa5fb;
   --accent-muted: #363949;
+  --accent-warm: #ffb86c;
+  --accent-warm-muted: #3d2e1c;
   --inline-code: #ffb86c;
   --diff-add: #1e3a2a;
   --diff-add-text: #50fa7b;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,20 @@
 import type { Metadata } from "next";
+import { Fraunces } from "next/font/google";
 import { ThemeProvider } from "@/lib/theme-context";
 import { AppProvider } from "@/lib/app-context";
 import "./globals.css";
+
+// Fraunces is loaded only for the MarDoc wordmark — everything else
+// uses the system font stack set in globals.css. Exposed via CSS
+// variable so components can opt-in per-element without changing the
+// global body font.
+const fraunces = Fraunces({
+  subsets: ["latin"],
+  weight: ["500", "600"],
+  style: ["normal", "italic"],
+  variable: "--font-fraunces",
+  display: "swap",
+});
 
 export const metadata: Metadata = {
   title: "mardoc.app",
@@ -14,7 +27,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning className={fraunces.variable}>
       <body>
         <ThemeProvider>
           <AppProvider>{children}</AppProvider>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -140,8 +140,24 @@ export default function Home() {
           </button>
           <div className="flex items-center gap-2">
             <BookOpen size={18} className="text-[var(--accent)]" />
-            <span className="font-semibold text-sm text-[var(--text-primary)]">
-              mar<span className="text-[var(--accent)]">doc</span>.app
+            <span
+              className="text-xl text-[var(--text-primary)] leading-none"
+              style={{
+                fontFamily: "var(--font-fraunces), Georgia, serif",
+                fontWeight: 600,
+                letterSpacing: "-0.015em",
+              }}
+            >
+              Mar
+              <span
+                className="text-[var(--accent)]"
+                style={{ fontStyle: "italic", fontWeight: 500 }}
+              >
+                Doc
+              </span>
+              <span className="text-[var(--text-muted)]" style={{ fontWeight: 500 }}>
+                .app
+              </span>
             </span>
           </div>
           <div className="h-4 w-px bg-[var(--border)] hidden sm:block" />
@@ -266,8 +282,22 @@ export default function Home() {
                 <div className="w-16 h-16 rounded-2xl bg-[var(--accent-muted)] flex items-center justify-center mx-auto mb-5">
                   <BookOpen size={28} className="text-[var(--accent)]" />
                 </div>
-                <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">
-                  Welcome to mardoc.app
+                <h2
+                  className="text-3xl text-[var(--text-primary)] mb-2"
+                  style={{
+                    fontFamily: "var(--font-fraunces), Georgia, serif",
+                    fontWeight: 500,
+                    letterSpacing: "-0.02em",
+                  }}
+                >
+                  Welcome to Mar
+                  <span
+                    className="text-[var(--accent)]"
+                    style={{ fontStyle: "italic" }}
+                  >
+                    Doc
+                  </span>
+                  <span className="text-[var(--text-muted)]">.app</span>
                 </h2>
                 <p className="text-sm text-[var(--text-secondary)] leading-relaxed mb-6">
                   {isEmbedded

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -650,7 +650,7 @@ export default function Sidebar() {
                       <div className="flex items-center gap-2 text-xs text-[var(--text-muted)] mt-0.5">
                         <span className="hidden md:inline">#{pr.number} by {pr.author}</span>
                         {pr.mdFileCount !== undefined && pr.mdFileCount > 0 && (
-                          <span className="text-[9px] px-1.5 py-0 rounded-full bg-[var(--accent-muted)] text-[var(--accent)] font-medium">
+                          <span className="text-[9px] px-1.5 py-0 rounded-full bg-[var(--accent-warm-muted)] text-[var(--accent-warm)] font-semibold">
                             {pr.mdFileCount} {pr.mdFileCount === 1 ? "file" : "files"}
                           </span>
                         )}


### PR DESCRIPTION
## Summary

Adopts two visual pieces from the mobile prototype (\`docs/design/mobile-prototype.html\`) into the desktop site without touching layout or navigation.

### 1. Fraunces wordmark

- Loaded via \`next/font/google\` with the \`--font-fraunces\` CSS variable. Only the MarDoc brand mark uses it; everything else stays on the system font stack.
- Renders as **Mar*Doc*.app** — \"Mar\" in Fraunces 600, \"Doc\" italic 500 in the purple accent, \".app\" muted. Matches the prototype's capitalization while keeping the \`.app\` domain cue you wanted to preserve.
- Applied to the header (text-xl) and the landing \"Welcome to MarDoc.app\" heading (text-3xl), so the serif type change is visible where it matters.

### 2. Warm orange accent for PR file counts

- Added \`--accent-warm\` and \`--accent-warm-muted\` CSS variables to \`globals.css\`:
  - Light mode: \`#ea580c\` / \`#ffedd5\`
  - Dark mode: \`#ffb86c\` (Dracula orange) / \`#3d2e1c\`
- Applied to the PR file-count pill in \`Sidebar.tsx\` (e.g. \"3 files\"), which was previously the same purple as the accent and blended in. Now orange-on-cream against the purple accent reaches out to reviewers — the color pairing the prototype uses to signal \"needs your attention.\"

## What this does NOT touch

- Navigation or layout
- State or routing
- Component structure
- The 80+ e2e selectors

## Test plan

- [x] Local \`npm run dev\` — wordmark renders with Fraunces in both header and welcome heading; PR file-count pill renders orange on the PR list
- [x] Dark mode toggle works for both changes
- [x] CI Test workflow green

## Related

Closed PR #88 (practice PR).