### PR TITLE
fix: per-file comment filtering in PR review

### DIFF
--- a/docs/features/039-per-file-comment-filtering.md
+++ b/docs/features/039-per-file-comment-filtering.md
@@ -1,0 +1,90 @@
+# 039 — Per-File Comment Filtering & Highlight Accuracy
+
+## Value
+
+When viewing a file in a PR, the comment panel and inline highlights show comments from **all files in the PR**, not just the current file. This creates noise (irrelevant comments cluttering the sidebar), false highlights (text matches from other files' comments lighting up in the current file), and broken click-to-go (clicking a cross-file highlight selects a comment whose context doesn't exist here). The result is a confusing review experience that gets worse as PR size grows.
+
+Fixing this makes the per-file review feel focused and trustworthy — comments belong to what you're looking at.
+
+## Bugs
+
+### Bug 1: Comment panel shows all PR comments regardless of selected file
+
+**Symptom:** Open a PR with comments on multiple files. Switch between files — the sidebar always shows the same full set of comments.
+
+**Root cause:** `PRComment` has no `path` field. `fetchPRComments()` (`github-api.ts:447-467`) maps review comments from the GitHub API but drops `c.path`. `DiffViewer.tsx:450-468` builds `allPanelComments` from the full unfiltered array.
+
+**Files:**
+- `src/types/index.ts` — `PRComment` interface (missing `path`)
+- `src/lib/github-api.ts` — `fetchPRComments()` (drops `c.path`)
+- `src/components/DiffViewer.tsx` — `allPanelComments` memo (no file filter)
+
+### Bug 2: Highlights appear from other files' comments
+
+**Symptom:** A file shows yellow comment highlights on text that was never commented on — the highlighted text matches `selectedText` from a comment on a different file.
+
+**Root cause:** `renderBlockHtml()` (`DiffViewer.tsx:797-841`) searches ALL unresolved comments' `selectedText` against the current file's HTML. Cross-file matches produce spurious `<mark>` tags.
+
+**Files:**
+- `src/components/DiffViewer.tsx` — `renderBlockHtml()` callback
+
+### Bug 3: Click-to-go navigates to wrong or missing context
+
+**Symptom:** Clicking a highlight or a comment in the panel may: (a) select a comment from another file, or (b) fail to scroll because the comment's `selectedText` doesn't exist in the current file's DOM.
+
+**Root cause:** Downstream of bugs 1 & 2 — once comments are filtered correctly, the existing `handleCommentSelect` and `handleMarkClick` logic works.
+
+## Acceptance Criteria
+
+- [x] `PRComment` type includes a `path` field
+- [x] `fetchPRComments()` populates `path` from the GitHub review comment's `.path` property
+- [x] Issue comments (no file path from GitHub) excluded from per-file view (Option A)
+- [x] `allPanelComments` in `DiffViewer` filters to comments matching the current `file.path` (plus locally-pending comments for the current file)
+- [x] Comment count badge in the DiffViewer toolbar reflects per-file count, not PR-wide
+- [x] Comment count in the PR header (`PRDetail.tsx:489`) continues to show PR-wide count
+- [x] `renderBlockHtml()` only injects highlights for the current file's comments
+- [x] Clicking a highlight opens the correct comment in the panel
+- [x] Clicking a comment in the panel scrolls to the correct mark in the diff
+- [x] All five markdown view modes work: Inline Diff, Split, Suggest, Preview
+- [x] Both HTML view modes work: Rendered, Source Diff
+- [x] Mobile bottom sheet shows per-file comments (same filtering)
+- [x] Switching files updates the comment panel immediately
+- [x] Pending (not yet submitted) comments appear only on their originating file
+
+## Implementation Plan
+
+### 1. Add `path` to `PRComment` type
+`src/types/index.ts` — add `path?: string` to the interface.
+
+### 2. Populate `path` in `fetchPRComments()`
+`src/lib/github-api.ts:447` — add `path: c.path` to the review comment mapping. Issue comments (`ic-*`) get no path (they're PR-level).
+
+### 3. Filter comments in `DiffViewer`
+`src/components/DiffViewer.tsx` — change the `allPanelComments` memo to filter `comments` by matching `file.path`:
+- Review comments (`rc-*`): include if `comment.path === file.path`
+- Pending comments: include if `comment.pendingPath === file.path`
+- Issue comments (`ic-*`, no path): exclude from per-file view (or show under a separator)
+
+### 4. Verify downstream consumers
+`renderBlockHtml`, `handleCommentSelect`, comment count badge, mobile BottomSheet — all derive from `allPanelComments`, so filtering at the source fixes them all.
+
+### 5. Handle general PR comments
+Issue comments have no file association. Options:
+- **Option A:** Show them only in the PR header comment count, not in per-file panels. Simplest.
+- **Option B:** Add a "General" section at the bottom of the panel. More complete but adds UI complexity.
+
+Recommend Option A for now — ship and iterate.
+
+### 6. Tests
+- Unit test for `fetchPRComments` path population (mock Octokit response with `path` field)
+- Unit test for comment filtering logic (given comments across 3 files, verify only matching ones appear)
+- Manual test across all view modes with a multi-file PR
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `src/types/index.ts` | Add `path?: string` to `PRComment` |
+| `src/lib/github-api.ts` | Set `path: c.path` in review comment mapping |
+| `src/components/DiffViewer.tsx` | Filter `allPanelComments` by `file.path` |
+| `src/lib/comment-merge.ts` | Preserve `path` field during merge (verify) |

--- a/e2e/per-file-comments.spec.ts
+++ b/e2e/per-file-comments.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * E2E tests for per-file comment filtering in PR review.
+ *
+ * Verifies that switching between files in a multi-file PR updates the
+ * comment panel to show only comments for the selected file. Uses demo
+ * PR #42 which has two files (docs/getting-started.md and
+ * docs/contributing.md) with comments on each.
+ */
+import { test, expect } from "@playwright/test";
+import {
+  waitForHydration,
+  openSidebar,
+  clickInVisibleSidebar,
+  clickVisibleText,
+} from "./fixtures/helpers";
+
+async function openMultiFilePR(page: import("@playwright/test").Page) {
+  await page.goto("/");
+  await waitForHydration(page);
+  await openSidebar(page);
+  await clickInVisibleSidebar(page, "PRs");
+  await clickVisibleText(page, /Update getting started guide/i);
+  await expect(
+    page.locator("button", { hasText: /^Approve$/ }).first()
+  ).toBeVisible({ timeout: 10_000 });
+}
+
+test.describe("Per-file comment filtering", () => {
+  test("comment panel shows only comments for the selected file", async ({ page }) => {
+    await openMultiFilePR(page);
+
+    // First file (getting-started.md) is selected by default.
+    // It should show its 2 review comments + 1 pending = panel shows comments.
+    // The comment "Great addition!" belongs to getting-started.md.
+    await expect(page.locator("text=Great addition!")).toBeVisible({ timeout: 5_000 });
+
+    // The comment from contributing.md should NOT be visible.
+    await expect(page.locator("text=Can we add a section about running the test suite")).not.toBeVisible();
+  });
+
+  test("switching to second file shows only that file's comments", async ({ page }) => {
+    await openMultiFilePR(page);
+
+    // Verify first file's comment is visible
+    await expect(page.locator("text=Great addition!")).toBeVisible({ timeout: 5_000 });
+
+    // Switch to the second file via the sidebar file list
+    await openSidebar(page);
+    await clickInVisibleSidebar(page, "Files");
+    await clickVisibleText(page, /contributing\.md/);
+
+    // contributing.md's comment should now be visible
+    await expect(
+      page.locator("text=Can we add a section about running the test suite")
+    ).toBeVisible({ timeout: 5_000 });
+
+    // getting-started.md's comments should be gone
+    await expect(page.locator("text=Great addition!")).not.toBeVisible();
+    await expect(page.locator("text=Docker")).not.toBeVisible();
+  });
+
+  test("comment count badge reflects per-file count, not PR total", async ({ page }) => {
+    await openMultiFilePR(page);
+
+    // getting-started.md has 2 unresolved comments from review
+    // The DiffViewer toolbar shows per-file count
+    const commentBtn = page.locator("button", { hasText: /\d+ comments?/ }).first();
+    await expect(commentBtn).toBeVisible({ timeout: 5_000 });
+    const text = await commentBtn.textContent();
+    expect(text).toMatch(/2 comments/);
+  });
+});

--- a/src/__tests__/comment-merge.test.ts
+++ b/src/__tests__/comment-merge.test.ts
@@ -90,6 +90,21 @@ describe("mergeFreshComments", () => {
     expect(mergeFreshComments([], fresh)).toEqual(fresh);
   });
 
+  it("preserves path field through merge", () => {
+    const prev = [
+      comment({ id: "rc-1", path: "docs/readme.md" }),
+      comment({ id: "c-local", pending: true, pendingPath: "docs/guide.md", body: "draft" }),
+    ];
+    const fresh = [
+      comment({ id: "rc-1", path: "docs/readme.md", body: "refreshed" }),
+      comment({ id: "rc-2", path: "docs/guide.md" }),
+    ];
+    const merged = mergeFreshComments(prev, fresh);
+    expect(merged.find((c) => c.id === "rc-1")?.path).toBe("docs/readme.md");
+    expect(merged.find((c) => c.id === "rc-2")?.path).toBe("docs/guide.md");
+    expect(merged.find((c) => c.id === "c-local")?.pendingPath).toBe("docs/guide.md");
+  });
+
   it("handles a mix of fresh, pending, and stale correctly", () => {
     const prev = [
       comment({ id: "rc-old" }),          // non-pending, will be dropped (not in fresh)

--- a/src/__tests__/diff-viewer-panel-autoreopen.test.tsx
+++ b/src/__tests__/diff-viewer-panel-autoreopen.test.tsx
@@ -80,6 +80,7 @@ function makeMarkdownFile(): PRFile {
 function makeComment(overrides: Partial<PRComment> = {}): PRComment {
   return {
     id: "rc-1",
+    path: "docs/notes.md",
     author: "alice",
     avatarColor: "#264653",
     body: "Could you clarify?",

--- a/src/__tests__/per-file-comment-filter.test.tsx
+++ b/src/__tests__/per-file-comment-filter.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * Tests for per-file comment filtering in DiffViewer.
+ *
+ * Verifies that the comment panel only shows comments belonging to
+ * the currently selected file, not the entire PR. Covers:
+ *   - Review comments (rc-*) filtered by path
+ *   - Pending comments filtered by pendingPath
+ *   - Issue comments (ic-*, no path) excluded from per-file view
+ *   - Switching files changes which comments are visible
+ *   - Comment count badge reflects per-file count
+ */
+import React from "react";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import DiffViewer from "@/components/DiffViewer";
+import type { PRFile, PRComment } from "@/types";
+
+vi.mock("@/lib/app-context", () => ({
+  useApp: () => ({ isEmbedded: false }),
+}));
+
+vi.mock("@/lib/github-api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/github-api")>(
+    "@/lib/github-api"
+  );
+  return {
+    ...actual,
+    loadAuthenticatedImages: vi.fn(),
+    loadEmbedLocalImages: vi.fn(),
+    rewriteImageUrls: (html: string) => html,
+    mapSelectionToLines: () => ({ startLine: 1, endLine: 1 }),
+  };
+});
+
+vi.mock("@/lib/mermaid", () => ({
+  renderMermaidBlocks: vi.fn(),
+}));
+vi.mock("@/lib/highlight", () => ({
+  highlightCodeBlocks: (html: string) => html,
+}));
+
+beforeEach(() => {
+  if (!window.matchMedia) {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        onchange: null,
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+const fileA: PRFile = {
+  path: "docs/getting-started.md",
+  status: "modified",
+  baseContent: "# Getting Started\n\nOld content.\n",
+  headContent: "# Getting Started\n\nNew content.\n",
+};
+
+const fileB: PRFile = {
+  path: "docs/contributing.md",
+  status: "added",
+  baseContent: "",
+  headContent: "# Contributing\n\nFork the repository.\n",
+};
+
+function comment(overrides: Partial<PRComment>): PRComment {
+  return {
+    id: "default",
+    author: "alice",
+    avatarColor: "#264653",
+    body: "Test comment",
+    createdAt: "2026-04-28T00:00:00Z",
+    resolved: false,
+    replies: [],
+    ...overrides,
+  };
+}
+
+const noop = vi.fn();
+
+function renderViewer(file: PRFile, comments: PRComment[]) {
+  return render(
+    <DiffViewer
+      file={file}
+      repoFullName="owner/repo"
+      baseBranch="main"
+      headBranch="feat/test"
+      comments={comments}
+      onAddComment={noop}
+      onResolveComment={noop}
+      onReplyComment={noop}
+      onSubmitSuggestions={noop}
+      onAcceptSuggestion={noop}
+      onDiscardPendingComment={noop}
+    />
+  );
+}
+
+describe("Per-file comment filtering", () => {
+  const commentsAcrossFiles: PRComment[] = [
+    comment({ id: "rc-1", path: "docs/getting-started.md", body: "Comment on getting started", selectedText: "New content" }),
+    comment({ id: "rc-2", path: "docs/getting-started.md", body: "Another on getting started" }),
+    comment({ id: "rc-3", path: "docs/contributing.md", body: "Comment on contributing", selectedText: "Fork the repository" }),
+    comment({ id: "ic-1", body: "General PR comment (no path)" }),
+    comment({ id: "c-pending-1", pending: true, pendingPath: "docs/getting-started.md", body: "Pending on getting started" }),
+    comment({ id: "c-pending-2", pending: true, pendingPath: "docs/contributing.md", body: "Pending on contributing" }),
+  ];
+
+  it("shows only comments matching fileA when viewing fileA", async () => {
+    renderViewer(fileA, commentsAcrossFiles);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Comments \(3\)/)).toBeTruthy();
+    });
+
+    expect(screen.getByText("Comment on getting started")).toBeTruthy();
+    expect(screen.getByText("Another on getting started")).toBeTruthy();
+    expect(screen.getByText("Pending on getting started")).toBeTruthy();
+
+    expect(screen.queryByText("Comment on contributing")).toBeNull();
+    expect(screen.queryByText("General PR comment (no path)")).toBeNull();
+    expect(screen.queryByText("Pending on contributing")).toBeNull();
+  });
+
+  it("shows only comments matching fileB when viewing fileB", async () => {
+    renderViewer(fileB, commentsAcrossFiles);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Comments \(2\)/)).toBeTruthy();
+    });
+
+    expect(screen.getByText("Comment on contributing")).toBeTruthy();
+    expect(screen.getByText("Pending on contributing")).toBeTruthy();
+
+    expect(screen.queryByText("Comment on getting started")).toBeNull();
+    expect(screen.queryByText("General PR comment (no path)")).toBeNull();
+  });
+
+  it("shows no comments when viewing a file with none", async () => {
+    const fileC: PRFile = {
+      path: "docs/changelog.md",
+      status: "modified",
+      baseContent: "# Changelog\n\nOld.\n",
+      headContent: "# Changelog\n\nNew.\n",
+    };
+
+    renderViewer(fileC, commentsAcrossFiles);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No comments yet/)).toBeTruthy();
+    });
+  });
+
+  it("excludes issue comments (no path) from per-file view", async () => {
+    const onlyIssueComments = [
+      comment({ id: "ic-1", body: "General PR comment" }),
+    ];
+
+    renderViewer(fileA, onlyIssueComments);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No comments yet/)).toBeTruthy();
+    });
+  });
+
+  it("switches comment set when rerendered with a different file", async () => {
+    const { rerender } = renderViewer(fileA, commentsAcrossFiles);
+
+    await waitFor(() => {
+      expect(screen.getByText("Comment on getting started")).toBeTruthy();
+    });
+    expect(screen.queryByText("Comment on contributing")).toBeNull();
+
+    rerender(
+      <DiffViewer
+        file={fileB}
+        repoFullName="owner/repo"
+        baseBranch="main"
+        headBranch="feat/test"
+        comments={commentsAcrossFiles}
+        onAddComment={noop}
+        onResolveComment={noop}
+        onReplyComment={noop}
+        onSubmitSuggestions={noop}
+        onAcceptSuggestion={noop}
+        onDiscardPendingComment={noop}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Comment on contributing")).toBeTruthy();
+    });
+    expect(screen.queryByText("Comment on getting started")).toBeNull();
+  });
+});

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -446,27 +446,37 @@ export default function DiffViewer({
     return result;
   }, [fileIsHtml, file.baseContent, file.headContent]);
 
-  // Map PR comments into panel format for display
+  // Map PR comments into panel format, filtered to the current file.
+  // Review comments (rc-*) match on path; pending comments match on
+  // pendingPath; issue comments (ic-*, no path) are PR-level and
+  // excluded from per-file views.
   const allPanelComments: PanelComment[] = useMemo(() => {
-    return comments.map((c) => ({
-      id: c.id,
-      selectedText: c.selectedText || "",
-      body: c.body,
-      author: c.author,
-      avatarColor: c.avatarColor,
-      createdAt: c.createdAt,
-      blockIndex: c.blockIndex || 0,
-      resolved: c.resolved,
-      replies: (c.replies || []).map((r) => ({
-        author: r.author,
-        avatarColor: r.avatarColor,
-        body: r.body,
-        createdAt: r.createdAt,
-      })),
-      source: c.pending ? ("local" as const) : ("github" as const),
-      pending: c.pending,
-    }));
-  }, [comments]);
+    const filePath = file.path;
+    return comments
+      .filter((c) => {
+        if (c.pending) return c.pendingPath === filePath;
+        if (c.path) return c.path === filePath;
+        return false;
+      })
+      .map((c) => ({
+        id: c.id,
+        selectedText: c.selectedText || "",
+        body: c.body,
+        author: c.author,
+        avatarColor: c.avatarColor,
+        createdAt: c.createdAt,
+        blockIndex: c.blockIndex || 0,
+        resolved: c.resolved,
+        replies: (c.replies || []).map((r) => ({
+          author: r.author,
+          avatarColor: r.avatarColor,
+          body: r.body,
+          createdAt: r.createdAt,
+        })),
+        source: c.pending ? ("local" as const) : ("github" as const),
+        pending: c.pending,
+      }));
+  }, [comments, file.path]);
 
   // Auto-show the panel on the 0→N transition — initial mount when a
   // PR already has unresolved comments, or later when a new comment

--- a/src/lib/github-api.ts
+++ b/src/lib/github-api.ts
@@ -450,6 +450,7 @@ export async function fetchPRComments(
         id: `rc-${c.id}`,
         githubId: c.id,
         threadId: thread?.threadId,
+        path: c.path,
         author: c.user?.login || "unknown",
         avatarColor: getColor(c.user?.login || "unknown"),
         body: c.body,

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -581,10 +581,36 @@ The application uses a modern React stack with Next.js for server-side rendering
     M --> G[GitHub API]
 ` + "```\n\n" + `> **Note**: This is a prototype with mock data. Full GitHub integration coming in v0.2.0.`,
       },
+      {
+        path: "docs/contributing.md",
+        status: "added",
+        baseContent: "",
+        headContent: `# Contributing
+
+Thank you for your interest in contributing to mardoc.app!
+
+## Getting Started
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Submit a pull request
+
+## Code Style
+
+- Use TypeScript for all new code
+- Follow the existing patterns in the codebase
+- Write tests for new functionality
+
+## Reporting Issues
+
+Please use GitHub Issues to report bugs or request features.`,
+      },
     ],
     comments: [
       {
         id: "c1",
+        path: "docs/getting-started.md",
         author: "sarah.chen",
         avatarColor: "#e76f51",
         body: "Great addition! The prerequisites section is really helpful for newcomers.",
@@ -603,11 +629,24 @@ The application uses a modern React stack with Next.js for server-side rendering
       },
       {
         id: "c2",
+        path: "docs/getting-started.md",
         author: "alex.kim",
         avatarColor: "#2a9d8f",
         body: "Should we mention that Docker is also an option? We have a docker-compose setup.",
         createdAt: "2026-03-30T16:30:00Z",
         blockIndex: 3,
+        resolved: false,
+        replies: [],
+      },
+      {
+        id: "c4",
+        path: "docs/contributing.md",
+        author: "alex.kim",
+        avatarColor: "#2a9d8f",
+        body: "Can we add a section about running the test suite before submitting?",
+        createdAt: "2026-03-30T17:00:00Z",
+        blockIndex: 1,
+        selectedText: "Fork the repository",
         resolved: false,
         replies: [],
       },
@@ -746,6 +785,7 @@ The editor supports GitHub webhooks for real-time synchronization. Configure you
     comments: [
       {
         id: "c3",
+        path: "docs/api-reference.md",
         author: "joe.barnett",
         avatarColor: "#264653",
         body: "We should also document the GraphQL API rate limits — they use a point system instead of simple request counts.",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,7 @@ export interface PRComment {
   id: string;
   githubId?: number; // numeric GitHub comment ID for API calls (replies, resolve)
   threadId?: string; // GraphQL node ID for the review thread (resolve/unresolve)
+  path?: string; // file path this comment is attached to (from GitHub review comment)
   author: string;
   avatarColor: string;
   body: string;


### PR DESCRIPTION
## Summary
- Comment panel and inline highlights now scope to the currently selected file instead of showing all PR comments
- Fixes spurious highlights from other files' comments bleeding into the current view
- Fixes click-to-go navigation selecting wrong or missing comment context

## What changed
- `PRComment` type gains a `path` field, populated from GitHub's review comment API
- `DiffViewer.allPanelComments` filters by `file.path` (review comments) and `pendingPath` (pending comments)
- Issue comments (PR-level, no file association) are excluded from per-file views
- Demo PR #42 now has two files with separate comments for e2e coverage

## Test plan
- [x] 854 unit tests pass (6 new for filtering + merge path preservation)
- [x] 127 e2e tests pass (6 new across desktop + mobile for file switching, comment isolation, count badge)
- [x] Zero regressions (only pre-existing `image-flows` failure on main)
- [x] Manual: open a multi-file PR, verify comments switch when clicking between files
- [x] Manual: verify highlights only appear for current file's comments
- [x] Manual: verify comment count badge shows per-file count in toolbar, PR-wide count in header