### PR TITLE
fix: memoize markdown blocks so mermaid survives comment sidebar toggle

### DIFF
--- a/e2e/pr-mermaid-stability.spec.ts
+++ b/e2e/pr-mermaid-stability.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * E2E regression for PR-mode mermaid stability.
+ *
+ * Symptom pre-fix: opening a PR with a mermaid diagram in the diff,
+ * then toggling the comment sidebar closed, wiped the rendered
+ * mermaid SVG. The diagram only came back on the next 30s poll tick
+ * — when the `comments` prop reference changed and re-fired the
+ * post-render useEffect that calls renderMermaidBlocks.
+ *
+ * Root cause: React 18 unconditionally re-applies innerHTML for
+ * dangerouslySetInnerHTML when the prop is an inline object literal,
+ * because the reconciler compares props by reference. The fix wraps
+ * each block in React.memo keyed on the html string so the host
+ * component bailout (`oldProps === newProps`) prevents the
+ * setInnerHTML call, and mermaid's post-render DOM mutation survives.
+ */
+import { test, expect } from "@playwright/test";
+import { openPullRequest } from "./fixtures/helpers";
+
+test.describe("PR mode — mermaid stability across comment sidebar toggle", () => {
+  test("mermaid SVG survives a comment panel open→close cycle", async ({
+    page,
+    viewport,
+  }) => {
+    test.skip(
+      !viewport || viewport.width < 768,
+      "comment panel rail is desktop-only"
+    );
+
+    await openPullRequest(page, /getting started guide/i);
+
+    const diagram = page.locator(".mermaid-diagram svg").first();
+    await expect(diagram).toBeVisible({ timeout: 15_000 });
+
+    // Tag the rendered SVG so we can detect if React tears down the
+    // mermaid wrapper and falls back to the raw <pre><code> source.
+    await page.evaluate(() => {
+      const svg = document.querySelector(".mermaid-diagram svg");
+      if (svg) svg.setAttribute("data-e2e-tag", "stable");
+    });
+
+    const closeBtn = page.locator('button[aria-label="Close comments"]').first();
+    if (await closeBtn.isVisible().catch(() => false)) {
+      await closeBtn.click();
+    } else {
+      await page
+        .locator("button", { hasText: /^(\d+ comments?|Comments)$/ })
+        .locator("visible=true")
+        .first()
+        .click();
+    }
+    await page.waitForTimeout(400);
+
+    const state = await page.evaluate(() => {
+      const svg = document.querySelector<SVGSVGElement>(".mermaid-diagram svg");
+      const preMermaid = document.querySelector(
+        "pre > code.language-mermaid, pre > code.mermaid"
+      );
+      return {
+        svgPresent: !!svg,
+        svgTagged: svg?.getAttribute("data-e2e-tag") === "stable",
+        sourceBlockBackToPre: !!preMermaid,
+      };
+    });
+
+    expect(
+      state,
+      "after panel toggle the mermaid SVG should still be the same tagged DOM node; if <pre><code> is back, React replaced innerHTML"
+    ).toEqual({
+      svgPresent: true,
+      svgTagged: true,
+      sourceBlockBackToPre: false,
+    });
+  });
+
+  test("mermaid SVG survives a comment panel close→open→close cycle", async ({
+    page,
+    viewport,
+  }) => {
+    test.skip(
+      !viewport || viewport.width < 768,
+      "comment panel rail is desktop-only"
+    );
+
+    await openPullRequest(page, /getting started guide/i);
+
+    const diagram = page.locator(".mermaid-diagram svg").first();
+    await expect(diagram).toBeVisible({ timeout: 15_000 });
+
+    await page.evaluate(() => {
+      const svg = document.querySelector(".mermaid-diagram svg");
+      if (svg) svg.setAttribute("data-e2e-tag", "stable");
+    });
+
+    const commentsBtn = page
+      .locator("button", { hasText: /^(\d+ comments?|Comments)$/ })
+      .locator("visible=true")
+      .first();
+
+    await commentsBtn.click();
+    await page.waitForTimeout(200);
+    await commentsBtn.click();
+    await page.waitForTimeout(200);
+    await commentsBtn.click();
+    await page.waitForTimeout(400);
+
+    const state = await page.evaluate(() => {
+      const svg = document.querySelector<SVGSVGElement>(".mermaid-diagram svg");
+      return {
+        present: !!svg,
+        tagged: svg?.getAttribute("data-e2e-tag") === "stable",
+      };
+    });
+    expect(state.present).toBe(true);
+    expect(state.tagged).toBe(true);
+  });
+});

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -79,6 +79,39 @@ function blockToHtml(block: string): string {
   return highlightCodeBlocks(blockToHtmlRaw(block));
 }
 
+// ─── Memoized dangerouslySetInnerHTML wrapper ─────────────────────────────
+//
+// React 18 re-applies innerHTML on every re-render when the
+// dangerouslySetInnerHTML prop is an inline object literal — the
+// reconciler in updateProperties compares props by reference
+// (`_nextProp !== _lastProp`), and `{__html: "..."}` literals never
+// pass that check. setProp → setInnerHTML$1 then runs unconditionally.
+//
+// For post-render DOM mutations (mermaid SVG, syntax highlighting
+// overlays, fetched-image data: URIs) that's destructive: the
+// mutation is wiped on any unrelated re-render (e.g. a sibling state
+// change). Wrapping the block in React.memo with just the html
+// string as a prop hits `updateHostComponent`'s
+// `oldProps === newProps` bailout, so the div is never re-committed
+// and the mutation survives.
+const MarkdownBlock = React.memo(function MarkdownBlock({
+  html,
+  className,
+  onClick,
+}: {
+  html: string;
+  className?: string;
+  onClick?: (e: React.MouseEvent) => void;
+}) {
+  return (
+    <div
+      className={className}
+      dangerouslySetInnerHTML={{ __html: html }}
+      onClick={onClick}
+    />
+  );
+});
+
 // ─── Floating Selection Toolbar ────────────────────────────────────────────
 
 function FloatingToolbar({
@@ -231,9 +264,9 @@ export default function DiffViewer({
   const htmlIframeRef = useRef<HTMLIFrameElement>(null);
   const commentInputRef = useRef<HTMLInputElement>(null);
   // Post-render: fetch private repo images and render mermaid diagrams (markdown only).
-  // Must re-run when comments change because renderBlockHtml injects highlight marks,
-  // which causes React to replace the dangerouslySetInnerHTML DOM — wiping any
-  // previously rendered mermaid SVGs.
+  // Re-runs when comments change because renderBlockHtml injects highlight marks for
+  // commented ranges; when those marks shift, MarkdownBlock's memo bailout misses and
+  // the DOM is re-committed, so we need to re-render mermaid for the affected blocks.
   useEffect(() => {
     if (!contentRef.current || fileIsHtml) return;
     loadAuthenticatedImages(contentRef.current);
@@ -1025,11 +1058,9 @@ export default function DiffViewer({
                   <div key={idx} className="group relative mb-1">
                     {/* Block content with highlighted selections */}
                     {block.type === "unchanged" && (
-                      <div
+                      <MarkdownBlock
                         className="rendered-block diff-content"
-                        dangerouslySetInnerHTML={{
-                          __html: renderBlockHtml(headBlockToHtml(block.headText)),
-                        }}
+                        html={renderBlockHtml(headBlockToHtml(block.headText))}
                         onClick={handleMarkClick}
                       />
                     )}
@@ -1039,10 +1070,8 @@ export default function DiffViewer({
                         <div className="flex items-center gap-1 text-xs text-[var(--diff-add-text)] font-medium mb-1">
                           <Plus size={12} /> Added
                         </div>
-                        <div
-                          dangerouslySetInnerHTML={{
-                            __html: renderBlockHtml(headBlockToHtml(block.headText)),
-                          }}
+                        <MarkdownBlock
+                          html={renderBlockHtml(headBlockToHtml(block.headText))}
                           onClick={handleMarkClick}
                         />
                       </div>
@@ -1053,10 +1082,8 @@ export default function DiffViewer({
                         <div className="flex items-center gap-1 text-xs text-[var(--diff-remove-text)] font-medium mb-1">
                           <X size={12} /> Removed
                         </div>
-                        <div
-                          dangerouslySetInnerHTML={{
-                            __html: renderBlockHtml(baseBlockToHtml(block.baseText)),
-                          }}
+                        <MarkdownBlock
+                          html={renderBlockHtml(baseBlockToHtml(block.baseText))}
                         />
                       </div>
                     )}
@@ -1066,13 +1093,11 @@ export default function DiffViewer({
                         <div className="flex items-center gap-1 text-xs text-[var(--accent)] font-medium mb-1">
                           Modified
                         </div>
-                        <div
+                        <MarkdownBlock
                           className="text-sm leading-relaxed"
-                          dangerouslySetInnerHTML={{
-                            __html: renderBlockHtml(
-                              headBlockToHtml(block.diffHtml || block.headText)
-                            ),
-                          }}
+                          html={renderBlockHtml(
+                            headBlockToHtml(block.diffHtml || block.headText)
+                          )}
                           onClick={handleMarkClick}
                         />
                       </div>
@@ -1100,10 +1125,10 @@ export default function DiffViewer({
                   </div>
                   <div className="p-6 diff-content">
                     {parseBlocks(file.baseContent).map((block, idx) => (
-                      <div
+                      <MarkdownBlock
                         key={idx}
                         className="mb-1"
-                        dangerouslySetInnerHTML={{ __html: renderBlockHtml(baseBlockToHtml(block)) }}
+                        html={renderBlockHtml(baseBlockToHtml(block))}
                         onClick={handleMarkClick}
                       />
                     ))}
@@ -1115,10 +1140,10 @@ export default function DiffViewer({
                   </div>
                   <div className="p-6 diff-content">
                     {parseBlocks(file.headContent).map((block, idx) => (
-                      <div
+                      <MarkdownBlock
                         key={idx}
                         className="mb-1"
-                        dangerouslySetInnerHTML={{ __html: renderBlockHtml(headBlockToHtml(block)) }}
+                        html={renderBlockHtml(headBlockToHtml(block))}
                         onClick={handleMarkClick}
                       />
                     ))}
@@ -1190,13 +1215,13 @@ export default function DiffViewer({
                           )}
                         </div>
                       )}
-                      <div
+                      <MarkdownBlock
                         className="rendered-block diff-content"
-                        dangerouslySetInnerHTML={{
-                          __html: hasSuggestion
+                        html={
+                          hasSuggestion
                             ? headBlockToHtml(suggestionForBlock!.editedMarkdown)
-                            : headBlockToHtml(block),
-                        }}
+                            : headBlockToHtml(block)
+                        }
                       />
                       {!hasSuggestion && (
                         <div className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1270,12 +1295,10 @@ export default function DiffViewer({
                   {previewBlocks.map((block, idx) => {
                     const hasSuggestion = showSuggestionsInPreview && allSuggestions.some((s) => s.blockIndex === idx);
                     return (
-                      <div
+                      <MarkdownBlock
                         key={idx}
                         className={`rendered-block mb-1 ${hasSuggestion ? "border-l-2 border-[var(--accent)] pl-3 bg-[var(--accent-muted)] rounded-r" : ""}`}
-                        dangerouslySetInnerHTML={{
-                          __html: renderBlockHtml(headBlockToHtml(block)),
-                        }}
+                        html={renderBlockHtml(headBlockToHtml(block))}
                         onClick={handleMarkClick}
                       />
                     );

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -503,7 +503,10 @@ npm run dev
 
 The application uses a modern React stack with Next.js for server-side rendering and TipTap for the editor component. The GitHub integration uses Octokit to interact with the GitHub API.
 
-> **Note**: This is a prototype with mock data. GitHub integration will be added in a future release.`,
+` + "```mermaid\n" + `flowchart LR
+    U[User] --> M[mardoc.app]
+    M --> G[GitHub API]
+` + "```\n\n" + `> **Note**: This is a prototype with mock data. GitHub integration will be added in a future release.`,
         headContent: `# Getting Started
 
 Welcome to the **mardoc.app** — a collaborative markdown workspace backed by GitHub.
@@ -572,7 +575,10 @@ npm run dev
 
 The application uses a modern React stack with Next.js for server-side rendering and TipTap for the editor component. The GitHub integration uses Octokit to interact with the GitHub API.
 
-> **Note**: This is a prototype with mock data. Full GitHub integration coming in v0.2.0.`,
+` + "```mermaid\n" + `flowchart LR
+    U[User] --> M[mardoc.app]
+    M --> G[GitHub API]
+` + "```\n\n" + `> **Note**: This is a prototype with mock data. Full GitHub integration coming in v0.2.0.`,
       },
     ],
     comments: [


### PR DESCRIPTION
## Summary

- **Bug (issue #2 of 4):** Opening a PR with a mermaid diagram in the diff, then toggling the comment sidebar closed, wiped the rendered mermaid SVG. The diagram only came back on the next 30s poll tick — when the `comments` prop reference changed and re-fired the post-render useEffect that calls `renderMermaidBlocks`. Manual interaction alone couldn't bring it back.
- **Root cause:** React 18's reconciler compares `dangerouslySetInnerHTML` props by reference (`_nextProp !== _lastProp`). Every render creates a new `{__html: "..."}` object literal, so `setProp` unconditionally calls `setInnerHTML$1` — wiping any post-render DOM mutation (mermaid SVG, highlighted code overlays, data-URI images). The only thing that prevents it is `updateHostComponent`'s `oldProps === newProps` bailout, which requires a stable props reference.
- **Fix:** Introduce a `React.memo`'d `MarkdownBlock` wrapper that takes `html` as a string prop. When the html is unchanged across re-renders, memo skips the render entirely — the host-component bailout fires, innerHTML is never re-applied, and the mermaid mutation survives. Applied uniformly to all 8 block render sites in `DiffViewer` (inline / split / suggest / preview views × unchanged / added / removed / modified).

The `comments`-dep useEffect still re-runs mermaid when it needs to (when highlight marks shift and the html actually changes), but unrelated re-renders no longer destroy the rendered diagram.

## Test plan

- [x] New e2e regression: `e2e/pr-mermaid-stability.spec.ts`
  - [x] Mermaid SVG survives a comment-panel open→close cycle (tagged DOM node persists)
  - [x] Mermaid SVG survives a close→open→close cycle
- [x] Full desktop e2e suite — 58 passed (1 pre-existing flake in `image-flows` retried clean)
- [x] Full mobile e2e suite — 47 passed (same pre-existing flake retried clean)
- [x] 835 unit tests pass (5 expected-fail, unchanged)
- [x] Manual verification: mermaid no longer disappears when toggling the comment sidebar