### PR TITLE
fix: deep-link regressions for PR + file URLs

### DIFF
--- a/e2e/navigation-routing.spec.ts
+++ b/e2e/navigation-routing.spec.ts
@@ -121,3 +121,51 @@ test.describe("Navigation: opening a PR from the sidebar", () => {
     ).toBeVisible({ timeout: 10_000 });
   });
 });
+
+test.describe("Navigation: hash-based deep links", () => {
+  // Regression guard for a bug where opening a PR URL directly
+  // (https://mardoc.app/#/owner/repo/pull/N) showed the welcome
+  // screen instead of the PR. The root cause was a stale-closure
+  // bug in navigateToHash's PR lookup, plus the initial-hash effect
+  // short-circuiting demo mode to file routes only. Both paths now
+  // flow through navigateToHash which resolves PRs synchronously if
+  // they are already in prList (demo mode) and via a pending-pr
+  // effect if not (authenticated deep links).
+  //
+  // Demo mode ships with a "Add architecture overview as HTML
+  // document" PR at #37. Any valid owner/repo prefix resolves
+  // because demo mode does not validate the repo name against
+  // mock data.
+
+  test("deep link /#/owner/repo/pull/N opens the PR directly", async ({ page }) => {
+    await page.goto("/#/mardoc/demo/pull/37");
+    await waitForHydration(page);
+    // The PR header has an Approve button — that proves the PR view
+    // rendered instead of the welcome screen.
+    await expect(
+      page.locator("button", { hasText: /^Approve$/ }).first()
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("deep link to a non-existent PR falls back to welcome without crashing", async ({ page }) => {
+    await page.goto("/#/mardoc/demo/pull/99999");
+    await waitForHydration(page);
+    // No PR matches — the app should stay on the welcome screen,
+    // not show a blank page or crash. We assert the welcome copy is
+    // visible which also proves the app hydrated successfully.
+    await expect(
+      page.getByText(/Welcome to/i).locator("visible=true").first()
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("deep link /#/owner/repo/blob/branch/file.md opens the file", async ({ page }) => {
+    await page.goto("/#/mardoc/demo/blob/main/README.md");
+    await waitForHydration(page);
+    // The ProseMirror editor surface is visible when the file loads
+    await expect(page.locator(".ProseMirror")).toBeVisible({ timeout: 10_000 });
+    // And the README's h1 text renders
+    await expect(
+      page.locator(".ProseMirror h1").first()
+    ).toBeVisible();
+  });
+});

--- a/src/lib/app-context.tsx
+++ b/src/lib/app-context.tsx
@@ -611,6 +611,18 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     }
   }, [currentRepo, selectedPR, setHash]);
 
+  // When navigateToHash arrives at a PR route before the PR list has
+  // finished loading (deep link on first paint), we can't resolve
+  // the PR synchronously — `await setCurrentRepo` returns before
+  // React commits the `setPRList` state update, so the `prList`
+  // captured in the callback's closure is still stale. Stash the
+  // pending route here and let a dedicated effect resolve it once
+  // prList has actually updated.
+  const [pendingPRRoute, setPendingPRRoute] = useState<{
+    prNumber: number;
+    prFileIdx?: number;
+  } | null>(null);
+
   // Navigate to a hash route — used on init and on hashchange
   const navigateToHash = useCallback(async (hash: string) => {
     const route = parseHash(hash);
@@ -622,12 +634,16 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     }
 
     if (route.type === "file" && route.filePath) {
-      // Need to find the file in the tree — it may not be loaded yet
-      // We'll set branch if specified, then navigate
       if (route.branch && route.branch !== selectedBranch) {
         setSelectedBranchState(route.branch);
       }
-      // Create a minimal RepoFile to open
+      if (isDemoMode) {
+        const mockFile = findFile(mockFiles, route.filePath);
+        if (mockFile) {
+          await openFile(mockFile);
+          return;
+        }
+      }
       const file: RepoFile = {
         id: `hash-${route.filePath}`,
         name: route.filePath.split("/").pop() || route.filePath,
@@ -636,45 +652,82 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       };
       await openFile(file);
     } else if (route.type === "pr" && route.prNumber) {
-      // Find the PR in the loaded list, or create a stub
+      // Fast path: PR is already in the loaded list (demo mode always,
+      // or a user clicking back to a PR they've seen in this session).
       const pr = prList.find((p) => p.number === route.prNumber);
       if (pr) {
         openPR(pr);
         if (route.prFileIdx !== undefined) {
           setSelectedPRFileIdx(route.prFileIdx);
         }
+        return;
       }
+      // Slow path: deep-link to a PR whose list has not loaded yet.
+      // Stash the route so the pending-pr effect below picks it up
+      // as soon as prList updates.
+      setPendingPRRoute({
+        prNumber: route.prNumber,
+        prFileIdx: route.prFileIdx,
+      });
     }
-  }, [currentRepo, selectedBranch, prList, setCurrentRepo, openFile, openPR]);
+  }, [currentRepo, selectedBranch, prList, isDemoMode, setCurrentRepo, openFile, openPR]);
 
-  // Handle hash route on mount and hashchange (back/forward)
+  // Resolve a pending PR deep link once prList finishes loading.
+  // Runs whenever prList changes; no-op when there is nothing pending.
   useEffect(() => {
-    // Initial hash navigation
+    if (!pendingPRRoute) return;
+    const pr = prList.find((p) => p.number === pendingPRRoute.prNumber);
+    if (!pr) return;
+    openPR(pr);
+    if (pendingPRRoute.prFileIdx !== undefined) {
+      setSelectedPRFileIdx(pendingPRRoute.prFileIdx);
+    }
+    setPendingPRRoute(null);
+  }, [prList, pendingPRRoute, openPR]);
+
+  // Handle hash route on mount and hashchange (back/forward).
+  //
+  // The effect intentionally re-runs whenever navigateToHash /
+  // openFile / openPR get new references (which happens on every
+  // state commit touching repo / prList / currentRepo). That sounds
+  // wasteful, but it's exactly what makes deep linking survive
+  // React Strict Mode's double-mount: each new mount gets a fresh
+  // set of closures bound to its own state setters, so the LATEST
+  // mount's setState calls stick.
+  //
+  // The demo-mode branches here bypass navigateToHash entirely and
+  // call openFile / openPR directly so the state updates use the
+  // current mount's setters synchronously. The authenticated
+  // branch still routes through navigateToHash (which awaits
+  // setCurrentRepo, then resolves the PR via the pendingPRRoute
+  // effect above).
+  useEffect(() => {
     if (window.location.hash) {
       const route = parseHash(window.location.hash);
       if (route.type !== "none" && githubToken) {
         navigateToHash(window.location.hash);
-      } else if (route.type !== "none" && isDemoMode && route.type === "file") {
-        // Demo mode file navigation
-        const route = parseHash(window.location.hash);
-        if (route.filePath) {
+      } else if (route.type !== "none" && isDemoMode) {
+        if (route.type === "file" && route.filePath) {
           const mockFile = findFile(mockFiles, route.filePath);
           if (mockFile) {
             openFile(mockFile);
+          }
+        } else if (route.type === "pr" && route.prNumber) {
+          const mockPR = prList.find((p) => p.number === route.prNumber);
+          if (mockPR) {
+            openPR(mockPR);
           }
         }
       }
     }
 
     const onHashChange = () => {
-      // If the current hash matches what we just wrote, we triggered
-      // this event ourselves — ignore it. Only act on user navigation.
       if (window.location.hash === lastWrittenHash.current) return;
       navigateToHash(window.location.hash);
     };
     window.addEventListener("hashchange", onHashChange);
     return () => window.removeEventListener("hashchange", onHashChange);
-  }, [githubToken, isDemoMode, navigateToHash, openFile]);
+  }, [githubToken, isDemoMode, navigateToHash, openFile, openPR, prList]);
 
   // Refresh the current repo
   const refreshRepo = useCallback(async () => {


### PR DESCRIPTION
## Summary

Fixes the user-reported regression where opening a PR URL directly — e.g. \`https://mardoc.app/#/cloudzero/project-telemetry-anchored-ai/pull/36\` — showed the welcome screen instead of the PR. Two underlying bugs were contributing to this class of failure.

### Bug 1 — demo-mode PR deep links had no handler

The initial-hash effect in \`app-context.tsx\` only handled \`isDemoMode && route.type === "file"\`. PR routes in demo mode silently fell through to the welcome screen. Fixed by adding a matching demo-mode PR branch that looks up the mock PR in \`prList\` and calls \`openPR\` directly.

### Bug 2 — authenticated PR deep links hit a stale closure

\`navigateToHash\` did \`await setCurrentRepo\` to populate \`prList\`, then called \`prList.find(...)\`. React batches state commits, so when the await resumed, the callback's closure still held the empty \`prList\` from before \`setCurrentRepo\` ran — the lookup returned \`undefined\` and navigation silently gave up. Fixed by stashing the pending route in a new \`pendingPRRoute\` state and adding a dedicated effect that resolves it as soon as \`prList\` actually updates.

### Why the effect still re-runs on every dep change

I spent a while trying to collapse the init effect into a one-shot to avoid the cascade it causes, but that breaks deep linking under React Strict Mode: the first (throwaway) mount's async navigation writes to state setters that are already dead, so the changes never stick. The original pattern — re-running the effect on every \`navigateToHash\` / \`openFile\` reference change — is what lets the LATEST mount's setters actually commit. Restored that structure and called it out in the code comments.

## Regression guards (the test that would have caught this)

Three new tests in \`e2e/navigation-routing.spec.ts\`:

- \`deep link /#/owner/repo/pull/N opens the PR directly\`
- \`deep link to a non-existent PR falls back to welcome without crashing\`
- \`deep link /#/owner/repo/blob/branch/file.md opens the file\`

Each runs on both desktop and mobile.

## Test plan

- [x] \`npx playwright test e2e/navigation-routing.spec.ts\` — 18/18 pass on desktop + mobile in 17.6s
- [x] Full e2e suite: 96 pass, 2 pre-existing image-flows flakes that pass 10/10 in isolation (not caused by this change)
- [ ] CI Test workflow green