### PR TITLE
fix: Cmd+C in embed mode writes selection to clipboard

### DIFF
--- a/e2e/embed-mode-clipboard.spec.ts
+++ b/e2e/embed-mode-clipboard.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * E2E tests for embed-mode clipboard handling.
+ *
+ * When MarDoc runs inside the VS Code extension's webview, the parent
+ * shell's Cmd+C handling interferes with the browser's native copy
+ * path: VS Code dispatches its own clipboard command against the
+ * outer webview document (which has no selection because the
+ * selection lives inside our cross-origin iframe), and as a side
+ * effect the iframe's text selection is cleared between the two
+ * keydown firings the iframe sees for a single Cmd+C press. By the
+ * time the browser would fire its native `copy` event there is
+ * nothing to copy, and the clipboard stays empty.
+ *
+ * The fix (app-context.tsx): in embed mode, a capture-phase keydown
+ * listener intercepts the first Cmd+C while the selection is still
+ * intact, runs document.execCommand('copy') synchronously, and
+ * preventDefault()s so the parent shell's subsequent handling can't
+ * clobber what we just copied.
+ *
+ * This spec can't reproduce VS Code's specific interference from
+ * Playwright, but it does verify the embed-mode copy path works
+ * end-to-end: loading the app with ?embed=true, receiving a file
+ * via the init postMessage path, selecting text, pressing Cmd+C,
+ * and reading the clipboard back. A regression that breaks the
+ * embed-mode keydown handler or the execCommand fallback fails here.
+ */
+import { test, expect } from "@playwright/test";
+import { waitForHydration } from "./fixtures/helpers";
+
+test.describe("Embed mode: clipboard", () => {
+  test("embed mode loads without crashing on ?embed=true", async ({ page }) => {
+    // Sanity check that embed mode activates and the MarDoc app
+    // renders. If this fails, the rest of the embed-mode flow is moot.
+    await page.goto("/?embed=true");
+    await waitForHydration(page);
+    await expect(page.getByText(/MarDoc/i).first()).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  test("Cmd+C in embed mode copies the selection to the clipboard", async ({
+    page,
+    context,
+    browserName,
+  }) => {
+    // Webkit in Playwright does not recognize `clipboard-write` as a
+    // permission and blocks navigator.clipboard.readText() on HTTP
+    // origins. The chromium run still exercises the embed-mode
+    // keydown handler, which is the code path that actually failed
+    // in the VS Code webview.
+    test.skip(browserName === "webkit", "webkit clipboard permissions not supported");
+    await context.grantPermissions(["clipboard-read"]);
+
+    await page.goto("/?embed=true");
+    await waitForHydration(page);
+
+    // Simulate the init message the VS Code extension host sends
+    // when it opens a file with "Edit with MarDoc". This is the same
+    // postMessage contract documented in feature 017.
+    const sentinel = `e2e-clip-${Date.now()}`;
+    const fileContent = `# Sample\n\nThis is a paragraph containing the sentinel ${sentinel} that the test selects and copies.\n`;
+    await page.evaluate(
+      (payload) => {
+        window.postMessage(payload, "*");
+      },
+      {
+        type: "init",
+        fileName: "sample.md",
+        filePath: "sample.md",
+        fileContent,
+      }
+    );
+
+    // Wait for the editor to render the file content
+    const pm = page.locator(".ProseMirror");
+    await expect(pm).toBeVisible({ timeout: 10_000 });
+    await expect(pm.locator("text=" + sentinel).first()).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // Select everything in the ProseMirror document and press Cmd+C.
+    // The embed-mode handler should run execCommand('copy')
+    // synchronously on this keydown and preventDefault the key.
+    await pm.click();
+    await page.keyboard.press("ControlOrMeta+A");
+    await page.keyboard.press("ControlOrMeta+C");
+
+    // Read the clipboard and verify it contains our sentinel. If the
+    // embed-mode handler is broken or the execCommand fallback is
+    // removed, this assertion fails loudly.
+    const clipText = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipText).toContain(sentinel);
+  });
+});

--- a/src/lib/app-context.tsx
+++ b/src/lib/app-context.tsx
@@ -90,6 +90,43 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
+  // Embed-mode Cmd+C fix.
+  //
+  // When MarDoc runs inside the VS Code extension's webview, the
+  // parent shell's clipboard handling interferes with the browser's
+  // native Cmd+C path: VS Code dispatches its own clipboard command
+  // against the outer webview document (which has no selection
+  // because the selection lives inside our cross-origin iframe),
+  // and as a side effect the iframe's text selection is cleared
+  // between the two keydown firings the iframe sees for a single
+  // Cmd+C press. By the time the browser would fire its native
+  // `copy` event, there is nothing to copy — so the clipboard
+  // stays empty and the user sees "Cmd+C does nothing".
+  //
+  // Fix: in embed mode only, attach a capture-phase keydown
+  // listener that intercepts the first Cmd+C while the selection
+  // is still intact, runs execCommand('copy') synchronously (which
+  // writes the current selection to the clipboard — verified to
+  // work inside the webview iframe), and preventDefault()s so the
+  // parent shell's subsequent handling can't clobber what we just
+  // copied. Has no effect outside embed mode.
+  useEffect(() => {
+    if (!isEmbedded) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      const isCopyShortcut = (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "c";
+      if (!isCopyShortcut) return;
+      const sel = window.getSelection();
+      if (!sel || sel.isCollapsed) return;
+      const ok = document.execCommand("copy");
+      if (ok) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => document.removeEventListener("keydown", onKeyDown, true);
+  }, [isEmbedded]);
+
   // Auth state — server-safe defaults, hydrated in useEffect
   const [githubToken, setGithubTokenState] = useState<string | null>(null);
   const [isDemoMode, setIsDemoMode] = useState(true);


### PR DESCRIPTION
## Summary

Cmd+C was silently failing when a user selected text inside a rendered document in the VS Code extension. Root cause confirmed by live-debugging inside the webview devtools:

- The webview shell dispatches its own copy command against the outer webview document, which has no selection (the selection lives inside our cross-origin iframe)
- As a side effect, the iframe's text selection is cleared between the two keydown firings the iframe sees for a single Cmd+C press
- By the time the browser's native copy path would fire, there's nothing to copy — no \`copy\` event fires and the clipboard stays empty

The iframe itself has clipboard-write permission (verified by running \`document.execCommand('copy')\` directly from the webview devtools — which copied correctly). The issue is specifically in the Cmd+C flow, not the clipboard permission.

## Fix

In embed mode only, a capture-phase keydown listener intercepts the first Cmd+C while the selection is still intact, runs \`document.execCommand('copy')\` synchronously, and \`preventDefault\`s so the parent shell's subsequent handling can't clobber what we just copied. ~15 lines in \`src/lib/app-context.tsx\`. No effect outside embed mode.

## Regression test

Adds \`e2e/embed-mode-clipboard.spec.ts\`:
- Loads the app with \`?embed=true\`
- Posts an \`init\` message to simulate the VS Code extension's file-load path
- Selects the rendered text
- Presses Cmd+C
- Reads \`navigator.clipboard.readText()\` and asserts the sentinel is on the clipboard

Skipped on webkit because Playwright's webkit doesn't support the \`clipboard-write\` permission; chromium is the relevant regression surface since VS Code's webview runs on Chromium under the hood.

## Test plan

- [x] Local webview repro confirmed fixed by the user — \"I was able to copy then paste outside the viewer\"
- [x] \`npx playwright test e2e/embed-mode-clipboard.spec.ts\` — 3 pass + 1 intentionally skipped on mobile webkit
- [x] Full suite: 99 pass, 2 pre-existing image-flows flakes (pass in isolation, not caused by this change)
- [ ] CI Test workflow green