### PR TITLE
docs: classic PAT as the primary path + read:org as required for orgs

### DIFF
--- a/docs/setup-github-pat.md
+++ b/docs/setup-github-pat.md
@@ -1,49 +1,51 @@
 # Setting Up a GitHub Personal Access Token for MarDoc
 
-MarDoc connects to GitHub using a **fine-grained Personal Access Token (PAT)**. This guide walks through creating one with the minimum permissions MarDoc needs.
+MarDoc connects to GitHub using a **Personal Access Token (PAT)**. The simplest path is a **classic token** with the `repo` scope — one checkbox, done. Fine-grained tokens also work if you need tighter scope control, but they're fiddlier to configure.
 
 ## Why a PAT?
 
 MarDoc runs entirely in your browser — there's no server. Your token is stored in your browser's local storage and used to call the GitHub API directly. It never leaves your machine.
 
-## Step-by-step
+## Step-by-step (classic token)
 
 ### 1. Open GitHub token settings
 
-Go to [github.com/settings/tokens?type=beta](https://github.com/settings/tokens?type=beta) (Settings > Developer settings > Personal access tokens > Fine-grained tokens).
+Go to [github.com/settings/tokens](https://github.com/settings/tokens) (Settings → Developer settings → Personal access tokens → Tokens (classic)).
 
-### 2. Click "Generate new token"
+### 2. Click "Generate new token" → "Generate new token (classic)"
 
 Give it a descriptive name like `MarDoc` so you remember what it's for.
 
-### 3. Set expiration
+### 3. Set an expiration
 
-Choose an expiration that matches your comfort level. You can always create a new one when it expires. MarDoc will prompt you to reconnect if your token stops working.
+Choose an expiration that matches your comfort level — 90 days is a reasonable default. You can always create a new one when it expires. MarDoc will prompt you to reconnect if your token stops working.
 
-### 4. Select repository access
+### 4. Select scopes
 
-Choose which repositories MarDoc can see:
+Check two boxes:
 
-- **All repositories** — convenient if you review docs across many repos
-- **Only select repositories** — more restrictive; pick the specific repos you want to review
+- **`repo`** — full read/write on any repository you already have access to. Checking this top-level box ticks all six sub-scopes automatically.
+- **`read:org`** — needed if any of the repositories you want to review belong to a GitHub organization. In theory the `repo` scope alone is enough; in practice organization repos (and anything behind SAML SSO) need `read:org` to show up reliably in MarDoc's repo picker. If every repo you review is in your personal account, you can skip this one.
 
-### 5. Set permissions
+```
+✅ repo
+  ✅ repo:status
+  ✅ repo_deployment
+  ✅ public_repo
+  ✅ repo:invite
+  ✅ security_events
+✅ read:org              ← check this if you want to see org repos
+```
 
-Under **Repository permissions**, enable:
+Leave everything else unchecked.
 
-| Permission | Access level | Why MarDoc needs it |
-|---|---|---|
-| **Contents** | Read | Browse repository files and read markdown content |
-| **Pull requests** | Read and Write | List PRs, read PR diffs, and post review comments |
-| **Issues** | Read and Write | *(Optional)* Only needed if you want to reference issues |
+**One extra step for SSO-protected orgs**: after generating the token, the token list page will show a **Configure SSO** button next to it. Click that and authorize the specific organization(s) whose repos you want to review. Without this step, SSO orgs will silently not appear even with both scopes set.
 
-All other permissions can stay at "No access."
+### 5. Generate and copy
 
-### 6. Generate and copy
+Click **Generate token** at the bottom, then copy the token immediately — GitHub only shows it once. It starts with `ghp_`. Store it somewhere safe (a password manager is ideal).
 
-Click **Generate token**, then copy the token immediately — GitHub only shows it once.
-
-### 7. Paste into MarDoc
+### 6. Paste into MarDoc
 
 1. Go to [mardoc.app](https://mardoc.app)
 2. Click the gear icon (Settings)
@@ -52,19 +54,38 @@ Click **Generate token**, then copy the token immediately — GitHub only shows 
 
 Your token is saved in your browser so you won't need to re-enter it on your next visit.
 
+## Alternative: fine-grained tokens
+
+Fine-grained tokens are the newer GitHub model — they scope to specific repositories and specific permissions rather than a single monolithic `repo` scope. They work with MarDoc, but the setup is more involved and easy to get wrong.
+
+If you still want one, go to [github.com/settings/tokens?type=beta](https://github.com/settings/tokens?type=beta) and configure:
+
+| Permission | Access level | Why MarDoc needs it |
+|---|---|---|
+| **Contents** | Read | Browse repository files and read markdown content |
+| **Pull requests** | Read and Write | List PRs, read PR diffs, and post review comments |
+| **Issues** | Read and Write | *(Optional)* Only needed if you want to reference issues |
+
+Under **Repository access**, pick the specific repositories MarDoc should see, or "All repositories" if you want it broad. All other permissions can stay at "No access."
+
+If a fine-grained token isn't letting MarDoc see a repo it should — or the PR list comes up empty even though PRs exist — it's almost always a missing permission or a repository that wasn't included in the token's scope. A classic token with `repo` sidesteps all of that.
+
 ## Revoking access
 
 To revoke MarDoc's access at any time:
 
 - **In MarDoc** — open Settings and click **Disconnect**. This removes the token from your browser.
-- **On GitHub** — go to [github.com/settings/tokens?type=beta](https://github.com/settings/tokens?type=beta) and delete the token. This immediately revokes API access.
+- **On GitHub** — go to [github.com/settings/tokens](https://github.com/settings/tokens) and delete the token. This immediately revokes API access.
 
 ## Troubleshooting
 
-**"Failed to load repository"** — Your token may not have access to that repo. Check that the repository is included in your token's repository access scope.
+**"Bad credentials"** — Double-check that you copied the full token (classic tokens start with `ghp_`). If it looks right, the token may have expired — regenerate it and reconnect.
 
-**"Not authenticated"** — Your token may have expired. Create a new one and reconnect.
+**"Failed to load repository" or org repos missing from the picker** — Almost always one of three things:
+1. Your token doesn't have `read:org` — regenerate with that box checked (Step 4).
+2. The organization uses SAML SSO and you haven't authorized the token for it — go back to [github.com/settings/tokens](https://github.com/settings/tokens), click **Configure SSO** next to your token, and authorize each org.
+3. You don't actually have access to that repo on github.com itself (check in a browser first).
 
-**No pull requests showing** — Make sure the Pull requests permission is set to at least Read.
+**No pull requests showing** — For classic tokens, make sure `repo` is checked. For fine-grained tokens, **Pull requests** needs to be set to at least Read.
 
-**Can't post comments** — Pull requests permission needs Read and Write, not just Read.
+**Can't post comments** — For fine-grained tokens, **Pull requests** needs to be Read **and Write**, not just Read. Classic tokens handle this automatically under `repo`.

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -203,10 +203,15 @@ export default function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
                       <li>Click "Generate new token" → "Generate new token (classic)"</li>
                       <li>Give it a note (e.g. "MarDoc") and set an expiration</li>
                       <li>
-                        Check the <strong>repo</strong> scope — this single scope covers reading
-                        code, managing pull requests, and creating review comments
+                        Check <strong>repo</strong> (reading code, PRs, and review comments)
+                        and <strong>read:org</strong> (if you want to see any organization
+                        repos — skip only if every repo is in your personal account)
                       </li>
-                      <li>Click "Generate token", copy the <code className="px-1 rounded bg-[var(--surface)]">ghp_…</code> value, and paste below</li>
+                      <li>
+                        Click "Generate token", then if any of your orgs use SSO click
+                        <strong> Configure SSO</strong> next to the token and authorize each one
+                      </li>
+                      <li>Copy the <code className="px-1 rounded bg-[var(--surface)]">ghp_…</code> value and paste below</li>
                     </ol>
                     <p className="text-[10px] text-[var(--text-muted)] mt-2 italic">
                       Classic tokens are simpler than fine-grained ones — one scope, one click.

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -202,11 +202,10 @@ Navigate to [github.com/settings/tokens](https://github.com/settings/tokens) and
 
 ### Required Scopes
 
-Select these scopes:
+Check these two boxes:
 
-- \`repo\` — Full control of private repositories (read/write access to code, PRs, and issues)
-
-That's it. mardoc.app only needs \`repo\` scope.
+- \`repo\` — full read/write on any repository you already have access to. Checking this top-level box ticks all six sub-scopes automatically.
+- \`read:org\` — needed if any of the repositories you want to review belong to a GitHub organization. Without it, org repos (and anything behind SAML SSO) won't show up reliably in the picker. Skip only if every repo you review is in your personal account.
 
 \`\`\`
 ✅  repo
@@ -215,16 +214,12 @@ That's it. mardoc.app only needs \`repo\` scope.
   ✅  public_repo
   ✅  repo:invite
   ✅  security_events
+✅  read:org              ← check this if you want to see org repos
 \`\`\`
 
-### Optional Scopes
+### One extra step for SSO-protected orgs
 
-These are **not required** but enable additional features:
-
-| Scope | Enables |
-|-------|---------|
-| \`read:org\` | Browsing organization repositories |
-| \`read:user\` | Displaying your profile info in the app |
+After generating the token, the token list page shows a **Configure SSO** button next to it. Click that and authorize each organization you want to see repos from. Without this step, SSO orgs stay invisible even with both scopes set.
 
 ## Step 3: Generate and Copy
 
@@ -399,7 +394,7 @@ mardoc.app is a thin layer on top of GitHub. Your repository is the source of tr
 ` + "```\n\n" + `| Permission | Why |
 |-----------|-----|
 | \`repo\` | Read files, create branches, open PRs |
-| \`read:org\` | *(optional)* Browse organization repos |
+| \`read:org\` | Browse organization repos (required if you have any) |
 
 We never store your code. Every read and write goes directly to the GitHub API. See the [PAT setup guide](docs/creating-a-github-pat.md) to get started.
 


### PR DESCRIPTION
## Summary

Three places in the repo tell users how to create a GitHub PAT for MarDoc, and they each said something slightly different:

| Where | Before |
|---|---|
| \`docs/setup-github-pat.md\` | Led with fine-grained tokens — finicky to scope correctly and the source of most first-time setup pain |
| \`src/components/SettingsPanel.tsx\` (in-app tip) | Led with classic tokens but mentioned only the \`repo\` scope |
| \`src/lib/mock-data.ts\` (demo \`creating-a-github-pat.md\`) | Labeled \`read:org\` as \`(optional)\` for browsing org repos |

In practice, \`read:org\` is **not** optional when you have org repos — GitHub's SAML SSO dance and org-repo visibility edges mean that without it, org repos don't show up reliably in MarDoc's repo picker. And fine-grained tokens are a trap for most users: every missing checkbox becomes a silent "where are my repos" bug.

## Unified story across all three surfaces

1. **Classic token is the primary path** — \`repo\` + \`read:org\`, two checkboxes. Fine-grained tokens move to a secondary "Alternative" section for users who want tighter scope control.
2. **\`read:org\` is required if any repo you review belongs to an org** — skip it only if every repo is in your personal account.
3. **SSO-protected orgs need a "Configure SSO" click** on the token list page after token generation to authorize each org. This was missing from all three places.

## Test plan

- [x] \`npx next build\` — static export still builds cleanly
- [ ] CI Test workflow green
- [ ] Spot-check rendered demo \`creating-a-github-pat.md\` in demo mode (the mock-data edits flow through here)