### PR TITLE
chore: update repo references from mardoc-io to mardoc-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Visit [mardoc.app](https://mardoc.app) in demo mode and explore sample repos and
 ## Run locally
 
 ```bash
-git clone https://github.com/mardoc-io/mardoc-io.github.io.git
-cd mardoc-io.github.io
+git clone https://github.com/mardoc-app/mardoc-app.github.io.git
+cd mardoc-app.github.io
 npm install
 npm run dev
 ```
@@ -121,4 +121,4 @@ See [elastic.co/licensing/elastic-license](https://www.elastic.co/licensing/elas
 
 Pull requests are welcome. The project uses the feature-sliced delivery style in `docs/features/` — one markdown file per story, moved to `docs/features/done/` on ship. Tests are non-negotiable: every new behavior gets unit-test coverage alongside the code. `npm test` and `npm run build` must both be clean before a PR merges.
 
-Bug reports and feature requests: [open an issue](https://github.com/mardoc-io/mardoc-io.github.io/issues).
+Bug reports and feature requests: [open an issue](https://github.com/mardoc-app/mardoc-app.github.io/issues).

--- a/docs/design/mobile-prototype.html
+++ b/docs/design/mobile-prototype.html
@@ -1893,7 +1893,7 @@ html, body {
             Closed
             <span class="count">42</span>
           </button>
-          <span class="pull-right stagger">mardoc-io · main</span>
+          <span class="pull-right stagger">mardoc-app · main</span>
         </div>
 
         <div class="pr-list">
@@ -2050,7 +2050,7 @@ html, body {
           <button class="icon-btn" onclick="nav.back()" aria-label="Back">
             <svg viewBox="0 0 24 24"><path d="M15 18l-6-6 6-6"/></svg>
           </button>
-          <div class="wordmark">mardoc-io / mardoc-io.github.io</div>
+          <div class="wordmark">mardoc-app / mardoc-app.github.io</div>
           <button class="icon-btn" aria-label="More">
             <svg viewBox="0 0 24 24"><circle cx="5" cy="12" r="1.5"/><circle cx="12" cy="12" r="1.5"/><circle cx="19" cy="12" r="1.5"/></svg>
           </button>
@@ -2295,7 +2295,7 @@ html, body {
 
       <div class="repo-card">
         <div class="label">Current repository</div>
-        <div class="name">mardoc-io / mardoc-io.github.io</div>
+        <div class="name">mardoc-app / mardoc-app.github.io</div>
       </div>
 
       <nav>

--- a/public/mobile-prototype.html
+++ b/public/mobile-prototype.html
@@ -1893,7 +1893,7 @@ html, body {
             Closed
             <span class="count">42</span>
           </button>
-          <span class="pull-right stagger">mardoc-io · main</span>
+          <span class="pull-right stagger">mardoc-app · main</span>
         </div>
 
         <div class="pr-list">
@@ -2050,7 +2050,7 @@ html, body {
           <button class="icon-btn" onclick="nav.back()" aria-label="Back">
             <svg viewBox="0 0 24 24"><path d="M15 18l-6-6 6-6"/></svg>
           </button>
-          <div class="wordmark">mardoc-io / mardoc-io.github.io</div>
+          <div class="wordmark">mardoc-app / mardoc-app.github.io</div>
           <button class="icon-btn" aria-label="More">
             <svg viewBox="0 0 24 24"><circle cx="5" cy="12" r="1.5"/><circle cx="12" cy="12" r="1.5"/><circle cx="19" cy="12" r="1.5"/></svg>
           </button>
@@ -2295,7 +2295,7 @@ html, body {
 
       <div class="repo-card">
         <div class="label">Current repository</div>
-        <div class="name">mardoc-io / mardoc-io.github.io</div>
+        <div class="name">mardoc-app / mardoc-app.github.io</div>
       </div>
 
       <nav>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -265,7 +265,7 @@ export default function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
                     type="text"
                     value={repoInput}
                     onChange={(e) => setRepoInput(e.target.value)}
-                    placeholder="e.g., mardoc-io/mardoc-io.github.io"
+                    placeholder="e.g., mardoc-app/mardoc-app.github.io"
                     className="flex-1 px-3 py-2 text-sm rounded-lg border border-[var(--border)] bg-[var(--surface)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)] font-mono"
                     onKeyDown={(e) => {
                       if (e.key === "Enter") handleManualRepo();

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -255,7 +255,7 @@ Generate a new token following the steps above, then update it in mardoc.app Set
 
 ---
 
-*Need help? Open an issue at [github.com/mardoc-io/mardoc-io.github.io](https://github.com/mardoc-io/mardoc-io.github.io/issues).*
+*Need help? Open an issue at [github.com/mardoc-app/mardoc-app.github.io](https://github.com/mardoc-app/mardoc-app.github.io/issues).*
 `,
       },
       {


### PR DESCRIPTION
## Summary

- Follow-up to the org rename (`mardoc-io` → `mardoc-app`). Updated the five in-repo references that don't benefit from GitHub's redirect layer: rendered issue links, a settings placeholder, a README clone URL, and cosmetic wordmarks in the mobile prototype.
- Custom domain (`mardoc.app` in `public/CNAME`) is unchanged, so the public surface stays identical. VS Code extension default (`mardoc.appUrl = https://mardoc.app`) also unaffected.

## Files

- `README.md` — clone URL + issues link
- `src/lib/mock-data.ts` — demo help-doc issues link
- `src/components/SettingsPanel.tsx` — repo input placeholder
- `public/mobile-prototype.html` + `docs/design/mobile-prototype.html` — cosmetic wordmarks

## Test plan

- [x] `npx vitest run` — all 48 files / 841 tests pass
- [x] `npm run build` — static export succeeds
- [x] CI green
- [x] Manual: load the site at `https://mardoc.app` post-merge and confirm custom domain still serves the deployed artifact