### PR TITLE
fix: render local markdown images in VS Code embed mode

### DIFF
--- a/src/__tests__/load-embed-local-images.test.ts
+++ b/src/__tests__/load-embed-local-images.test.ts
@@ -26,10 +26,41 @@ vi.mock("@/lib/embed-image-bridge", () => ({
     .mockResolvedValue({ data: "QUFBQQ==", mimeType: "image/png" }),
 }));
 
-import { loadEmbedLocalImages } from "@/lib/github-api";
+import { loadEmbedLocalImages, rewriteImageUrls } from "@/lib/github-api";
 import { requestEmbedImage } from "@/lib/embed-image-bridge";
 
 const mockedRequest = requestEmbedImage as unknown as ReturnType<typeof vi.fn>;
+
+describe("rewriteImageUrls — __local__ path handling", () => {
+  it("strips the __local__/ prefix before building the raw.githubusercontent URL", () => {
+    // A file opened via the VS Code extension from a git repo has the
+    // `__local__/` scope marker prepended to its path but ALSO has
+    // owner/repo/branch context. rewriteImageUrls was baking the
+    // prefix into the URL → 404 on GitHub.
+    const out = rewriteImageUrls(
+      '<img src="docs/images/mvp-final-state.png" alt="arch">',
+      "Cloudzero/feature-ai-collector-macos",
+      "main",
+      "__local__/README.md"
+    );
+    expect(out).toContain(
+      'src="https://raw.githubusercontent.com/Cloudzero/feature-ai-collector-macos/main/docs/images/mvp-final-state.png"'
+    );
+    expect(out).not.toContain("__local__");
+  });
+
+  it("resolves relative paths correctly when currentFilePath is nested under __local__/", () => {
+    const out = rewriteImageUrls(
+      '<img src="../assets/logo.png">',
+      "acme/repo",
+      "main",
+      "__local__/docs/guide/intro.md"
+    );
+    expect(out).toContain(
+      'src="https://raw.githubusercontent.com/acme/repo/main/docs/assets/logo.png"'
+    );
+  });
+});
 
 describe("loadEmbedLocalImages — __local__ path handling", () => {
   const originalParent = Object.getOwnPropertyDescriptor(window, "parent");

--- a/src/__tests__/load-embed-local-images.test.ts
+++ b/src/__tests__/load-embed-local-images.test.ts
@@ -2,21 +2,27 @@
  * Regression for the VS Code embed `__local__` image bug.
  *
  * When a file is opened via the VS Code extension (drag-drop or the
- * "open folder" flow), `applyInitData` in app-context prefixes the
- * workspace-relative path with `__local__/` as an app-internal
- * marker to distinguish local-file scope from GitHub-repo scope.
+ * "open folder" flow), `applyInitData` in app-context prepends a
+ * `__local__/` scope marker to the workspace-relative path to
+ * distinguish local-file scope from GitHub-repo scope in the draft
+ * store. The marker is purely an app concept — it is NOT a real
+ * directory on disk.
  *
- * That prefix is purely an app concept — it's not a real directory
- * on the user's filesystem. Before this fix, loadEmbedLocalImages
- * passed the prefix through to resolvePath, and then on to the
- * extension via requestEmbedImage, so a markdown file like
+ * Before this fix, loadEmbedLocalImages passed the prefix straight
+ * through to resolvePath and then on to the extension via
+ * requestEmbedImage. A markdown file like
  *   `__local__/docs/guide.md`  referencing  `./images/arch.png`
  * asked the extension for `__local__/docs/images/arch.png` — which
- * the extension can't find, and the image renders as broken.
+ * is not a real path on disk, so the image rendered broken.
  *
  * The fix strips the `__local__/` prefix from currentFilePath before
  * resolving, so the extension receives the real workspace-relative
  * path (`docs/images/arch.png`).
+ *
+ * A companion fix in Editor.tsx gates `rewriteImageUrls` on
+ * `!filePath.startsWith("__local__/")`. Local files leave their
+ * <img src> relative and this loader handles them; only GitHub-backed
+ * files get rewritten to raw.githubusercontent.com.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
@@ -26,41 +32,10 @@ vi.mock("@/lib/embed-image-bridge", () => ({
     .mockResolvedValue({ data: "QUFBQQ==", mimeType: "image/png" }),
 }));
 
-import { loadEmbedLocalImages, rewriteImageUrls } from "@/lib/github-api";
+import { loadEmbedLocalImages } from "@/lib/github-api";
 import { requestEmbedImage } from "@/lib/embed-image-bridge";
 
 const mockedRequest = requestEmbedImage as unknown as ReturnType<typeof vi.fn>;
-
-describe("rewriteImageUrls — __local__ path handling", () => {
-  it("strips the __local__/ prefix before building the raw.githubusercontent URL", () => {
-    // A file opened via the VS Code extension from a git repo has the
-    // `__local__/` scope marker prepended to its path but ALSO has
-    // owner/repo/branch context. rewriteImageUrls was baking the
-    // prefix into the URL → 404 on GitHub.
-    const out = rewriteImageUrls(
-      '<img src="docs/images/mvp-final-state.png" alt="arch">',
-      "Cloudzero/feature-ai-collector-macos",
-      "main",
-      "__local__/README.md"
-    );
-    expect(out).toContain(
-      'src="https://raw.githubusercontent.com/Cloudzero/feature-ai-collector-macos/main/docs/images/mvp-final-state.png"'
-    );
-    expect(out).not.toContain("__local__");
-  });
-
-  it("resolves relative paths correctly when currentFilePath is nested under __local__/", () => {
-    const out = rewriteImageUrls(
-      '<img src="../assets/logo.png">',
-      "acme/repo",
-      "main",
-      "__local__/docs/guide/intro.md"
-    );
-    expect(out).toContain(
-      'src="https://raw.githubusercontent.com/acme/repo/main/docs/assets/logo.png"'
-    );
-  });
-});
 
 describe("loadEmbedLocalImages — __local__ path handling", () => {
   const originalParent = Object.getOwnPropertyDescriptor(window, "parent");

--- a/src/__tests__/load-embed-local-images.test.ts
+++ b/src/__tests__/load-embed-local-images.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression for the VS Code embed `__local__` image bug.
+ *
+ * When a file is opened via the VS Code extension (drag-drop or the
+ * "open folder" flow), `applyInitData` in app-context prefixes the
+ * workspace-relative path with `__local__/` as an app-internal
+ * marker to distinguish local-file scope from GitHub-repo scope.
+ *
+ * That prefix is purely an app concept — it's not a real directory
+ * on the user's filesystem. Before this fix, loadEmbedLocalImages
+ * passed the prefix through to resolvePath, and then on to the
+ * extension via requestEmbedImage, so a markdown file like
+ *   `__local__/docs/guide.md`  referencing  `./images/arch.png`
+ * asked the extension for `__local__/docs/images/arch.png` — which
+ * the extension can't find, and the image renders as broken.
+ *
+ * The fix strips the `__local__/` prefix from currentFilePath before
+ * resolving, so the extension receives the real workspace-relative
+ * path (`docs/images/arch.png`).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("@/lib/embed-image-bridge", () => ({
+  requestEmbedImage: vi
+    .fn()
+    .mockResolvedValue({ data: "QUFBQQ==", mimeType: "image/png" }),
+}));
+
+import { loadEmbedLocalImages } from "@/lib/github-api";
+import { requestEmbedImage } from "@/lib/embed-image-bridge";
+
+const mockedRequest = requestEmbedImage as unknown as ReturnType<typeof vi.fn>;
+
+describe("loadEmbedLocalImages — __local__ path handling", () => {
+  const originalParent = Object.getOwnPropertyDescriptor(window, "parent");
+
+  beforeEach(() => {
+    mockedRequest.mockClear();
+    // loadEmbedLocalImages early-returns when window.parent === window
+    // (i.e. not embedded). Stub so the function runs.
+    Object.defineProperty(window, "parent", {
+      configurable: true,
+      value: {} as Window,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    if (originalParent) {
+      Object.defineProperty(window, "parent", originalParent);
+    }
+  });
+
+  it("strips the __local__/ prefix before asking the extension", async () => {
+    const container = document.createElement("div");
+    container.innerHTML = '<img src="./images/arch.png" alt="arch">';
+
+    await loadEmbedLocalImages(container, "__local__/docs/guide.md");
+
+    expect(mockedRequest).toHaveBeenCalledTimes(1);
+    expect(mockedRequest).toHaveBeenCalledWith("docs/images/arch.png");
+  });
+
+  it("handles files at the workspace root (no directory) under __local__/", async () => {
+    const container = document.createElement("div");
+    container.innerHTML = '<img src="./logo.png">';
+
+    await loadEmbedLocalImages(container, "__local__/README.md");
+
+    expect(mockedRequest).toHaveBeenCalledWith("logo.png");
+  });
+
+  it("does not modify paths that do not start with __local__/", async () => {
+    const container = document.createElement("div");
+    container.innerHTML = '<img src="./images/arch.png">';
+
+    await loadEmbedLocalImages(container, "docs/guide.md");
+
+    expect(mockedRequest).toHaveBeenCalledWith("docs/images/arch.png");
+  });
+
+  it("resolves ../ paths correctly after stripping the prefix", async () => {
+    const container = document.createElement("div");
+    container.innerHTML = '<img src="../assets/diagram.png">';
+
+    await loadEmbedLocalImages(container, "__local__/docs/guide/intro.md");
+
+    expect(mockedRequest).toHaveBeenCalledWith("docs/assets/diagram.png");
+  });
+});

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -189,7 +189,13 @@ function markdownToHtml(md: string, repoFullName?: string, branch?: string, file
   // <div align="center"><img></div> structure.
   let html = transformGitHubAlerts(showdownConverter.makeHtml(transformFootnotes(md)));
   html = unwrapCenteredImages(html);
-  if (repoFullName && branch && filePath) {
+  // Files opened via the VS Code extension carry a `__local__/` scope
+  // marker prepended by applyInitData. Those live on the user's disk,
+  // not on GitHub, so rewriting to raw.githubusercontent.com would
+  // produce a dead URL (and leak the scope marker into it). Leave the
+  // <img src> relative — loadEmbedLocalImages will resolve it against
+  // the workspace and ask the extension to read the bytes.
+  if (repoFullName && branch && filePath && !filePath.startsWith("__local__/")) {
     return rewriteImageUrls(html, repoFullName, branch, filePath);
   }
   return html;
@@ -886,7 +892,7 @@ export default function Editor({ content, onContentChange, filePath, repoFullNam
       let rawHtml = unwrapCenteredImages(
         transformGitHubAlerts(showdownConverter.makeHtml(transformFootnotes(codeContent)))
       );
-      if (repoFullName && branch && filePath) {
+      if (repoFullName && branch && filePath && !filePath.startsWith("__local__/")) {
         rawHtml = rewriteImageUrls(rawHtml, repoFullName, branch, filePath);
       }
       const html = await preRenderMermaid(rawHtml);

--- a/src/lib/github-api.ts
+++ b/src/lib/github-api.ts
@@ -1228,6 +1228,13 @@ export async function loadEmbedLocalImages(
 ): Promise<void> {
   if (typeof window === "undefined" || window.parent === window) return;
 
+  // `__local__/` is an app-internal scope marker prepended by
+  // applyInitData for files opened via the VS Code extension. It's
+  // not a real directory on the user's filesystem, so strip it before
+  // resolving — otherwise the extension is asked for
+  // `__local__/docs/images/arch.png` and the read fails.
+  const workspaceFilePath = currentFilePath.replace(/^__local__\//, "");
+
   const IMAGE_MIME: Record<string, string> = {
     png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg",
     gif: "image/gif", svg: "image/svg+xml", webp: "image/webp",
@@ -1255,7 +1262,7 @@ export async function loadEmbedLocalImages(
   const results = await Promise.allSettled(
     candidates.map(async (img) => {
       const src = img.getAttribute("src") || "";
-      const resolved = resolvePath(currentFilePath, src);
+      const resolved = resolvePath(workspaceFilePath, src);
       const { data, mimeType } = await requestEmbedImage(resolved);
       // Prefer the mimeType from the extension; fall back to the
       // file extension in case the extension doesn't set one.

--- a/src/lib/github-api.ts
+++ b/src/lib/github-api.ts
@@ -1082,7 +1082,13 @@ export function rewriteImageUrls(
   filePath: string
 ): string {
   const { owner, repo } = parseOwnerRepo(repoFullName);
-  const fileDir = filePath.split("/").slice(0, -1).join("/");
+  // Strip the `__local__/` scope marker — see loadEmbedLocalImages for
+  // background. Without this, a file opened via the VS Code extension
+  // gets its relative images rewritten to
+  //   https://raw.githubusercontent.com/owner/repo/ref/__local__/docs/...
+  // which is never a real object on GitHub.
+  const workspaceFilePath = filePath.replace(/^__local__\//, "");
+  const fileDir = workspaceFilePath.split("/").slice(0, -1).join("/");
 
   return html.replace(
     /(<img\s+[^>]*?src=")([^"]+)("[^>]*?>)/gi,

--- a/src/lib/github-api.ts
+++ b/src/lib/github-api.ts
@@ -1082,13 +1082,7 @@ export function rewriteImageUrls(
   filePath: string
 ): string {
   const { owner, repo } = parseOwnerRepo(repoFullName);
-  // Strip the `__local__/` scope marker — see loadEmbedLocalImages for
-  // background. Without this, a file opened via the VS Code extension
-  // gets its relative images rewritten to
-  //   https://raw.githubusercontent.com/owner/repo/ref/__local__/docs/...
-  // which is never a real object on GitHub.
-  const workspaceFilePath = filePath.replace(/^__local__\//, "");
-  const fileDir = workspaceFilePath.split("/").slice(0, -1).join("/");
+  const fileDir = filePath.split("/").slice(0, -1).join("/");
 
   return html.replace(
     /(<img\s+[^>]*?src=")([^"]+)("[^>]*?>)/gi,


### PR DESCRIPTION
## Summary

- **Bug (issue #3 of 4):** Images in markdown files opened via **Edit with MarDoc** (VS Code extension) don't render. The relative `![arch](docs/images/mvp-final-state.png)` was being rewritten to `raw.githubusercontent.com/owner/repo/main/__local__/docs/images/mvp-final-state.png` — which 404s even if the file IS on GitHub (leaking the app-internal `__local__/` scope marker into the URL), and is outright wrong for a file that lives on disk and may never have been pushed.
- **Root cause:** `applyInitData` in `src/lib/app-context.tsx` prepends `__local__/` to the workspace-relative path as an app-internal scope marker (so draft-store keys for local files don't collide with git-backed drafts of the same path). Treating that marker as a real path component produced a fabricated GitHub URL for something that has no business being a GitHub URL in the first place.
- **Fix:**
  - In `Editor.tsx`, gate both `rewriteImageUrls` call sites on `!filePath.startsWith("__local__/")`. Local files leave their `<img src="docs/images/x.png">` relative so `loadEmbedLocalImages` can ask the VS Code extension to read the bytes from disk.
  - In `loadEmbedLocalImages`, strip the `__local__/` prefix from `currentFilePath` before resolving `./images/x.png` against it — otherwise the extension gets asked for `__local__/docs/images/x.png`, which is not a real path.
  - `rewriteImageUrls` itself is untouched; callers just stop passing it `__local__/` paths.
- **Companion change:** `mardoc-vscode` PR #2 adds the `file:read-image` handler the app expects. Without that, local image requests time out and render the standard failed-image placeholder; with it, they resolve to data URIs.

## Test plan

- [x] `src/__tests__/load-embed-local-images.test.ts` — 4 cases covering the strip and path resolution (workspace root, nested files, `../` traversal, non-`__local__` paths left alone)
- [x] 839 unit tests pass
- [x] Manual end-to-end: `Edit with MarDoc` on a README that references `docs/images/mvp-final-state.png` renders the image from disk; code view shows the clean relative `src` (no `__local__/`, no `raw.githubusercontent.com` leak)
- [x] Verified in a multi-root workspace (the file's repo is NOT `workspaceFolders[0]`) after landing the paired extension PR

## Why no e2e

The regression surface is the postMessage bridge between the app iframe and the VS Code extension. Playwright can't load a VS Code extension, so an embed-mode e2e would need a dedicated harness that spins up the app in an iframe and mocks the postMessage protocol (reads, saves, theme sync). That's a meaningful scaffolding lift and would be better as a standalone harness PR rather than bundled into this fix. Unit tests pin the strip and gate logic; manual validation confirmed the end-to-end path.